### PR TITLE
Changed paths to work with build tools

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,8 +1,8 @@
 import nox
 from nox import session
 
-PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
-SPHINX_VERSIONS = ["5.0", "6.2.1", "7.1.2", "7.2.5"]
+PYTHON_VERSIONS = ["3.10", "3.11", "3.12"]
+SPHINX_VERSIONS = ["7.1.2", "7.2.5", "7.4.1"]
 TEST_DEPENDENCIES = [
     "pytest",
     "pytest-xdist",
@@ -23,6 +23,7 @@ def run_tests(session, sphinx):
     session.install(".")
     session.install(*TEST_DEPENDENCIES)
     session.run("pip", "install", f"sphinx=={sphinx}", silent=True)
+    session.run("pip", "install", "sphinx-needs==3.0", silent=True)
     session.run("pip", "install", "-r", "doc-requirements.txt", silent=True)
     session.run("make", "test", external=True)
 

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@
 
 import os
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
-requires = ["sphinx>=4.0", "lxml", "sphinx-needs>=1.0.1"]
+requires = ["sphinx>=7.4.1", "lxml", "sphinx-needs>=1.0.1", "setuptools"]
 
 with open(os.path.join(os.path.dirname(__file__), "README.rst")) as file:
     setup(
@@ -36,7 +36,7 @@ with open(os.path.join(os.path.dirname(__file__), "README.rst")) as file:
             "Topic :: Documentation",
         ],
         platforms="any",
-        packages=find_packages(),
+        packages=find_namespace_packages(include=['sphinxcontrib.*']),
         include_package_data=True,
         install_requires=requires,
         namespace_packages=["sphinxcontrib"],

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)  # noqa: F401

--- a/sphinxcontrib/test_reports/__init__.py
+++ b/sphinxcontrib/test_reports/__init__.py
@@ -1,2 +1,2 @@
 # from sphinxcontrib.test_reports.needs.dyn_functions import Results4Needs
-from sphinxcontrib.test_reports.test_reports import setup
+from .test_reports import setup

--- a/sphinxcontrib/test_reports/directives/test_case.py
+++ b/sphinxcontrib/test_reports/directives/test_case.py
@@ -3,8 +3,8 @@ from docutils.parsers.rst import directives
 from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
 
-from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
-from sphinxcontrib.test_reports.exceptions import TestReportInvalidOption
+from .test_common import TestCommonDirective
+from ..exceptions import TestReportInvalidOption
 
 
 class TestCase(nodes.General, nodes.Element):

--- a/sphinxcontrib/test_reports/directives/test_common.py
+++ b/sphinxcontrib/test_reports/directives/test_common.py
@@ -8,10 +8,10 @@ from docutils.parsers.rst import Directive
 from sphinx.util import logging
 from sphinx_needs.api import make_hashed_id
 
-from sphinxcontrib.test_reports.exceptions import (
+from ..exceptions import (
     SphinxError, TestReportFileNotSetException)
-from sphinxcontrib.test_reports.jsonparser import JsonParser
-from sphinxcontrib.test_reports.junitparser import JUnitParser
+from ..jsonparser import JsonParser
+from ..junitparser import JUnitParser
 
 # fmt: on
 

--- a/sphinxcontrib/test_reports/directives/test_file.py
+++ b/sphinxcontrib/test_reports/directives/test_file.py
@@ -5,9 +5,9 @@ from docutils.parsers.rst import directives
 from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
 
-import sphinxcontrib.test_reports.directives.test_suite
-from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
-from sphinxcontrib.test_reports.exceptions import TestReportIncompleteConfiguration
+from .test_suite import TestSuiteDirective
+from .test_common import TestCommonDirective
+from ..exceptions import TestReportIncompleteConfiguration
 
 
 class TestFile(nodes.General, nodes.Element):
@@ -124,7 +124,7 @@ class TestFileDirective(TestCommonDirective):
 
                 arguments = [suite["name"]]
                 suite_directive = (
-                    sphinxcontrib.test_reports.directives.test_suite.TestSuiteDirective(
+                    TestSuiteDirective(
                         self.app.config.tr_suite[0],
                         arguments,
                         options,

--- a/sphinxcontrib/test_reports/directives/test_report.py
+++ b/sphinxcontrib/test_reports/directives/test_report.py
@@ -4,9 +4,9 @@ import os
 from docutils import nodes
 from docutils.parsers.rst import directives
 
-from sphinxcontrib.test_reports.directives.test_common import \
+from .test_common import \
     TestCommonDirective
-from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
+from ..exceptions import InvalidConfigurationError
 
 # fmt: on
 

--- a/sphinxcontrib/test_reports/directives/test_results.py
+++ b/sphinxcontrib/test_reports/directives/test_results.py
@@ -3,7 +3,7 @@ import os
 from docutils import nodes
 from docutils.parsers.rst import Directive
 
-from sphinxcontrib.test_reports.junitparser import JUnitParser
+from ..junitparser import JUnitParser
 
 
 class TestResults(nodes.General, nodes.Element):

--- a/sphinxcontrib/test_reports/directives/test_suite.py
+++ b/sphinxcontrib/test_reports/directives/test_suite.py
@@ -5,9 +5,9 @@ from docutils.parsers.rst import directives
 from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
 
-import sphinxcontrib.test_reports.directives.test_case
-from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
-from sphinxcontrib.test_reports.exceptions import TestReportInvalidOption
+from .test_case import TestCaseDirective 
+from .test_common import TestCommonDirective
+from ..exceptions import TestReportInvalidOption
 
 
 class TestSuite(nodes.General, nodes.Element):
@@ -121,7 +121,7 @@ class TestSuiteDirective(TestCommonDirective):
 
                 arguments = [suite["name"]]
                 suite_directive = (
-                    sphinxcontrib.test_reports.directives.test_suite.TestSuiteDirective(
+                    TestSuiteDirective(
                         self.app.config.tr_suite[0],
                         arguments,
                         options,
@@ -176,7 +176,7 @@ class TestSuiteDirective(TestCommonDirective):
 
                 arguments = [case["name"]]
                 case_directive = (
-                    sphinxcontrib.test_reports.directives.test_case.TestCaseDirective(
+                    TestCaseDirective(
                         self.app.config.tr_case[0],
                         arguments,
                         options,

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -7,20 +7,20 @@ from packaging.version import Version
 from sphinx_needs.api import (add_dynamic_function, add_extra_option,
                               add_need_type)
 
-from sphinxcontrib.test_reports.directives.test_case import (TestCase,
+from .directives.test_case import (TestCase,
                                                              TestCaseDirective)
-from sphinxcontrib.test_reports.directives.test_env import (EnvReport,
+from .directives.test_env import (EnvReport,
                                                             EnvReportDirective)
-from sphinxcontrib.test_reports.directives.test_file import (TestFile,
+from .directives.test_file import (TestFile,
                                                              TestFileDirective)
-from sphinxcontrib.test_reports.directives.test_report import (
+from .directives.test_report import (
     TestReport, TestReportDirective)
-from sphinxcontrib.test_reports.directives.test_results import (
+from .directives.test_results import (
     TestResults, TestResultsDirective)
-from sphinxcontrib.test_reports.directives.test_suite import (
+from .directives.test_suite import (
     TestSuite, TestSuiteDirective)
-from sphinxcontrib.test_reports.environment import install_styles_static_files
-from sphinxcontrib.test_reports.functions import tr_link
+from .environment import install_styles_static_files
+from .functions import tr_link
 
 sphinx_version = sphinx.__version__
 if Version(sphinx_version) >= Version("1.6"):


### PR DESCRIPTION
This is the second 'split' PR that was discussed for splitting the big one into smaller ones. This one here https://github.com/useblocks/sphinx-test-reports/pull/80


This PR just fixes the pathing in the library, making it work with other systems that expect a more modern approach than the one with setup tools  (which is not needed anymore since python 3.3) that was used. 
Setuptools was a necessary change in this PR as otherwise the tests will not work, due to failing `pip install .`

fixes #79 

---
**Note: I need some help on this PR, as I run into a small problem. I uploaded the `noxtest.py`  as well so you can see how I tested this change. **

When I run `nox` with this the outcome is as follows:
```sh
nox > Session tests-3.12(sphinx='7.4.1') was successful.
nox > Running session lint
nox > Missing interpreters will error by default on CI systems.
nox > Session lint skipped: Python interpreter 3.9 not found.
nox > Running session linkcheck
nox > Missing interpreters will error by default on CI systems.
nox > Session linkcheck skipped: Python interpreter 3.9 not found.
nox > Ran multiple sessions:
nox > * tests-3.10(sphinx='7.1.2'): failed
nox > * tests-3.10(sphinx='7.2.5'): failed
nox > * tests-3.10(sphinx='7.4.1'): success
nox > * tests-3.11(sphinx='7.1.2'): skipped
nox > * tests-3.11(sphinx='7.2.5'): skipped
nox > * tests-3.11(sphinx='7.4.1'): skipped
nox > * tests-3.12(sphinx='7.1.2'): failed
nox > * tests-3.12(sphinx='7.2.5'): failed
nox > * tests-3.12(sphinx='7.4.1'): success
nox > * lint: skipped
nox > * linkcheck: skipped
```
For Sphinx 7.4.1 it works fine and has no issues but the other two versions fail. With this error: 
```
FAILED tests/test_custom_template.py::test_custom_utf8_template[test_app0] - sphinx.errors.ThemeError: An error happened in rendering the page index.
FAILED tests/test_custom_template.py::test_custom_koi8_template[test_app0] - sphinx.errors.ThemeError: An error happened in rendering the page index.
FAILED tests/test_custom_template.py::test_custom_template[test_app0] - sphinx.errors.ThemeError: An error happened in rendering the page index.
```
Some more context:
```
E           sphinx.errors.ThemeError: An error happened in rendering the page index.
E           Reason: TemplateNotFound("'about.html' not found in ['/tmp/tmpxvaxwngv/custom_tr_template/_templates', '/home/maxi/tmp/testing/sphinx-test-reports/.nox/tests-3-12-sphinx-7-2-5/lib/python3.12/site-packages/sphinx/themes/basic']")
```
This always seems to stem from the `tests/test_custom_template.py`  file. All of the  `app.build()` calls there fail due to this same error. 

I'm not sure how to fix this as I can't find the 'about.html' anywhere in the project?

Let me know if you have any more insight or need some more information from my side to triage this.