### PR TITLE
[#69] fix deprecation warning

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 from nox import session
 
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
-SPHINX_VERSIONS = ["5.0"]
+SPHINX_VERSIONS = ["5.0", "6.2.1", "7.2.5"]
 TEST_DEPENDENCIES = [
     "pytest",
     "pytest-xdist",

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 from nox import session
 
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
-SPHINX_VERSIONS = ["5.0", "6.2.1", "7.2.5"]
+SPHINX_VERSIONS = ["5.0", "6.2.1", "7.1.2", "7.2.5"]
 TEST_DEPENDENCIES = [
     "pytest",
     "pytest-xdist",

--- a/sphinxcontrib/test_reports/directives/test_env.py
+++ b/sphinxcontrib/test_reports/directives/test_env.py
@@ -5,10 +5,10 @@ import os
 import sphinx
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from pkg_resources import parse_version
+from packaging.version import Version
 
 sphinx_version = sphinx.__version__
-if parse_version(sphinx_version) >= parse_version("1.6"):
+if Version(sphinx_version) >= Version("1.6"):
     from sphinx.util import logging
 else:
     import logging

--- a/sphinxcontrib/test_reports/environment.py
+++ b/sphinxcontrib/test_reports/environment.py
@@ -1,13 +1,14 @@
 import os
 
 import sphinx
-from pkg_resources import parse_version
+from packaging.version import Version
+
 from sphinx.util.console import brown
 from sphinx.util.osutil import copyfile, ensuredir
 
 sphinx_version = sphinx.__version__
-if parse_version(sphinx_version) >= parse_version("1.6"):
-    if parse_version(sphinx_version) >= parse_version("6.1"):
+if Version(sphinx_version) >= Version("1.6"):
+    if Version(sphinx_version) >= Version("6.1"):
         from sphinx.util.display import status_iterator
     else:
         from sphinx.util import status_iterator  # NOQA Sphinx 1.5
@@ -83,7 +84,7 @@ def install_styles_static_files(app, env):
     # Be sure no "old" css layout is already set
     safe_remove_file("sphinx-test-reports/common.css", app)
 
-    if parse_version(sphinx_version) < parse_version("1.6"):
+    if Version(sphinx_version) < Version("1.6"):
         global status_iterator
         status_iterator = app.status_iterator
 

--- a/sphinxcontrib/test_reports/environment.py
+++ b/sphinxcontrib/test_reports/environment.py
@@ -7,7 +7,7 @@ from sphinx.util.osutil import copyfile, ensuredir
 
 sphinx_version = sphinx.__version__
 if parse_version(sphinx_version) >= parse_version("1.6"):
-    if parse_version(sphinx_version) >= parse_version("6.0"):
+    if parse_version(sphinx_version) >= parse_version("6.1"):
         from sphinx.util.display import status_iterator
     else:
         from sphinx.util import status_iterator  # NOQA Sphinx 1.5

--- a/sphinxcontrib/test_reports/environment.py
+++ b/sphinxcontrib/test_reports/environment.py
@@ -7,7 +7,10 @@ from sphinx.util.osutil import copyfile, ensuredir
 
 sphinx_version = sphinx.__version__
 if parse_version(sphinx_version) >= parse_version("1.6"):
-    from sphinx.util.display import status_iterator  # NOQA Sphinx 1.5
+    if parse_version(sphinx_version) >= parse_version("6.0"):
+        from sphinx.util.display import status_iterator
+    else:
+        from sphinx.util import status_iterator  # NOQA Sphinx 1.5
 
 STATICS_DIR_NAME = "_static"
 

--- a/sphinxcontrib/test_reports/environment.py
+++ b/sphinxcontrib/test_reports/environment.py
@@ -7,7 +7,7 @@ from sphinx.util.osutil import copyfile, ensuredir
 
 sphinx_version = sphinx.__version__
 if parse_version(sphinx_version) >= parse_version("1.6"):
-    from sphinx.util import status_iterator  # NOQA Sphinx 1.5
+    from sphinx.util.display import status_iterator  # NOQA Sphinx 1.5
 
 STATICS_DIR_NAME = "_static"
 

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -2,8 +2,8 @@
 import os
 
 import sphinx
+from packaging.version import Version
 # from docutils import nodes
-from pkg_resources import parse_version
 from sphinx_needs.api import (add_dynamic_function, add_extra_option,
                               add_need_type)
 
@@ -23,7 +23,7 @@ from sphinxcontrib.test_reports.environment import install_styles_static_files
 from sphinxcontrib.test_reports.functions import tr_link
 
 sphinx_version = sphinx.__version__
-if parse_version(sphinx_version) >= parse_version("1.6"):
+if Version(sphinx_version) >= Version("1.6"):
     from sphinx.util import logging
 else:
     import logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,14 +3,14 @@ import shutil
 from tempfile import mkdtemp
 
 import pytest
-from sphinx.testing.path import path
+from pathlib import Path
 
 pytest_plugins = "sphinx.testing.fixtures"
 
 
 def copy_srcdir_to_tmpdir(srcdir, tmp):
-    srcdir = path(__file__).parent.abspath() / srcdir
-    tmproot = tmp / path(srcdir).basename()
+    srcdir = Path(__file__).parent.absolute() / srcdir
+    tmproot = tmp / Path(srcdir).name
     shutil.copytree(srcdir, tmproot)
     return tmproot
 
@@ -19,12 +19,12 @@ def copy_srcdir_to_tmpdir(srcdir, tmp):
 def test_app(make_app, request):
     # We create a temp-folder on our own, as the util-functions from sphinx and pytest make troubles.
     # It seems like they reuse certain-temp names
-    sphinx_test_tempdir = path(mkdtemp())
+    sphinx_test_tempdir = Path(mkdtemp())
 
     builder_params = request.param
 
     # copy plantuml.jar, xml files and json files to current test temdir
-    util_files = path(__file__).parent.abspath() / "doc_test/utils"
+    util_files = Path(__file__).parent.absolute() / "doc_test/utils"
     shutil.copytree(util_files, sphinx_test_tempdir / "utils")
 
     # copy test srcdir to test temporary directory sphinx_test_tempdir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,19 +2,17 @@
 import shutil
 from pathlib import Path
 from tempfile import mkdtemp
-import os.path
 
 import pytest
-
 from packaging.version import Version
 from sphinx import __version__ as sphinx_version
 
 if Version(sphinx_version) < Version("7.2"):
     from sphinx.testing.path import path
- 
 
 
 pytest_plugins = "sphinx.testing.fixtures"
+
 
 def copy_srcdir_to_tmpdir(srcdir, tmp):
     srcdir = Path(__file__).parent.absolute() / srcdir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,21 @@
 """Pytest conftest module containing common test configuration and fixtures."""
 import shutil
+from pathlib import Path
 from tempfile import mkdtemp
 
 import pytest
 from pkg_resources import parse_version
-
 from sphinx import __version__ as sphinx_version
-
 from sphinx.testing.path import path
-from pathlib import Path
+
 
 def convert_path(name):
-    return name if parse_version(sphinx_version) >= parse_version("7.0") else path(name.absolute())
+    return (
+        name
+        if parse_version(sphinx_version) >= parse_version("7.0")
+        else path(name.absolute())
+    )
+
 
 pytest_plugins = "sphinx.testing.fixtures"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,19 @@
 import shutil
 from pathlib import Path
 from tempfile import mkdtemp
+import os.path
 
 import pytest
-from pkg_resources import parse_version
+
+from packaging.version import Version
 from sphinx import __version__ as sphinx_version
-from sphinx.testing.path import path
+
+if Version(sphinx_version) < Version("7.2"):
+    from sphinx.testing.path import path
+ 
 
 
 pytest_plugins = "sphinx.testing.fixtures"
-
 
 def copy_srcdir_to_tmpdir(srcdir, tmp):
     srcdir = Path(__file__).parent.absolute() / srcdir
@@ -18,7 +22,7 @@ def copy_srcdir_to_tmpdir(srcdir, tmp):
     shutil.copytree(srcdir, tmproot)
     return (
         tmproot
-        if parse_version(sphinx_version) >= parse_version("7.2")
+        if Version(sphinx_version) >= Version("7.2")
         else path(tmproot.absolute())
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from sphinx.testing.path import path
 def convert_path(name):
     return (
         name
-        if parse_version(sphinx_version) >= parse_version("7.0")
+        if parse_version(sphinx_version) >= parse_version("7.2")
         else path(name.absolute())
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,15 @@ import shutil
 from tempfile import mkdtemp
 
 import pytest
+from pkg_resources import parse_version
+
+from sphinx import __version__ as sphinx_version
+
+from sphinx.testing.path import path
 from pathlib import Path
+
+def convert_path(name):
+    return name if parse_version(sphinx_version) >= parse_version("7.0") else path(name.absolute())
 
 pytest_plugins = "sphinx.testing.fixtures"
 
@@ -34,7 +42,7 @@ def test_app(make_app, request):
     # return sphinx.testing fixture make_app and new srcdir which in sphinx_test_tempdir
     app = make_app(
         buildername=builder_params.get("buildername", "html"),
-        srcdir=src_dir,
+        srcdir=convert_path(src_dir),
         freshenv=builder_params.get("freshenv"),
         confoverrides=builder_params.get("confoverrides"),
         status=builder_params.get("status"),


### PR DESCRIPTION
Sphinx in  Versions >= 7 migrated to PathLib and generates warnings.
Tests must considers this too