### PR TITLE
add missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-requires = ["sphinx>=4.0", "lxml", "sphinx-needs>=1.0.1"]
+requires = ["sphinx>=4.0", "lxml", "sphinx-needs>=1.0.1", "sphinxcontrib-plantuml"]
 
 with open(os.path.join(os.path.dirname(__file__), "README.rst")) as file:
     setup(
@@ -39,5 +39,6 @@ with open(os.path.join(os.path.dirname(__file__), "README.rst")) as file:
         packages=find_packages(),
         include_package_data=True,
         install_requires=requires,
+        tests_require=requires,
         namespace_packages=["sphinxcontrib"],
     )


### PR DESCRIPTION
Currently for tests no dependencies are declared. Additionally `plantuml` is used but not listed as a dependency.