### PR TITLE
Changed import to enable sphinx-needs 4.1 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
+        args: [--line-length=120]
 
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,8 @@ version = "1.0"
 # The full version, including alpha/beta/rc tags
 release = "1.0.2"
 
+needs_id_regex = ".*"
+needs_css = "dark.css"
 
 # -- General configuration ---------------------------------------------------
 
@@ -111,6 +113,7 @@ html_title = "Sphinx-Test-Reports"
 other_options = {
     "repo_url": "https://github.com/useblocks/sphinx-test-reports",
     "repo_name": "sphinx-test-reports",
+    "font": False,
 }
 html_theme_options.update(other_options)
 html_theme_options["features"].extend(["navigation.tabs", "navigation.tabs.sticky"])
@@ -195,6 +198,7 @@ texinfo_documents = [
 linkcheck_ignore = [
     r"http://localhost:\d+",
     r"http://127.0.0.1:\d+",
+    r"https://fonts.googleapis.com",
 ]
 
 linkcheck_request_headers = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -134,27 +134,6 @@ In the last years, we have created additional information and extensions, which 
 
     .. grid-item-card::
         :columns: 12 6 6 6
-        :link: https://useblocks.com/sphinx-needs-enterprise/
-        :img-top: /_static/sphinx-needs-enterprise-card.png
-        :class-card: border
-
-        Sphinx-Needs Enterprise
-        ^^^^^^^^^^^^^^^^^^^^^^^
-        Synchronize Sphinx-Needs data with external, company internal systems like CodeBeamer, Jira or Azure Boards.
-
-        Provides scripts to baseline data and makes CI usage easier.
-        +++
-
-        .. button-link:: http://useblocks.com/sphinx-needs-enterprise/
-            :color: primary
-            :outline:
-            :align: center
-            :expand:
-
-            :octicon:`book;1em;sd-text-primary` Technical Docs
-
-    .. grid-item-card::
-        :columns: 12 6 6 6
         :link: https://sphinx-test-reports.readthedocs.io/en/latest/
         :img-top: /_static/sphinx-test-reports-logo.png
         :class-card: border

--- a/sphinxcontrib/test_reports/directives/test_case.py
+++ b/sphinxcontrib/test_reports/directives/test_case.py
@@ -3,7 +3,8 @@ from docutils.parsers.rst import directives
 from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
 
-from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
+from sphinxcontrib.test_reports.directives.test_common import \
+    TestCommonDirective
 from sphinxcontrib.test_reports.exceptions import TestReportInvalidOption
 
 

--- a/sphinxcontrib/test_reports/directives/test_case.py
+++ b/sphinxcontrib/test_reports/directives/test_case.py
@@ -3,8 +3,7 @@ from docutils.parsers.rst import directives
 from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
 
-from sphinxcontrib.test_reports.directives.test_common import \
-    TestCommonDirective
+from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
 from sphinxcontrib.test_reports.exceptions import TestReportInvalidOption
 
 
@@ -66,31 +65,20 @@ class TestCaseDirective(TestCommonDirective):
                 break
 
         if suite is None:
-            raise TestReportInvalidOption(
-                f"Suite {suite_name} not found in test file {self.test_file}"
-            )
+            raise TestReportInvalidOption(f"Suite {suite_name} not found in test file {self.test_file}")
 
         case = None
 
         for case_obj in suite["testcases"]:
-            if (
-                case_obj["name"] == case_full_name  # noqa: SIM114
-                and class_name is None  # noqa: W503
-            ):
+            if case_obj["name"] == case_full_name and class_name is None:  # noqa: SIM114  # noqa: W503
                 case = case_obj
                 break
 
-            elif (
-                case_obj["classname"] == class_name  # noqa: SIM114
-                and case_full_name is None  # noqa: W503
-            ):
+            elif case_obj["classname"] == class_name and case_full_name is None:  # noqa: SIM114  # noqa: W503
                 case = case_obj
                 break
 
-            elif (
-                case_obj["name"] == case_full_name
-                and case_obj["classname"] == class_name  # noqa: W503
-            ):
+            elif case_obj["name"] == case_full_name and case_obj["classname"] == class_name:  # noqa: W503
                 case = case_obj
                 break
 
@@ -106,9 +94,7 @@ class TestCaseDirective(TestCommonDirective):
         if case is None:
             raise TestReportInvalidOption(
                 "Case {} with classname {} not found in test file {} "
-                "and testsuite {}".format(
-                    case_full_name, class_name, self.test_file, suite_name
-                )
+                "and testsuite {}".format(case_full_name, class_name, self.test_file, suite_name)
             )
 
         result = case["result"]

--- a/sphinxcontrib/test_reports/directives/test_common.py
+++ b/sphinxcontrib/test_reports/directives/test_common.py
@@ -6,7 +6,8 @@ import os
 
 from docutils.parsers.rst import Directive
 from sphinx.util import logging
-from sphinx_needs.api import make_hashed_id
+from sphinx_needs.api.need import _make_hashed_id
+from sphinx_needs.config import NeedsSphinxConfig
 
 from sphinxcontrib.test_reports.exceptions import (
     SphinxError, TestReportFileNotSetException)
@@ -90,9 +91,7 @@ class TestCommonDirective(Directive):
             self.need_type = self.app.tr_types[self.name][0]
             self.test_id = self.options.get(
                 "id",
-                make_hashed_id(
-                    self.app, self.need_type, self.test_name, self.test_content
-                ),
+                _make_hashed_id(self.need_type, self.test_name, self.test_content, NeedsSphinxConfig(self.app.config)),
             )
         else:
             self.test_id = self.options.get("id")

--- a/sphinxcontrib/test_reports/directives/test_common.py
+++ b/sphinxcontrib/test_reports/directives/test_common.py
@@ -69,9 +69,7 @@ class TestCommonDirective(Directive):
             self.test_file = os.path.join(root_path, self.test_file)
         if not os.path.exists(self.test_file):
             # raise TestReportFileInvalidException('Given test_file path invalid: {}'.format(self.test_file))
-            self.log.warning(
-                f"Given test_file path invalid: {self.test_file} in {self.docname} (Line: {self.lineno})"
-            )
+            self.log.warning(f"Given test_file path invalid: {self.test_file} in {self.docname} (Line: {self.lineno})")
             return None
 
         if self.test_file not in self.app.testreport_data.keys():

--- a/sphinxcontrib/test_reports/directives/test_common.py
+++ b/sphinxcontrib/test_reports/directives/test_common.py
@@ -70,9 +70,7 @@ class TestCommonDirective(Directive):
         if not os.path.exists(self.test_file):
             # raise TestReportFileInvalidException('Given test_file path invalid: {}'.format(self.test_file))
             self.log.warning(
-                "Given test_file path invalid: {} in {} (Line: {})".format(
-                    self.test_file, self.docname, self.lineno
-                )
+                f"Given test_file path invalid: {self.test_file} in {self.docname} (Line: {self.lineno})"
             )
             return None
 
@@ -106,9 +104,7 @@ class TestCommonDirective(Directive):
                     NeedsSphinxConfig(self.app.config),
                 )
             else:  # Sphinx-Needs < 4
-                hashed_id = make_hashed_id(
-                    self.app, self.need_type, self.test_name, self.test_content
-                )
+                hashed_id = make_hashed_id(self.app, self.need_type, self.test_name, self.test_content)
 
             self.test_id = self.options.get(
                 "id",

--- a/sphinxcontrib/test_reports/directives/test_common.py
+++ b/sphinxcontrib/test_reports/directives/test_common.py
@@ -1,8 +1,10 @@
 """
 A Common directive, from which all other test directives inherit the shared functions.
 """
+
 # fmt: off
 import os
+from importlib.metadata import version
 
 from docutils.parsers.rst import Directive
 from sphinx.util import logging
@@ -13,14 +15,12 @@ from sphinxcontrib.test_reports.exceptions import (
 from sphinxcontrib.test_reports.jsonparser import JsonParser
 from sphinxcontrib.test_reports.junitparser import JUnitParser
 
-from importlib.metadata import version
 sn_major_version = int(version("sphinx-needs").split('.')[0])
 
 if sn_major_version >= 4:
     from sphinx_needs.api.need import _make_hashed_id
 else:
     from sphinx_needs.api import make_hashed_id
-
 
 
 # fmt: on
@@ -99,10 +99,17 @@ class TestCommonDirective(Directive):
         if self.name != "test-report":
             self.need_type = self.app.tr_types[self.name][0]
             if sn_major_version >= 4:
-                hashed_id = _make_hashed_id(self.need_type, self.test_name, self.test_content, NeedsSphinxConfig(self.app.config))
-            else: # Sphinx-Needs < 4
-                hashed_id = make_hashed_id(self.app, self.need_type, self.test_name, self.test_content)
-               
+                hashed_id = _make_hashed_id(
+                    self.need_type,
+                    self.test_name,
+                    self.test_content,
+                    NeedsSphinxConfig(self.app.config),
+                )
+            else:  # Sphinx-Needs < 4
+                hashed_id = make_hashed_id(
+                    self.app, self.need_type, self.test_name, self.test_content
+                )
+
             self.test_id = self.options.get(
                 "id",
                 hashed_id,

--- a/sphinxcontrib/test_reports/directives/test_env.py
+++ b/sphinxcontrib/test_reports/directives/test_env.py
@@ -78,11 +78,7 @@ class EnvReportDirective(Directive):
             try:
                 results = json.load(fp_json)
             except ValueError:
-                raise InvalidJsonFile(
-                    "The given file {} is not a valid JSON".format(
-                        json_path.split("/")[-1]
-                    )
-                )
+                raise InvalidJsonFile("The given file {} is not a valid JSON".format(json_path.split("/")[-1]))
 
         # check to see if environment is present in JSON or not
         if self.req_env_list is not None:
@@ -118,9 +114,7 @@ class EnvReportDirective(Directive):
                     # option check
                     for opt in self.data_option_list:
                         if opt not in temp_dict2[enviro]:
-                            logger.warning(
-                                f"option '{opt}' is not present in JSON file"
-                            )
+                            logger.warning(f"option '{opt}' is not present in JSON file")
 
                 del temp_dict
 
@@ -146,11 +140,7 @@ class EnvReportDirective(Directive):
                 # option check
                 for opt in self.data_option_list:
                     if opt not in temp_dict2[enviro]:
-                        logger.warning(
-                            "option '{}' is not present in '{}' environment file".format(
-                                opt, enviro
-                            )
-                        )
+                        logger.warning(f"option '{opt}' is not present in '{enviro}' environment file")
 
                 del temp_dict
 

--- a/sphinxcontrib/test_reports/directives/test_file.py
+++ b/sphinxcontrib/test_reports/directives/test_file.py
@@ -6,10 +6,8 @@ from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
 
 import sphinxcontrib.test_reports.directives.test_suite
-from sphinxcontrib.test_reports.directives.test_common import \
-    TestCommonDirective
-from sphinxcontrib.test_reports.exceptions import \
-    TestReportIncompleteConfiguration
+from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
+from sphinxcontrib.test_reports.exceptions import TestReportIncompleteConfiguration
 
 
 class TestFile(nodes.General, nodes.Element):
@@ -89,13 +87,9 @@ class TestFileDirective(TestCommonDirective):
             errors=errors,
         )
 
-        if (
-            "auto_cases" in self.options.keys()
-            and "auto_suites" not in self.options.keys()  # noqa W 503
-        ):
+        if "auto_cases" in self.options.keys() and "auto_suites" not in self.options.keys():  # noqa W 503
             raise TestReportIncompleteConfiguration(
-                "option auto_cases must be used together with "
-                "auto_suites for test-file directives."
+                "option auto_cases must be used together with " "auto_suites for test-file directives."
             )
 
         if "auto_suites" in self.options.keys():
@@ -125,18 +119,16 @@ class TestFileDirective(TestCommonDirective):
                     options["links"] = options["links"] + ";" + self.test_id
 
                 arguments = [suite["name"]]
-                suite_directive = (
-                    sphinxcontrib.test_reports.directives.test_suite.TestSuiteDirective(
-                        self.app.config.tr_suite[0],
-                        arguments,
-                        options,
-                        "",
-                        self.lineno,  # no content
-                        self.content_offset,
-                        self.block_text,
-                        self.state,
-                        self.state_machine,
-                    )
+                suite_directive = sphinxcontrib.test_reports.directives.test_suite.TestSuiteDirective(
+                    self.app.config.tr_suite[0],
+                    arguments,
+                    options,
+                    "",
+                    self.lineno,  # no content
+                    self.content_offset,
+                    self.block_text,
+                    self.state,
+                    self.state_machine,
                 )
 
                 main_section += suite_directive.run()

--- a/sphinxcontrib/test_reports/directives/test_file.py
+++ b/sphinxcontrib/test_reports/directives/test_file.py
@@ -6,8 +6,10 @@ from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
 
 import sphinxcontrib.test_reports.directives.test_suite
-from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
-from sphinxcontrib.test_reports.exceptions import TestReportIncompleteConfiguration
+from sphinxcontrib.test_reports.directives.test_common import \
+    TestCommonDirective
+from sphinxcontrib.test_reports.exceptions import \
+    TestReportIncompleteConfiguration
 
 
 class TestFile(nodes.General, nodes.Element):

--- a/sphinxcontrib/test_reports/directives/test_report.py
+++ b/sphinxcontrib/test_reports/directives/test_report.py
@@ -54,14 +54,10 @@ class TestReportDirective(TestCommonDirective):
 
         if not os.path.isfile(template_path):
             raise InvalidConfigurationError(
-                "could not find a template file with name {} in conf.py directory".format(
-                    template_path
-                )
+                f"could not find a template file with name {template_path} in conf.py directory"
             )
 
-        with open(
-            template_path, encoding=self.app.config.tr_import_encoding
-        ) as template_file:
+        with open(template_path, encoding=self.app.config.tr_import_encoding) as template_file:
             template = "".join(template_file.readlines())
 
         if self.test_links is not None and len(self.test_links) > 0:
@@ -75,11 +71,7 @@ class TestReportDirective(TestCommonDirective):
             "file_type": self.app.config.tr_file[0],
             "suite_need": self.app.config.tr_suite[1],
             "case_need": self.app.config.tr_case[1],
-            "tags": (
-                ";".join([self.test_tags, self.test_id])
-                if len(self.test_tags) > 0
-                else self.test_id
-            ),
+            "tags": (";".join([self.test_tags, self.test_id]) if len(self.test_tags) > 0 else self.test_id),
             "links_string": links_string,
             "title": self.test_name,
             "content": self.content,
@@ -87,8 +79,6 @@ class TestReportDirective(TestCommonDirective):
         }
 
         template_ready = template.format(**template_data)
-        self.state_machine.insert_input(
-            template_ready.split("\n"), self.state_machine.document.attributes["source"]
-        )
+        self.state_machine.insert_input(template_ready.split("\n"), self.state_machine.document.attributes["source"])
 
         return []

--- a/sphinxcontrib/test_reports/directives/test_report.py
+++ b/sphinxcontrib/test_reports/directives/test_report.py
@@ -75,9 +75,11 @@ class TestReportDirective(TestCommonDirective):
             "file_type": self.app.config.tr_file[0],
             "suite_need": self.app.config.tr_suite[1],
             "case_need": self.app.config.tr_case[1],
-            "tags": ";".join([self.test_tags, self.test_id])
-            if len(self.test_tags) > 0
-            else self.test_id,
+            "tags": (
+                ";".join([self.test_tags, self.test_id])
+                if len(self.test_tags) > 0
+                else self.test_id
+            ),
             "links_string": links_string,
             "title": self.test_name,
             "content": self.content,

--- a/sphinxcontrib/test_reports/directives/test_results.py
+++ b/sphinxcontrib/test_reports/directives/test_results.py
@@ -52,9 +52,7 @@ class TestResultsDirective(Directive):
                     skips=testsuite["skips"],
                 )
             )
-            section += nodes.paragraph(
-                text="Time: {time}".format(time=testsuite["time"])
-            )
+            section += nodes.paragraph(text="Time: {time}".format(time=testsuite["time"]))
 
             table = nodes.table()
             section += table
@@ -92,9 +90,7 @@ class TestResultsDirective(Directive):
 
         row = nodes.row(classes=["tr_" + testcase["result"]])
         for index, cell in enumerate(row_cells):
-            entry = nodes.entry(
-                classes=["tr_" + testcase["result"], self.header[index]]
-            )
+            entry = nodes.entry(classes=["tr_" + testcase["result"], self.header[index]])
             row += entry
             entry += nodes.paragraph(text=cell, classes=["tr_" + testcase["result"]])
         return row

--- a/sphinxcontrib/test_reports/directives/test_suite.py
+++ b/sphinxcontrib/test_reports/directives/test_suite.py
@@ -6,7 +6,8 @@ from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
 
 import sphinxcontrib.test_reports.directives.test_case
-from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
+from sphinxcontrib.test_reports.directives.test_common import \
+    TestCommonDirective
 from sphinxcontrib.test_reports.exceptions import TestReportInvalidOption
 
 

--- a/sphinxcontrib/test_reports/directives/test_suite.py
+++ b/sphinxcontrib/test_reports/directives/test_suite.py
@@ -6,8 +6,7 @@ from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
 
 import sphinxcontrib.test_reports.directives.test_case
-from sphinxcontrib.test_reports.directives.test_common import \
-    TestCommonDirective
+from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
 from sphinxcontrib.test_reports.exceptions import TestReportInvalidOption
 
 
@@ -63,9 +62,7 @@ class TestSuiteDirective(TestCommonDirective):
                 break
 
         if suite is None:
-            raise TestReportInvalidOption(
-                f"Suite {suite_name} not found in test file {self.test_file}"
-            )
+            raise TestReportInvalidOption(f"Suite {suite_name} not found in test file {self.test_file}")
 
         cases = suite["tests"]
 
@@ -121,18 +118,16 @@ class TestSuiteDirective(TestCommonDirective):
                     options["links"] = options["links"] + ";" + self.test_id
 
                 arguments = [suite["name"]]
-                suite_directive = (
-                    sphinxcontrib.test_reports.directives.test_suite.TestSuiteDirective(
-                        self.app.config.tr_suite[0],
-                        arguments,
-                        options,
-                        "",
-                        self.lineno,  # no content
-                        self.content_offset,
-                        self.block_text,
-                        self.state,
-                        self.state_machine,
-                    )
+                suite_directive = sphinxcontrib.test_reports.directives.test_suite.TestSuiteDirective(
+                    self.app.config.tr_suite[0],
+                    arguments,
+                    options,
+                    "",
+                    self.lineno,  # no content
+                    self.content_offset,
+                    self.block_text,
+                    self.state,
+                    self.state_machine,
                 )
 
                 is_nested = len(suite_obj["testsuites"]) > 0
@@ -150,9 +145,7 @@ class TestSuiteDirective(TestCommonDirective):
                 case_id = self.test_id
                 case_id += (
                     "_"
-                    + hashlib.sha1(  # noqa: W503
-                        case["classname"].encode("UTF-8") + case["name"].encode("UTF-8")
-                    )
+                    + hashlib.sha1(case["classname"].encode("UTF-8") + case["name"].encode("UTF-8"))  # noqa: W503
                     .hexdigest()
                     .upper()[: self.app.config.tr_case_id_length]
                 )
@@ -176,18 +169,16 @@ class TestSuiteDirective(TestCommonDirective):
                     options["links"] = options["links"] + ";" + self.test_id
 
                 arguments = [case["name"]]
-                case_directive = (
-                    sphinxcontrib.test_reports.directives.test_case.TestCaseDirective(
-                        self.app.config.tr_case[0],
-                        arguments,
-                        options,
-                        "",
-                        self.lineno,  # no content
-                        self.content_offset,
-                        self.block_text,
-                        self.state,
-                        self.state_machine,
-                    )
+                case_directive = sphinxcontrib.test_reports.directives.test_case.TestCaseDirective(
+                    self.app.config.tr_case[0],
+                    arguments,
+                    options,
+                    "",
+                    self.lineno,  # no content
+                    self.content_offset,
+                    self.block_text,
+                    self.state,
+                    self.state_machine,
                 )
 
                 is_nested = len(suite_obj["testsuite_nested"]) > 0 or nested

--- a/sphinxcontrib/test_reports/environment.py
+++ b/sphinxcontrib/test_reports/environment.py
@@ -29,21 +29,13 @@ def safe_add_file(filename, app):
     static_data_file = os.path.join("_static", data_file)
 
     if data_file.split(".")[-1] == "js":
-        if (
-            hasattr(app.builder, "script_files")
-            and static_data_file not in app.builder.script_files  # noqa: W503
-        ):
+        if hasattr(app.builder, "script_files") and static_data_file not in app.builder.script_files:  # noqa: W503
             app.add_js_file(data_file)
     elif data_file.split(".")[-1] == "css":
-        if (
-            hasattr(app.builder, "css_files")
-            and static_data_file not in app.builder.css_files  # noqa: W503
-        ):
+        if hasattr(app.builder, "css_files") and static_data_file not in app.builder.css_files:  # noqa: W503
             app.add_css_file(data_file)
     else:
-        raise NotImplementedError(
-            "File type {} not support by save_add_file".format(data_file.split(".")[-1])
-        )
+        raise NotImplementedError("File type {} not support by save_add_file".format(data_file.split(".")[-1]))
 
 
 def safe_remove_file(filename, app):
@@ -60,14 +52,10 @@ def safe_remove_file(filename, app):
     static_data_file = os.path.join("_static", data_file)
 
     if data_file.split(".")[-1] == "js":
-        if (
-            hasattr(app.builder, "script_files")
-            and static_data_file in app.builder.script_files  # noqa: W503
-        ):
+        if hasattr(app.builder, "script_files") and static_data_file in app.builder.script_files:  # noqa: W503
             app.builder.script_files.remove(static_data_file)
     elif data_file.split(".")[-1] == "css" and (
-        hasattr(app.builder, "css_files")
-        and static_data_file in app.builder.css_files  # noqa: W503
+        hasattr(app.builder, "css_files") and static_data_file in app.builder.css_files  # noqa: W503
     ):
         app.builder.css_files.remove(static_data_file)
 
@@ -94,19 +82,11 @@ def install_styles_static_files(app, env):
         len(files_to_copy),
     ):
         if not os.path.isabs(source_file_path):
-            source_file_path = os.path.join(
-                os.path.dirname(__file__), "css", source_file_path
-            )
+            source_file_path = os.path.join(os.path.dirname(__file__), "css", source_file_path)
 
         if not os.path.exists(source_file_path):
-            source_file_path = os.path.join(
-                os.path.dirname(__file__), "css", "blank.css"
-            )
-            print(
-                "{} not found. Copying sphinx-internal blank.css".format(
-                    source_file_path
-                )
-            )
+            source_file_path = os.path.join(os.path.dirname(__file__), "css", "blank.css")
+            print(f"{source_file_path} not found. Copying sphinx-internal blank.css")
 
         dest_file_path = os.path.join(dest_path, os.path.basename(source_file_path))
 

--- a/sphinxcontrib/test_reports/environment.py
+++ b/sphinxcontrib/test_reports/environment.py
@@ -2,7 +2,6 @@ import os
 
 import sphinx
 from packaging.version import Version
-
 from sphinx.util.console import brown
 from sphinx.util.osutil import copyfile, ensuredir
 

--- a/sphinxcontrib/test_reports/jsonparser.py
+++ b/sphinxcontrib/test_reports/jsonparser.py
@@ -5,6 +5,7 @@ Must be configured via config, as there is no known standard for Test data in JS
 
 API must be in sync with the JUnit parser in ``junitparser.py``.
 """
+
 import json
 import operator
 import os

--- a/sphinxcontrib/test_reports/jsonparser.py
+++ b/sphinxcontrib/test_reports/jsonparser.py
@@ -57,23 +57,15 @@ class JsonParser:
 
         def parse_testcase(json_dict) -> Dict[str, Any]:
             tc_mapping = self.json_mapping.get("testcase")
-            tc_dict = {
-                k: dict_get(json_dict, v[0], v[1]) for k, v in tc_mapping.items()
-            }
+            tc_dict = {k: dict_get(json_dict, v[0], v[1]) for k, v in tc_mapping.items()}
             return tc_dict
 
         def parse_testsuite(json_dict) -> Dict[str, Any]:
             ts_mapping = self.json_mapping.get("testsuite")
-            ts_dict = {
-                k: dict_get(json_dict, v[0], v[1])
-                for k, v in ts_mapping.items()
-                if k != "testcases"
-            }
+            ts_dict = {k: dict_get(json_dict, v[0], v[1]) for k, v in ts_mapping.items() if k != "testcases"}
             ts_dict.update({"testcases": [], "testsuite_nested": []})
 
-            testcases = dict_get(
-                json_dict, ts_mapping["testcases"][0], ts_mapping["testcases"][1]
-            )
+            testcases = dict_get(json_dict, ts_mapping["testcases"][0], ts_mapping["testcases"][1])
             for tc in testcases:
                 new_testcase = parse_testcase(tc)
                 ts_dict["testcases"].append(new_testcase)

--- a/sphinxcontrib/test_reports/junitparser.py
+++ b/sphinxcontrib/test_reports/junitparser.py
@@ -20,9 +20,7 @@ class JUnitParser:
         self.valid_xml = None
 
         if not os.path.exists(self.junit_xml_path):
-            raise JUnitFileMissing(
-                f"The given file does not exist: {self.junit_xml_path}"
-            )
+            raise JUnitFileMissing(f"The given file does not exist: {self.junit_xml_path}")
         self.junit_xml_doc = etree.parse(self.junit_xml_path)
 
         self.junit_xml_string = etree.tostring(self.junit_xml_doc)

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -62,9 +62,7 @@ def setup(app):
     )
 
     # adds option for custom template
-    template_dir = os.path.join(
-        os.path.dirname(__file__), "directives/test_report_template.txt"
-    )
+    template_dir = os.path.join(os.path.dirname(__file__), "directives/test_report_template.txt")
     app.add_config_value("tr_report_template", template_dir, "html")
 
     app.add_config_value("tr_suite_id_length", 3, "html")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,7 @@ def copy_srcdir_to_tmpdir(srcdir, tmp):
     srcdir = Path(__file__).parent.absolute() / srcdir
     tmproot = tmp / Path(srcdir).name
     shutil.copytree(srcdir, tmproot)
-    return (
-        tmproot
-        if Version(sphinx_version) >= Version("7.2")
-        else path(tmproot.absolute())
-    )
+    return tmproot if Version(sphinx_version) >= Version("7.2") else path(tmproot.absolute())
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Pytest conftest module containing common test configuration and fixtures."""
+
 import shutil
 from pathlib import Path
 from tempfile import mkdtemp

--- a/tests/doc_test/custom_tr_koi8_template/conf.py
+++ b/tests/doc_test/custom_tr_koi8_template/conf.py
@@ -22,9 +22,7 @@ import os
 
 project = "sphinx-test-reports"
 now = datetime.datetime.now()
-copyright = '2017-{year}, <a href="http://useblocks.com">team useblocks</a>'.format(
-    year=now.year
-)
+copyright = f'2017-{now.year}, <a href="http://useblocks.com">team useblocks</a>'
 author = "team useblocks"
 
 # The short X.Y version

--- a/tests/doc_test/custom_tr_koi8_template/conf.py
+++ b/tests/doc_test/custom_tr_koi8_template/conf.py
@@ -135,9 +135,9 @@ html_theme_options = {
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
-html_sidebars = {
-    "**": ["about.html", "navigation.html"],
-}
+# html_sidebars = {
+#     "**": ["about.html", "navigation.html"],
+# }
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/tests/doc_test/custom_tr_template/conf.py
+++ b/tests/doc_test/custom_tr_template/conf.py
@@ -22,9 +22,7 @@ import os
 
 project = "sphinx-test-reports"
 now = datetime.datetime.now()
-copyright = '2017-{year}, <a href="http://useblocks.com">team useblocks</a>'.format(
-    year=now.year
-)
+copyright = f'2017-{now.year}, <a href="http://useblocks.com">team useblocks</a>'
 author = "team useblocks"
 
 # The short X.Y version

--- a/tests/doc_test/custom_tr_template/conf.py
+++ b/tests/doc_test/custom_tr_template/conf.py
@@ -133,9 +133,9 @@ html_theme_options = {
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
-html_sidebars = {
-    "**": ["about.html", "navigation.html"],
-}
+# html_sidebars = {
+#     "**": ["about.html", "navigation.html"],
+# }
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/tests/doc_test/custom_tr_utf8_template/conf.py
+++ b/tests/doc_test/custom_tr_utf8_template/conf.py
@@ -22,9 +22,7 @@ import os
 
 project = "sphinx-test-reports"
 now = datetime.datetime.now()
-copyright = '2017-{year}, <a href="http://useblocks.com">team useblocks</a>'.format(
-    year=now.year
-)
+copyright = f'2017-{now.year}, <a href="http://useblocks.com">team useblocks</a>'
 author = "team useblocks"
 
 # The short X.Y version

--- a/tests/doc_test/custom_tr_utf8_template/conf.py
+++ b/tests/doc_test/custom_tr_utf8_template/conf.py
@@ -135,9 +135,9 @@ html_theme_options = {
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
-html_sidebars = {
-    "**": ["about.html", "navigation.html"],
-}
+# html_sidebars = {
+#     "**": ["about.html", "navigation.html"],
+# }
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/tests/test_basic_doc.py
+++ b/tests/test_basic_doc.py
@@ -3,9 +3,7 @@ from pathlib import Path
 import pytest
 
 
-@pytest.mark.parametrize(
-    "test_app", [{"buildername": "html", "srcdir": "doc_test/basic_doc"}], indirect=True
-)
+@pytest.mark.parametrize("test_app", [{"buildername": "html", "srcdir": "doc_test/basic_doc"}], indirect=True)
 def test_doc_build_html(test_app):
     app = test_app
     app.build()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,9 +5,7 @@ from subprocess import STDOUT, check_output
 import pytest
 import sphinx
 
-sphinx_version = int(
-    sphinx.__version__.split(".")[0] + sphinx.__version__.split(".")[1]
-)
+sphinx_version = int(sphinx.__version__.split(".")[0] + sphinx.__version__.split(".")[1])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -82,9 +82,7 @@ def test_json_parser_build_html(test_app):
     # Check TestCase need object(s)
     case_name = "test case 2"
     case_classname = "class name 2"
-    hash_c = hashlib.sha1(
-        case_classname.encode("UTF-8") + case_name.encode("UTF-8")
-    ).hexdigest()
+    hash_c = hashlib.sha1(case_classname.encode("UTF-8") + case_name.encode("UTF-8")).hexdigest()
     case_id = f"{suite_id}_{hash_c.upper()[: app.config.tr_case_id_length]}"
 
     assert '<span class="needs_data">Test-Case</span>' in html

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -1,19 +1,11 @@
 import os
 
 xml_path = os.path.join(os.path.dirname(__file__), "doc_test/utils", "xml_data.xml")
-xml_pytest_path = os.path.join(
-    os.path.dirname(__file__), "doc_test/utils", "pytest_data.xml"
-)
-xml_pytest51_path = os.path.join(
-    os.path.dirname(__file__), "doc_test/utils", "pytest_data_5_1.xml"
-)
-xml_pytest62_path = os.path.join(
-    os.path.dirname(__file__), "doc_test/utils", "pytest_data_6_2.xml"
-)
+xml_pytest_path = os.path.join(os.path.dirname(__file__), "doc_test/utils", "pytest_data.xml")
+xml_pytest51_path = os.path.join(os.path.dirname(__file__), "doc_test/utils", "pytest_data_5_1.xml")
+xml_pytest62_path = os.path.join(os.path.dirname(__file__), "doc_test/utils", "pytest_data_6_2.xml")
 
-xml_nose_path = os.path.join(
-    os.path.dirname(__file__), "doc_test/utils", "nose_data.xml"
-)
+xml_nose_path = os.path.join(os.path.dirname(__file__), "doc_test/utils", "nose_data.xml")
 
 xml_ctest_path = os.path.join(os.path.dirname(__file__), "doc_test/utils", "ctest.xml")
 
@@ -140,9 +132,7 @@ def test_parse_ctest_xml():
     assert test_suite["testcases"][0]["result"] == "passed"
     assert test_suite["testcases"][1]["name"] == "success_test"
     assert test_suite["testcases"][1]["result"] == "passed"
-    assert (
-        test_suite["testcases"][2]["name"] == "fail_test"
-    )  # fail in name, but nowhere in status, faked fail
+    assert test_suite["testcases"][2]["name"] == "fail_test"  # fail in name, but nowhere in status, faked fail
     assert test_suite["testcases"][2]["result"] == "passed"
     assert test_suite["testcases"][3]["name"] == "fail_test_output"
     assert test_suite["testcases"][3]["result"] == "failure"

--- a/tests/test_test_ctest_file.py
+++ b/tests/test_test_ctest_file.py
@@ -28,9 +28,7 @@ def test_test_ctest_file(test_app):
     srcdir = Path(app.srcdir)
     out_dir = srcdir / "_build"
 
-    out = subprocess.run(
-        ["sphinx-build", "-M", "html", srcdir, out_dir], capture_output=True
-    )
+    out = subprocess.run(["sphinx-build", "-M", "html", srcdir, out_dir], capture_output=True)
 
     assert out.returncode == 0
 

--- a/tests/test_test_file.py
+++ b/tests/test_test_file.py
@@ -28,9 +28,7 @@ def test_test_file_needs_extra_options_no_warning(test_app):
     srcdir = Path(app.srcdir)
     out_dir = srcdir / "_build"
 
-    out = subprocess.run(
-        ["sphinx-build", "-M", "html", srcdir, out_dir], capture_output=True
-    )
+    out = subprocess.run(["sphinx-build", "-M", "html", srcdir, out_dir], capture_output=True)
 
     assert out.returncode == 0
 


### PR DESCRIPTION
This is the third 'split' PR that was discussed for splitting the big one into smaller ones. This one here https://github.com/useblocks/sphinx-test-reports/pull/80

This PR changes the import of `make_hashed_id`  to the now only internal version `_make_hashed_id` and adapts the arguments to fit as well.
Unsure if this is the best way to do it, or if maybe upstream the function should be exported again.

fixes #78 

---

Note: This PR has a similar issue as #82 issue being that the 8.1.3 Sphinx tests fail, with the same error message. 
```
FAILED tests/test_custom_template.py::test_custom_koi8_template[test_app0] - sphinx.errors.ThemeError: An error happened in rendering the page index.
FAILED tests/test_custom_template.py::test_custom_utf8_template[test_app0] - sphinx.errors.ThemeError: An error happened in rendering the page index.
FAILED tests/test_custom_template.py::test_custom_template[test_app0] - sphinx.errors.ThemeError: An error happened in rendering the page index.
```
More exact:
```
E           sphinx.errors.ThemeError: An error happened in rendering the page index.
E           Reason: TemplateNotFound("'about.html' not found in ['/tmp/tmptxv71yyp/custom_tr_template/_templates', '/home/maxi/tmp/testing/sphinx-test-reports/.nox/tests-3-12-sphinx-8-1-3/lib/python3.12/site-packages/sphinx/themes/basic']")

.nox/tests-3-12-sphinx-8-1-3/lib/python3.12/site-packages/sphinx/builders/html/__init__.py:1201: ThemeError
```

also here let me know if this can be resolved somehow, as I did not find the 'html' it talks about. 

I could remove `about.html` from the conf.py but unsure if that has further consequences.


