### PR TITLE
Allowing multiple option attributes for `tr_link` function

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -33,6 +33,9 @@ Then it goes through **all** other needs and checks if the value of their ``sour
 the ``target_option``.
 If this is the case, their IDs get stored and finally returned.
 
+``source_option`` can also reference an option with comma separated values. 
+In this case a comparions is performed for each value, which may lead to multiple links.  
+
 **Example**::
 
    .. spec:: sphinxcontrib.test_reports.test_reports

--- a/sphinxcontrib/test_reports/functions/__init__.py
+++ b/sphinxcontrib/test_reports/functions/__init__.py
@@ -1,16 +1,19 @@
 def tr_link(app, need, needs, test_option, target_option, *args, **kwargs):
     if test_option not in need:
         return ""
-    test_opt = need[test_option]
+
+    # Allow for multiple values in option
+    test_opt_values = need[test_option].split(",")    
 
     links = []
     for need_target in needs.values():
         if target_option not in need_target:
             continue
-
-        if (
-            test_opt == need_target[target_option] and test_opt is not None and len(test_opt) > 0  # fmt: skip
-        ):
-            links.append(need_target["id"])
+        for test_opt_raw in test_opt_values:
+            test_opt = test_opt_raw.strip()
+            if (
+                test_opt == need_target[target_option] and test_opt is not None and len(test_opt) > 0  # fmt: skip
+            ):
+                links.append(need_target["id"])
 
     return links

--- a/sphinxcontrib/test_reports/functions/__init__.py
+++ b/sphinxcontrib/test_reports/functions/__init__.py
@@ -3,7 +3,7 @@ def tr_link(app, need, needs, test_option, target_option, *args, **kwargs):
         return ""
 
     # Allow for multiple values in option
-    test_opt_values = need[test_option].split(",")    
+    test_opt_values = need[test_option].split(",")
 
     links = []
     for need_target in needs.values():

--- a/tests/doc_test/needs_linking/conf.py
+++ b/tests/doc_test/needs_linking/conf.py
@@ -75,7 +75,7 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-needs_extra_options = ["asil", "uses_secure"]
+needs_extra_options = ["asil", "uses_secure", "references"]
 
 # General information about the project.
 project = "test-report test docs"

--- a/tests/doc_test/needs_linking/index.rst
+++ b/tests/doc_test/needs_linking/index.rst
@@ -14,11 +14,15 @@ Basic Document FOR TEST FILE
    :id: TEST_3
    :tags: A, B
    :uses_secure: True
+   :references: TEST_4
+   :links: [[tr_link('references', 'id')]]
 
 .. spec:: TEST_4
    :id: TEST_4
    :tags: B
    :uses_secure: True
+   :references: TEST_1, TEST_2
+   :links: [[tr_link('references', 'id')]]
 
 Need number with extra options: :need_count:`asil=='D'`
 

--- a/tests/test_needs_linking.py
+++ b/tests/test_needs_linking.py
@@ -2,8 +2,6 @@ from pathlib import Path
 
 import pytest
 
-# links_outgoing = """<div class="line"><span><div class="line">links outgoing: <span class="links"><span><a class="reference internal" href="#TEST_1" title="TEST_4">TEST_1</a>, <a class="reference internal" href="#TEST_2" title="TEST_4">TEST_2</a></span></span></div>"""
-# links_incoming = """<div class="line">links incoming: <span class="links"><span><a class="reference internal" href="#TEST_3" title="TEST_4">TEST_3</a></span></span></div>
 @pytest.mark.parametrize(
     "test_app",
     [{"buildername": "html", "srcdir": "doc_test/needs_linking"}],

--- a/tests/test_needs_linking.py
+++ b/tests/test_needs_linking.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+
 @pytest.mark.parametrize(
     "test_app",
     [{"buildername": "html", "srcdir": "doc_test/needs_linking"}],
@@ -13,7 +14,7 @@ def test_doc_testsuites_html(test_app):
     html = Path(app.outdir, "index.html").read_text()
     print(html)
     assert html
-    assert "links outgoing: " in html 
+    assert "links outgoing: " in html
     assert """<a class="reference internal" href="#TEST_1" title="TEST_4">TEST_1</a>""" in html
     assert """<a class="reference internal" href="#TEST_2" title="TEST_4">TEST_2</a>""" in html
     assert "links incoming: " in html

--- a/tests/test_needs_linking.py
+++ b/tests/test_needs_linking.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 import pytest
 
-
+# links_outgoing = """<div class="line"><span><div class="line">links outgoing: <span class="links"><span><a class="reference internal" href="#TEST_1" title="TEST_4">TEST_1</a>, <a class="reference internal" href="#TEST_2" title="TEST_4">TEST_2</a></span></span></div>"""
+# links_incoming = """<div class="line">links incoming: <span class="links"><span><a class="reference internal" href="#TEST_3" title="TEST_4">TEST_3</a></span></span></div>
 @pytest.mark.parametrize(
     "test_app",
     [{"buildername": "html", "srcdir": "doc_test/needs_linking"}],
@@ -12,4 +13,10 @@ def test_doc_testsuites_html(test_app):
     app = test_app
     app.build()
     html = Path(app.outdir, "index.html").read_text()
+    print(html)
     assert html
+    assert "links outgoing: " in html 
+    assert """<a class="reference internal" href="#TEST_1" title="TEST_4">TEST_1</a>""" in html
+    assert """<a class="reference internal" href="#TEST_2" title="TEST_4">TEST_2</a>""" in html
+    assert "links incoming: " in html
+    assert """<a class="reference internal" href="#TEST_3" title="TEST_4">TEST_3</a>""" in html


### PR DESCRIPTION
This is the first 'split' PR that was discussed for splitting the big one into smaller ones. This one here #80 
---

This change adds the possibility for the `tr_link` dynamic function to work with options that have multiple attributes.

I have added two testcases to check if single values and multiple values are interpreted correctly. 

All tests passed locally with 'nox' with changed setup. (Python 3.10-3.12) (Sphinx-needs pinned to 3.0) (Sphinx 7-7.4)

Let me know any feedback and/or changes you would like to see.