### PR TITLE
Added possibility for directives to have 'extra-options' defined in c…

### DIFF
--- a/sphinxcontrib/test_reports/directives/test_case.py
+++ b/sphinxcontrib/test_reports/directives/test_case.py
@@ -2,6 +2,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
+from sphinx_needs.config import NeedsSphinxConfig
 
 from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
 from sphinxcontrib.test_reports.exceptions import TestReportInvalidOption
@@ -32,9 +33,6 @@ class TestCaseDirective(TestCommonDirective):
     }
 
     final_argument_whitespace = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def run(self, nested=False, suite_count=-1, case_count=-1):
         self.prepare_basic_options()
@@ -163,6 +161,40 @@ class TestCaseDirective(TestCommonDirective):
 
         main_section = []
         docname = self.state.document.settings.env.docname
+        needs_config = NeedsSphinxConfig(self.env.config)
+        extra_links = needs_config.extra_links
+        extra_options = needs_config.extra_options
+        specified_opts = (
+            "docname",
+            "lineno",
+            "type",
+            "title",
+            "id",
+            "content",
+            "links",
+            "tags",
+            "status",
+            "collapse",
+            "file",
+            "suite",
+            "case",
+            "case_name",
+            "case_parameter",
+            "classname",
+            "result",
+            "time",
+            "style",
+            "passed",
+            "skipped",
+            "failed",
+            "errors",
+        )
+        need_extra_options = {}
+        extra_links_options = [x["option"] for x in extra_links]
+        all_options = extra_links_options + list(extra_options.keys())
+        for extra_option in all_options:
+            if extra_option not in specified_opts:
+                need_extra_options[extra_option] = self.options.get(extra_option, "")
         main_section += add_need(
             self.app,
             self.state,
@@ -185,6 +217,7 @@ class TestCaseDirective(TestCommonDirective):
             result=result,
             time=time,
             style=style,
+            **need_extra_options
         )
 
         add_doc(self.env, docname)

--- a/sphinxcontrib/test_reports/directives/test_common.py
+++ b/sphinxcontrib/test_reports/directives/test_common.py
@@ -4,9 +4,10 @@ A Common directive, from which all other test directives inherit the shared func
 # fmt: off
 import os
 
-from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Directive, directives
 from sphinx.util import logging
-from sphinx_needs.api import make_hashed_id
+from sphinx_needs.api.need import _make_hashed_id
+from sphinx_needs.config import NeedsSphinxConfig
 
 from sphinxcontrib.test_reports.exceptions import (
     SphinxError, TestReportFileNotSetException)
@@ -20,6 +21,35 @@ class TestCommonDirective(Directive):
     """
     Common directive, which provides some shared functions to "real" directives.
     """
+
+    @classmethod 
+    def update_option_spec(cls, app):
+        """
+        Adding extra_options & extra_links defined via sphinx_needs to 'allowed' options
+        """
+        needs_config = NeedsSphinxConfig(app.config)
+
+        if not hasattr(cls, 'option_spec'):
+            cls.option_spec = {}
+        elif cls.option_spec is None: 
+            cls.option_spec = {}
+        new_options = dict(getattr(cls, 'option_spec', {}) or {})
+
+        extra_options = getattr(needs_config, 'extra_options', None)
+        if extra_options is None: 
+            extra_options = {}
+        extra_links = getattr(needs_config, 'extra_links', None)
+        if extra_links is None: 
+            extra_links = {}
+
+        extra_links_options = [x["option"] for x in extra_links]
+        all_options = extra_links_options + list(extra_options.keys())
+
+        for option in all_options:
+            if option not in new_options:
+                new_options[option] = directives.unchanged    
+
+        cls.option_spec = new_options
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -90,9 +120,7 @@ class TestCommonDirective(Directive):
             self.need_type = self.app.tr_types[self.name][0]
             self.test_id = self.options.get(
                 "id",
-                make_hashed_id(
-                    self.app, self.need_type, self.test_name, self.test_content
-                ),
+                _make_hashed_id(self.need_type, self.test_name, self.test_content, NeedsSphinxConfig(self.app.config))
             )
         else:
             self.test_id = self.options.get("id")

--- a/sphinxcontrib/test_reports/directives/test_file.py
+++ b/sphinxcontrib/test_reports/directives/test_file.py
@@ -4,6 +4,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx_needs.api import add_need
 from sphinx_needs.utils import add_doc
+from sphinx_needs.config import NeedsSphinxConfig
 
 import sphinxcontrib.test_reports.directives.test_suite
 from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
@@ -35,11 +36,36 @@ class TestFileDirective(TestCommonDirective):
 
     final_argument_whitespace = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.suite_ids = {}
-
     def run(self):
+        self.suite_ids = {}
+        needs_config = NeedsSphinxConfig(self.env.config)
+        extra_links = needs_config.extra_links
+        extra_options = needs_config.extra_options
+        specified_opts = (
+            "docname",
+            "lineno",
+            "type",
+            "title",
+            "id",
+            "content",
+            "links",
+            "tags",
+            "status",
+            "collapse",
+            "file",
+            "suites",
+            "cases",
+            "passed",
+            "skipped",
+            "failed",
+            "errors",
+        )
+        need_extra_options = {}
+        extra_links_options = [x["option"] for x in extra_links]
+        all_options = extra_links_options + list(extra_options.keys())
+        for extra_option in all_options:
+            if extra_option not in specified_opts:
+                need_extra_options[extra_option] = self.options.get(extra_option, "")
         self.prepare_basic_options()
         results = self.load_test_file()
 
@@ -85,6 +111,7 @@ class TestFileDirective(TestCommonDirective):
             skipped=skipped,
             failed=failed,
             errors=errors,
+            **need_extra_options
         )
 
         if (

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -117,6 +117,7 @@ def setup(app):
     app.connect("env-updated", install_styles_static_files)
     app.connect("config-inited", tr_preparation)
     app.connect("config-inited", sphinx_needs_update)
+    app.connect("env-before-read-docs", add_extra_options_to_directives)
 
     return {
         "version": VERSION,  # identifies the version of our extension
@@ -179,3 +180,15 @@ def sphinx_needs_update(app, *args):
     add_need_type(app, *app.config.tr_file[1:])
     add_need_type(app, *app.config.tr_suite[1:])
     add_need_type(app, *app.config.tr_case[1:])
+
+
+def add_extra_options_to_directives(app, env, *args, **kwargs):
+    """
+    Add 'needs_extra_options' to the 'opt_spec' of the directives.
+    In order to allow them to have said directives inside rst files
+    """
+    if not hasattr(env.config, 'needs_extra_options'):
+        env.config.needs_extra_options = [] 
+    TestCaseDirective.update_option_spec(app)
+    TestSuiteDirective.update_option_spec(app)
+    TestFileDirective.update_option_spec(app)

--- a/tests/doc_test/doc_test_file/conf.py
+++ b/tests/doc_test/doc_test_file/conf.py
@@ -75,7 +75,7 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-needs_extra_options = ["asil", "uses_secure"]
+needs_extra_options = ["asil", "uses_secure", "verifies"]
 
 # General information about the project.
 project = "test-report test docs"

--- a/tests/doc_test/doc_test_file/index.rst
+++ b/tests/doc_test/doc_test_file/index.rst
@@ -23,6 +23,7 @@ Basic Document FOR TEST FILE
 
 .. test-file:: My Test Data
    :file: ../utils/xml_data.xml
+   :verifies: This is an extra option
    :id: TESTFILE_1
 
 

--- a/tests/test_custom_template.py
+++ b/tests/test_custom_template.py
@@ -44,7 +44,5 @@ def test_custom_koi8_template(test_app):
     app.build()
     html = Path(app.outdir / "index.html").read_text(encoding="utf8")
 
-    print(html)
-
     assert "бцдеф" in html
     assert "Testfбlle" in html

--- a/tests/test_test_file.py
+++ b/tests/test_test_file.py
@@ -13,6 +13,7 @@ def test_doc_build_html(test_app):
     app.build()
     html = Path(app.outdir, "index.html").read_text()
     assert html
+    assert "This is an extra option" in html
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is the fourth 'split' PR that was discussed for splitting the big one into smaller ones. This one here https://github.com/useblocks/sphinx-test-reports/pull/80


Note: PR depends on another. #83. 

This PR adds the capability of the directives declared in the package to contain `extra_options` defined via the `sphinx-needs` option in conf.py. 

Note: This PR has a similar issue as #83  issue being that the 8.1.3 Sphinx tests fail, with the same error message.
```
FAILED tests/test_custom_template.py::test_custom_koi8_template[test_app0] - sphinx.errors.ThemeError: An error happened in rendering the page index.
FAILED tests/test_custom_template.py::test_custom_utf8_template[test_app0] - sphinx.errors.ThemeError: An error happened in rendering the page index.
FAILED tests/test_custom_template.py::test_custom_template[test_app0] - sphinx.errors.ThemeError: An error happened in rendering the page index.
```
More exact:
```
E           sphinx.errors.ThemeError: An error happened in rendering the page index.
E           Reason: TemplateNotFound("'about.html' not found in ['/tmp/tmptxv71yyp/custom_tr_template/_templates', '/home/maxi/tmp/testing/sphinx-test-reports/.nox/tests-3-12-sphinx-8-1-3/lib/python3.12/site-packages/sphinx/themes/basic']")

.nox/tests-3-12-sphinx-8-1-3/lib/python3.12/site-packages/sphinx/builders/html/__init__.py:1201: ThemeError
```
