### PR TITLE
Fix RemovedInSphinx40Warning

### DIFF
--- a/sphinxcontrib/test_reports/environment.py
+++ b/sphinxcontrib/test_reports/environment.py
@@ -28,10 +28,10 @@ def safe_add_file(filename, app):
 
     if data_file.split(".")[-1] == "js":
         if hasattr(app.builder, "script_files") and static_data_file not in app.builder.script_files:
-            app.add_javascript(data_file)
+            app.add_js_file(data_file)
     elif data_file.split(".")[-1] == "css":
         if hasattr(app.builder, "css_files") and static_data_file not in app.builder.css_files:
-            app.add_stylesheet(data_file)
+            app.add_css_file(data_file)
     else:
         raise NotImplementedError("File type {} not support by save_add_file".format(data_file.split(".")[-1]))
 


### PR DESCRIPTION
When updating Sphinx to version 3.1.2 I get the following warning

```
/usr/local/lib/python3.7/site-packages/sphinxcontrib/test_reports/environment.py:34: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet(data_file)
```

I can see [in the changelog](https://www.sphinx-doc.org/en/master/changes.html#id83) that `add_javascript` is also deprecated, so I've changed that as well in this PR.