### PR TITLE
upgrade to sphinx 7.2.6 and sphinx 6.2.1

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 from nox import session
 
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
-SPHINX_VERSIONS = ["5.0"]
+SPHINX_VERSIONS = ["5.0", "6.2.1", "7.2.6"]
 TEST_DEPENDENCIES = [
     "pytest",
     "pytest-xdist",


### PR DESCRIPTION
Due to changes in sphinx 7.2 all conftest.py files should be adapted to accept pathlib.Path objects