### PR TITLE
 add junit ctest xml tests

### DIFF
--- a/tests/doc_test/utils/ctest.xml
+++ b/tests/doc_test/utils/ctest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="Linux-c++"
-	tests="4"
+	tests="5"
 	failures="1"
 	disabled="0"
-	skipped="0"
+	skipped="1"
 	hostname=""
 	time="0"
 	timestamp="2022-12-08T15:15:07"
@@ -26,4 +26,13 @@
 		<system-out>FAIL
 </system-out>
 	</testcase>
+	<testcase name="skipped_test" classname="skipped_test" time="0.134036" status="notrun">
+		<skipped message="SKIP_REGULAR_EXPRESSION_MATCHED"/>
+		<system-out>Skipped feature due to @skip tag
+0 features passed, 0 failed, 1 skipped
+0 scenarios passed, 0 failed, 14 skipped
+0 steps passed, 0 failed, 42 skipped, 0 undefined
+</system-out>
+	</testcase>
 </testsuite>
+    

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -15,6 +15,8 @@ xml_nose_path = os.path.join(
     os.path.dirname(__file__), "doc_test/utils", "nose_data.xml"
 )
 
+xml_ctest_path = os.path.join(os.path.dirname(__file__), "doc_test/utils", "ctest.xml")
+
 
 def test_init_parser():
     from sphinxcontrib.test_reports.junitparser import JUnitParser
@@ -115,3 +117,34 @@ def test_parse_pytest_61_gets_test_suite_attributes():
     assert test_suite["skips"] == 3
     assert test_suite["passed"] == 1
     assert test_suite["time"] == 4.088
+
+
+def test_parse_ctest_xml():
+    from sphinxcontrib.test_reports.junitparser import JUnitParser
+
+    parser = JUnitParser(xml_ctest_path)
+    test_suites = parser.parse()
+
+    assert len(test_suites) == 1
+    test_suite = test_suites[0]
+
+    print(test_suite["testcases"])
+
+    assert test_suite["tests"] == 5
+    assert test_suite["errors"] == -1
+    assert test_suite["failures"] == 1
+    assert test_suite["skips"] == 1
+    assert test_suite["passed"] == 3
+
+    assert test_suite["testcases"][0]["name"] == "usage_test"
+    assert test_suite["testcases"][0]["result"] == "passed"
+    assert test_suite["testcases"][1]["name"] == "success_test"
+    assert test_suite["testcases"][1]["result"] == "passed"
+    assert (
+        test_suite["testcases"][2]["name"] == "fail_test"
+    )  # fail in name, but nowhere in status, faked fail
+    assert test_suite["testcases"][2]["result"] == "passed"
+    assert test_suite["testcases"][3]["name"] == "fail_test_output"
+    assert test_suite["testcases"][3]["result"] == "failure"
+    assert test_suite["testcases"][4]["name"] == "skipped_test"
+    assert test_suite["testcases"][4]["result"] == "skipped"


### PR DESCRIPTION
Add test for junit parser in ctest junit xml file for skipped tests
in ctests disabled state is not handled in junit file. Could be matched to skipped by junit parser, decided to skip tests in cmake itself instead of disable the tests