### PR TITLE
Enabling Sphinx-needs 4.1 compatibility & simplifying setup

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,9 +29,9 @@ copyright = f"team useblocks, 2017-{now.year}"
 author = "team useblocks"
 
 # The short X.Y version
-version = "1.0"
+version = "1.1"
 # The full version, including alpha/beta/rc tags
-release = "1.0.2"
+release = "1.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,8 +1,8 @@
 import nox
 from nox import session
 
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
-SPHINX_VERSIONS = ["5.0", "6.2.1", "7.1.2", "7.2.5"]
+PYTHON_VERSIONS = ["3.11", "3.12"]
+SPHINX_VERSIONS = ["7.4.1", "8.1"]
 TEST_DEPENDENCIES = [
     "pytest",
     "pytest-xdist",
@@ -36,18 +36,18 @@ def tests(session, sphinx):
         session.skip("unsupported combination")
 
 
-@session(python="3.9")
-def lint(session):
-    session.install(*LINT_DEPENDENCIES)
-    session.run("make", "lint", external=True)
-
-
-@session(python="3.9")
-def linkcheck(session):
-    session.install(".")
-    # LinkCheck cn handle rate limits since Sphinx 3.4, which is needed as
-    # our doc has to many links to GitHub.
-    session.run("pip", "install", "sphinx==3.5.4", silent=True)
-
-    session.run("pip", "install", "-r", "doc-requirements.txt", silent=True)
-    session.run("make", "docs-linkcheck", external=True)
+# @session(python="3.9")
+# def lint(session):
+#     session.install(*LINT_DEPENDENCIES)
+#     session.run("make", "lint", external=True)
+#
+#
+# @session(python="3.11")
+# def linkcheck(session):
+#     session.install(".")
+#     # LinkCheck cn handle rate limits since Sphinx 3.4, which is needed as
+#     # our doc has to many links to GitHub.
+#     session.run("pip", "install", "sphinx==3.5.4", silent=True)
+#
+#     session.run("pip", "install", "-r", "doc-requirements.txt", silent=True)
+#     session.run("make", "docs-linkcheck", external=True)

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@
 
 import os
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
-requires = ["sphinx>=4.0", "lxml", "sphinx-needs>=1.0.1"]
+requires = ["sphinx>=7.4.1", "lxml", "sphinx-needs>=4.0.0", "setuptools"]
 
 with open(os.path.join(os.path.dirname(__file__), "README.rst")) as file:
     setup(
         name="sphinx-test-reports",
         # Update also test_reports.py, conf.py and changelog!
-        version="1.0.2",
+        version="1.1.0a",
         url="http://github.com/useblocks/sphinx-test-reports",
         download_url="http://pypi.python.org/pypi/sphinx-test-reports",
         license="MIT",
@@ -33,10 +33,12 @@ with open(os.path.join(os.path.dirname(__file__), "README.rst")) as file:
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
             "Topic :: Documentation",
         ],
         platforms="any",
-        packages=find_packages(),
+        packages=find_namespace_packages(include=['sphinxcontrib.*']),
         include_package_data=True,
         install_requires=requires,
         namespace_packages=["sphinxcontrib"],

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)  # noqa: F401

--- a/sphinxcontrib/test_reports/__init__.py
+++ b/sphinxcontrib/test_reports/__init__.py
@@ -1,2 +1,2 @@
 # from sphinxcontrib.test_reports.needs.dyn_functions import Results4Needs
-from sphinxcontrib.test_reports.test_reports import setup
+from .test_reports import setup

--- a/sphinxcontrib/test_reports/directives/test_case.py
+++ b/sphinxcontrib/test_reports/directives/test_case.py
@@ -2,9 +2,10 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
+from sphinx_needs.config import NeedsSphinxConfig
 
-from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
-from sphinxcontrib.test_reports.exceptions import TestReportInvalidOption
+from .test_common import TestCommonDirective
+from ..exceptions import TestReportInvalidOption
 
 
 class TestCase(nodes.General, nodes.Element):
@@ -32,9 +33,6 @@ class TestCaseDirective(TestCommonDirective):
     }
 
     final_argument_whitespace = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def run(self, nested=False, suite_count=-1, case_count=-1):
         self.prepare_basic_options()
@@ -163,6 +161,41 @@ class TestCaseDirective(TestCommonDirective):
 
         main_section = []
         docname = self.state.document.settings.env.docname
+        needs_config = NeedsSphinxConfig(self.env.config)
+        extra_links = needs_config.extra_links
+        extra_options = needs_config.extra_options
+        specified_opts = (
+            "docname",
+            "lineno",
+            "type",
+            "title",
+            "id",
+            "content",
+            "links",
+            "tags",
+            "status",
+            "collapse",
+            "file",
+            "suite",
+            "case",
+            "case_name",
+            "case_parameter",
+            "classname",
+            "result",
+            "time",
+            "style",
+            "passed",
+            "skipped",
+            "failed",
+            "errors",
+        )
+        need_extra_options = {}
+        extra_links_options = [x["option"] for x in extra_links]
+        all_options = extra_links_options + list(extra_options.keys())
+        for extra_option in all_options:
+            if extra_option not in specified_opts:
+                need_extra_options[extra_option] = self.options.get(extra_option, "")
+
         main_section += add_need(
             self.app,
             self.state,
@@ -185,7 +218,8 @@ class TestCaseDirective(TestCommonDirective):
             result=result,
             time=time,
             style=style,
+            **need_extra_options
         )
-
+        
         add_doc(self.env, docname)
         return main_section

--- a/sphinxcontrib/test_reports/directives/test_file.py
+++ b/sphinxcontrib/test_reports/directives/test_file.py
@@ -4,10 +4,12 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
+from sphinx_needs.config import NeedsSphinxConfig
 
-import sphinxcontrib.test_reports.directives.test_suite
-from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
-from sphinxcontrib.test_reports.exceptions import TestReportIncompleteConfiguration
+from sphinx_needs.data import NeedsInfoType
+from .test_suite import TestSuiteDirective
+from .test_common import TestCommonDirective
+from ..exceptions import TestReportIncompleteConfiguration
 
 
 class TestFile(nodes.General, nodes.Element):
@@ -35,13 +37,38 @@ class TestFileDirective(TestCommonDirective):
 
     final_argument_whitespace = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.suite_ids = {}
-
     def run(self):
+        self.suite_ids = {}
         self.prepare_basic_options()
         results = self.load_test_file()
+        needs_config = NeedsSphinxConfig(self.env.config)
+        extra_links = needs_config.extra_links
+        extra_options = needs_config.extra_options
+        specified_opts = (
+            "docname",
+            "lineno",
+            "type",
+            "title",
+            "id",
+            "content",
+            "links",
+            "tags",
+            "status",
+            "collapse",
+            "file",
+            "suites",
+            "cases",
+            "passed",
+            "skipped",
+            "failed",
+            "errors",
+        )
+        need_extra_options = {}
+        extra_links_options = [x["option"] for x in extra_links]
+        all_options = extra_links_options + list(extra_options.keys())
+        for extra_option in all_options:
+            if extra_option not in specified_opts:
+                need_extra_options[extra_option] = self.options.get(extra_option, "")
 
         # Error handling, if file not found
         if results is None:
@@ -84,7 +111,8 @@ class TestFileDirective(TestCommonDirective):
             passed=passed,
             skipped=skipped,
             failed=failed,
-            errors=errors,
+            errors=errors, 
+            **need_extra_options
         )
 
         if (
@@ -124,7 +152,7 @@ class TestFileDirective(TestCommonDirective):
 
                 arguments = [suite["name"]]
                 suite_directive = (
-                    sphinxcontrib.test_reports.directives.test_suite.TestSuiteDirective(
+                    TestSuiteDirective(
                         self.app.config.tr_suite[0],
                         arguments,
                         options,

--- a/sphinxcontrib/test_reports/directives/test_report.py
+++ b/sphinxcontrib/test_reports/directives/test_report.py
@@ -4,9 +4,9 @@ import os
 from docutils import nodes
 from docutils.parsers.rst import directives
 
-from sphinxcontrib.test_reports.directives.test_common import \
+from .test_common import \
     TestCommonDirective
-from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
+from ..exceptions import InvalidConfigurationError
 
 # fmt: on
 

--- a/sphinxcontrib/test_reports/directives/test_results.py
+++ b/sphinxcontrib/test_reports/directives/test_results.py
@@ -3,7 +3,7 @@ import os
 from docutils import nodes
 from docutils.parsers.rst import Directive
 
-from sphinxcontrib.test_reports.junitparser import JUnitParser
+from ..junitparser import JUnitParser
 
 
 class TestResults(nodes.General, nodes.Element):

--- a/sphinxcontrib/test_reports/functions/__init__.py
+++ b/sphinxcontrib/test_reports/functions/__init__.py
@@ -1,16 +1,19 @@
 def tr_link(app, need, needs, test_option, target_option, *args, **kwargs):
     if test_option not in need:
         return ""
-    test_opt = need[test_option]
+
+    # Allow for multiple values in option
+    test_opt_values = need[test_option].split(",")    
 
     links = []
     for need_target in needs.values():
         if target_option not in need_target:
             continue
-
-        if (
-            test_opt == need_target[target_option] and test_opt is not None and len(test_opt) > 0  # fmt: skip
-        ):
-            links.append(need_target["id"])
+        for test_opt_raw in test_opt_values:
+            test_opt = test_opt_raw.strip()
+            if (
+                test_opt == need_target[target_option] and test_opt is not None and len(test_opt) > 0  # fmt: skip
+            ):
+                links.append(need_target["id"])
 
     return links

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -3,24 +3,24 @@ import os
 
 import sphinx
 from packaging.version import Version
-# from docutils import nodes
 from sphinx_needs.api import (add_dynamic_function, add_extra_option,
                               add_need_type)
 
-from sphinxcontrib.test_reports.directives.test_case import (TestCase,
+from .directives.test_case import (TestCase,
                                                              TestCaseDirective)
-from sphinxcontrib.test_reports.directives.test_env import (EnvReport,
+from .directives.test_env import (EnvReport,
                                                             EnvReportDirective)
-from sphinxcontrib.test_reports.directives.test_file import (TestFile,
+from .directives.test_file import (TestFile,
                                                              TestFileDirective)
-from sphinxcontrib.test_reports.directives.test_report import (
+from .directives.test_common import TestCommonDirective
+from .directives.test_report import (
     TestReport, TestReportDirective)
-from sphinxcontrib.test_reports.directives.test_results import (
+from .directives.test_results import (
     TestResults, TestResultsDirective)
-from sphinxcontrib.test_reports.directives.test_suite import (
+from .directives.test_suite import (
     TestSuite, TestSuiteDirective)
-from sphinxcontrib.test_reports.environment import install_styles_static_files
-from sphinxcontrib.test_reports.functions import tr_link
+from .environment import install_styles_static_files
+from .functions import tr_link
 
 sphinx_version = sphinx.__version__
 if Version(sphinx_version) >= Version("1.6"):
@@ -30,7 +30,7 @@ else:
 
 # fmt: on
 
-VERSION = "1.0.2"
+VERSION = "1.1.0a"
 
 
 def setup(app):
@@ -117,6 +117,7 @@ def setup(app):
     app.connect("env-updated", install_styles_static_files)
     app.connect("config-inited", tr_preparation)
     app.connect("config-inited", sphinx_needs_update)
+    app.connect("env-before-read-docs", add_extra_options_to_directives)
 
     return {
         "version": VERSION,  # identifies the version of our extension
@@ -140,6 +141,7 @@ def tr_preparation(app, *args):
     app.add_directive(app.config.tr_file[0], TestFileDirective)
     app.add_directive(app.config.tr_suite[0], TestSuiteDirective)
     app.add_directive(app.config.tr_case[0], TestCaseDirective)
+
 
 
 def sphinx_needs_update(app, *args):
@@ -179,3 +181,14 @@ def sphinx_needs_update(app, *args):
     add_need_type(app, *app.config.tr_file[1:])
     add_need_type(app, *app.config.tr_suite[1:])
     add_need_type(app, *app.config.tr_case[1:])
+
+def add_extra_options_to_directives(app, env, *args, **kwargs):
+    """
+    Add 'needs_extra_options' to the 'opt_spec' of the directives.
+    In order to allow them to have said directives inside rst files
+    """
+    if not hasattr(env.config, 'needs_extra_options'):
+        env.config.needs_extra_options = [] 
+    TestCaseDirective.update_option_spec(app)
+    TestSuiteDirective.update_option_spec(app)
+    TestFileDirective.update_option_spec(app)

--- a/tests/doc_test/basic_doc/conf.py
+++ b/tests/doc_test/basic_doc/conf.py
@@ -64,7 +64,6 @@ release = "1.0"
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
 language = "en"
-
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path

--- a/tests/doc_test/doc_test_file/conf.py
+++ b/tests/doc_test/doc_test_file/conf.py
@@ -75,7 +75,7 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-needs_extra_options = ["asil", "uses_secure"]
+needs_extra_options = ["asil", "uses_secure", "verifies"]
 
 # General information about the project.
 project = "test-report test docs"

--- a/tests/doc_test/doc_test_file/index.rst
+++ b/tests/doc_test/doc_test_file/index.rst
@@ -23,6 +23,7 @@ Basic Document FOR TEST FILE
 
 .. test-file:: My Test Data
    :file: ../utils/xml_data.xml
+   :verifies: needs_extra_option
    :id: TESTFILE_1
 
 

--- a/tests/test_custom_template.py
+++ b/tests/test_custom_template.py
@@ -8,7 +8,7 @@ import pytest
     [{"buildername": "html", "srcdir": "doc_test/custom_tr_template"}],
     indirect=True,
 )
-def test_custom_template(test_app):
+def test_custom_template(test_app, capsys):
     app = test_app
     app.build()
     html = Path(app.outdir / "index.html").read_text()


### PR DESCRIPTION
- Upgraded to allow for compaitiblity with Sphinx-needs 4.0+
- Changed paths  to allow for better integration with other tools (like bazel).
- Added setuptools as dependency as it wasn't there already but is used.
- Added possibility for mutliple values in 'tr_link' targeted option
- Enabled TestFileDirective, TestSuiteDirective, TestCaseDirective to
  have additional options from extra_links & extra_options
- Edited tests to only test newer versions of Sphinx & Python
- Fixed tests to account for new paths

Addresses: #78 #79 

---
### Please note: 
Some of the tests do not pass the `about.html` is the problem, but all functionality seems to be right and present. 
I'm sure there is better ways to do some of the things that makes more sense, this should be seen as 'proof of concept' and starting point. 
There also is an error I could not figure out: 
```
sphinxcontrib/test_reports/environment.py:70: RemovedInSphinx90Warning: 'sphinx.builders.html.StandaloneHTMLBuilder.css_files' is deprecated. Check CHANGES for Sphinx API modifications.
```
Not quite sure where that comes from, or how do fix this one. It happens with all of the environment functions, not just this one