### PR TITLE
🔧 Add sphinx-needs 8.0.0 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.12"] # No "3.10", as nose seem to have problems with it
         sphinx-version: ["5.0", "8.1.3"]
-        sphinx_needs-version: ["2.1", "4.2", "5.1", "6.3.0"]
+        sphinx_needs-version: ["2.1", "4.2", "5.1", "6.3.0", "8.0.0"]
     steps:
       - uses: actions/checkout@v2
       - name: Set Up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,6 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: v0.9.3
-    hooks:
-      - id: taplo-format
-
   - repo: https://github.com/google/yamlfmt
     rev: v0.16.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,11 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+
   - repo: https://github.com/google/yamlfmt
     rev: v0.16.0
     hooks:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -107,7 +107,7 @@ introduces several maintenance improvements.
 -----
 :Released: 26.09.2022
 
-* Improvement: Supporting `Sphinx-Needs <https://www.sphinx-needs.com/>`__ ``>= 1.01`` only.
+* Improvement: Supporting `Sphinx-Needs <https://sphinx-needs.readthedocs.io/en/latest/>`__ ``>= 1.01`` only.
 * Improvement: Migrated nosetests to pytest.
 
 0.3.7

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,9 @@ import os
 # import os
 import sys
 
+import sphinx_needs
+from packaging.version import Version
+
 sys.path.append(os.path.abspath("."))
 
 from ub_theme.conf import html_theme_options
@@ -67,7 +70,13 @@ plantuml_output_format = "png"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates", "ub_theme/templates"]
-needs_extra_options = ["more_info"]
+if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+    needs_fields = {
+        "more_info": {"nullable": True},
+    }
+else:
+    needs_extra_options = ["more_info"]
+
 tr_extra_options = ["more_info"]
 # Add a custom test report template. Please add a relative path from this conf.py
 # tr_report_template = "./custom_test_report_template.txt"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,7 +92,7 @@ In the last years, we have created additional information and extensions, which 
 
     .. grid-item-card::
         :columns: 12 6 6 6
-        :link: https://sphinx-needs.com
+        :link: https://sphinx-needs.readthedocs.io/en/latest/
         :img-top: /_static/sphinx-needs-card.png
         :class-card: border
 
@@ -103,7 +103,7 @@ In the last years, we have created additional information and extensions, which 
         Also, it is a good entry point to understand the benefits and get an idea about the complete ecosystem of Sphinx-Needs.
         +++
 
-        .. button-link:: https://sphinx-needs.com
+        .. button-link:: https://sphinx-needs.readthedocs.io/en/latest/
             :color: primary
             :outline:
             :align: center

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ from nox import session
 
 PYTHON_VERSIONS = ["3.10", "3.12"]
 SPHINX_VERSIONS = ["5.0", "7.2.5", "8.1.3"]
-SPHINX_NEEDS_VERSIONS = ["2.1", "4.2", "5.1", "6.0.0", "6.3.0"]
+SPHINX_NEEDS_VERSIONS = ["2.1", "4.2", "5.1", "6.0.0", "6.3.0", "8.0.0"]
 
 
 def run_tests(session, sphinx, sphinx_needs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 keywords = ["sphinx", "documentation", "test-reports"]
 requires-python = ">=3.10"
-dependencies = ["sphinx>4.0", "lxml", "sphinx-needs>=1.0.1"]
+dependencies = ["sphinx>4.0", "lxml", "sphinx-needs>=1.0.1", "packaging>=20.0"]
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = ["sphinx>4.0", "lxml", "sphinx-needs>=1.0.1", "packaging>=20.0"]
 
 [project.optional-dependencies]
 test = [
+  "beautifulsoup4",
   "nox>=2025.2.9",
   "pytest-xdist",
   "pytest>=7.0",

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -191,14 +191,13 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
     needs_version = Version(sphinx_needs.__version__)
     use_schema = needs_version >= Version("6.0.0")
 
-    _register_field(app, getattr(config, "tr_file_option", "file"))
-    _register_field(app, "suite")
-    _register_field(app, "case")
-    _register_field(app, "case_name")
-    _register_field(app, "case_parameter")
-    _register_field(app, "classname")
-
     if use_schema:
+        _register_field(app, getattr(config, "tr_file_option", "file"), schema={"type": "string"})
+        _register_field(app, "suite", schema={"type": "string"})
+        _register_field(app, "case", schema={"type": "string"})
+        _register_field(app, "case_name", schema={"type": "string"})
+        _register_field(app, "case_parameter", schema={"type": "string"})
+        _register_field(app, "classname", schema={"type": "string"})
         _register_field(app, "time", schema={"type": "string"})
         _register_field(app, "suites", schema={"type": "integer"})
         _register_field(app, "cases", schema={"type": "integer"})
@@ -208,6 +207,12 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
         _register_field(app, "errors", schema={"type": "integer"})
         _register_field(app, "result", schema={"type": "string"})
     else:
+        _register_field(app, getattr(config, "tr_file_option", "file"))
+        _register_field(app, "suite")
+        _register_field(app, "case")
+        _register_field(app, "case_name")
+        _register_field(app, "case_parameter")
+        _register_field(app, "classname")
         _register_field(app, "time")
         _register_field(app, "suites")
         _register_field(app, "cases")

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -1,4 +1,5 @@
 # fmt: off
+import inspect
 import os
 
 import sphinx
@@ -10,37 +11,6 @@ from sphinx.config import Config
 
 # from docutils import nodes
 from sphinx_needs.api import add_dynamic_function, add_need_type
-
-# Field descriptions for better semantics
-FIELD_DESCRIPTIONS = {
-    "file": "Test file name",
-    "suite": "Test suite name", 
-    "case": "Test case name",
-    "case_name": "Test case display name",
-    "case_parameter": "Test case parameter",
-    "classname": "Test class name",
-    "time": "Test execution time",
-    "suites": "Number of test suites",
-    "cases": "Number of test cases", 
-    "passed": "Number of passed tests",
-    "skipped": "Number of skipped tests",
-    "failed": "Number of failed tests",
-    "errors": "Number of test errors",
-    "result": "Test result status",
-}
-
-try:
-    from sphinx_needs.api import add_field as _add_field
-
-    def _register_field(app, name, schema=None):
-        description = FIELD_DESCRIPTIONS.get(name, name)
-        _add_field(name, description, schema=schema)
-except ImportError:
-    from sphinx_needs.api import add_extra_option as _add_extra_option
-
-    def _register_field(app, name, schema=None):
-        description = FIELD_DESCRIPTIONS.get(name, name)
-        _add_extra_option(app, name, description=description, **({} if schema is None else {"schema": schema}))
 
 from sphinxcontrib.test_reports.directives.test_case import TestCase, TestCaseDirective
 from sphinxcontrib.test_reports.directives.test_env import EnvReport, EnvReportDirective
@@ -69,6 +39,46 @@ else:
 # fmt: on
 
 VERSION = "1.3.2"
+
+# Field descriptions for better semantics
+FIELD_DESCRIPTIONS = {
+    "file": "Test file name",
+    "suite": "Test suite name",
+    "case": "Test case name",
+    "case_name": "Test case display name",
+    "case_parameter": "Test case parameter",
+    "classname": "Test class name",
+    "time": "Test execution time",
+    "suites": "Number of test suites",
+    "cases": "Number of test cases",
+    "passed": "Number of passed tests",
+    "skipped": "Number of skipped tests",
+    "failed": "Number of failed tests",
+    "errors": "Number of test errors",
+    "result": "Test result status",
+}
+
+try:
+    from sphinx_needs.api import add_field as _add_field
+
+    def _register_field(app, name, schema=None):
+        description = FIELD_DESCRIPTIONS.get(name, name)
+        _add_field(name, description, schema=schema)
+
+except ImportError:
+    from sphinx_needs.api import add_extra_option as _add_extra_option
+
+    _add_extra_option_supports_description = (
+        "description" in inspect.signature(_add_extra_option).parameters
+    )
+
+    def _register_field(app, name, schema=None):
+        kwargs = {}
+        if _add_extra_option_supports_description:
+            kwargs["description"] = FIELD_DESCRIPTIONS.get(name, name)
+        if schema is not None:
+            kwargs["schema"] = schema
+        _add_extra_option(app, name, **kwargs)
 
 
 def setup(app: Sphinx):

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -9,7 +9,18 @@ from sphinx.application import Sphinx
 from sphinx.config import Config
 
 # from docutils import nodes
-from sphinx_needs.api import add_dynamic_function, add_extra_option, add_need_type
+from sphinx_needs.api import add_dynamic_function, add_need_type
+
+try:
+    from sphinx_needs.api import add_field as _add_field
+
+    def _register_field(app, name, schema=None):
+        _add_field(name, name, schema=schema)
+except ImportError:
+    from sphinx_needs.api import add_extra_option as _add_extra_option
+
+    def _register_field(app, name, schema=None):
+        _add_extra_option(app, name, **({} if schema is None else {"schema": schema}))
 
 from sphinxcontrib.test_reports.directives.test_case import TestCase, TestCaseDirective
 from sphinxcontrib.test_reports.directives.test_env import EnvReport, EnvReportDirective
@@ -177,44 +188,34 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
     sphinx-needs configuration
     """
 
-    # Check sphinx-needs version to determine if schema is needed
-    try:
-        needs_version = Version(sphinx_needs.__version__)
-        use_schema = needs_version >= Version("6.0.0")
-    except ImportError:
-        # If we can't determine version, assume older version
-        use_schema = False
+    needs_version = Version(sphinx_needs.__version__)
+    use_schema = needs_version >= Version("6.0.0")
 
-    # Extra options
-    # For details read
-    # https://sphinx-needs.readthedocs.io/en/latest/api.html#sphinx_needs.api.configuration.add_extra_option
+    _register_field(app, getattr(config, "tr_file_option", "file"))
+    _register_field(app, "suite")
+    _register_field(app, "case")
+    _register_field(app, "case_name")
+    _register_field(app, "case_parameter")
+    _register_field(app, "classname")
 
-    add_extra_option(app, getattr(config, "tr_file_option", "file"))
-
-    add_extra_option(app, "suite")
-    add_extra_option(app, "case")
-    add_extra_option(app, "case_name")
-    add_extra_option(app, "case_parameter")
-    add_extra_option(app, "classname")
-    # Add schema parameter conditionally based on sphinx-needs version
     if use_schema:
-        add_extra_option(app, "time", schema={"type": "string"})
-        add_extra_option(app, "suites", schema={"type": "integer"})
-        add_extra_option(app, "cases", schema={"type": "integer"})
-        add_extra_option(app, "passed", schema={"type": "integer"})
-        add_extra_option(app, "skipped", schema={"type": "integer"})
-        add_extra_option(app, "failed", schema={"type": "integer"})
-        add_extra_option(app, "errors", schema={"type": "integer"})
-        add_extra_option(app, "result", schema={"type": "string"})
+        _register_field(app, "time", schema={"type": "string"})
+        _register_field(app, "suites", schema={"type": "integer"})
+        _register_field(app, "cases", schema={"type": "integer"})
+        _register_field(app, "passed", schema={"type": "integer"})
+        _register_field(app, "skipped", schema={"type": "integer"})
+        _register_field(app, "failed", schema={"type": "integer"})
+        _register_field(app, "errors", schema={"type": "integer"})
+        _register_field(app, "result", schema={"type": "string"})
     else:
-        add_extra_option(app, "time")
-        add_extra_option(app, "suites")
-        add_extra_option(app, "cases")
-        add_extra_option(app, "passed")
-        add_extra_option(app, "skipped")
-        add_extra_option(app, "failed")
-        add_extra_option(app, "errors")
-        add_extra_option(app, "result")
+        _register_field(app, "time")
+        _register_field(app, "suites")
+        _register_field(app, "cases")
+        _register_field(app, "passed")
+        _register_field(app, "skipped")
+        _register_field(app, "failed")
+        _register_field(app, "errors")
+        _register_field(app, "result")
     # Extra dynamic functions
     # For details about usage read
     # https://sphinx-needs.readthedocs.io/en/latest/api.html#sphinx_needs.api.configuration.add_dynamic_function

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -11,16 +11,36 @@ from sphinx.config import Config
 # from docutils import nodes
 from sphinx_needs.api import add_dynamic_function, add_need_type
 
+# Field descriptions for better semantics
+FIELD_DESCRIPTIONS = {
+    "file": "Test file name",
+    "suite": "Test suite name", 
+    "case": "Test case name",
+    "case_name": "Test case display name",
+    "case_parameter": "Test case parameter",
+    "classname": "Test class name",
+    "time": "Test execution time",
+    "suites": "Number of test suites",
+    "cases": "Number of test cases", 
+    "passed": "Number of passed tests",
+    "skipped": "Number of skipped tests",
+    "failed": "Number of failed tests",
+    "errors": "Number of test errors",
+    "result": "Test result status",
+}
+
 try:
     from sphinx_needs.api import add_field as _add_field
 
     def _register_field(app, name, schema=None):
-        _add_field(name, name, schema=schema)
+        description = FIELD_DESCRIPTIONS.get(name, name)
+        _add_field(name, description, schema=schema)
 except ImportError:
     from sphinx_needs.api import add_extra_option as _add_extra_option
 
     def _register_field(app, name, schema=None):
-        _add_extra_option(app, name, **({} if schema is None else {"schema": schema}))
+        description = FIELD_DESCRIPTIONS.get(name, name)
+        _add_extra_option(app, name, description=description, **({} if schema is None else {"schema": schema}))
 
 from sphinxcontrib.test_reports.directives.test_case import TestCase, TestCaseDirective
 from sphinxcontrib.test_reports.directives.test_env import EnvReport, EnvReportDirective

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -192,7 +192,9 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
     use_schema = needs_version >= Version("6.0.0")
 
     if use_schema:
-        _register_field(app, getattr(config, "tr_file_option", "file"), schema={"type": "string"})
+        _register_field(
+            app, getattr(config, "tr_file_option", "file"), schema={"type": "string"}
+        )
         _register_field(app, "suite", schema={"type": "string"})
         _register_field(app, "case", schema={"type": "string"})
         _register_field(app, "case_name", schema={"type": "string"})

--- a/tests/doc_test/basic_doc/conf.py
+++ b/tests/doc_test/basic_doc/conf.py
@@ -69,7 +69,13 @@ language = "en"
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-needs_extra_options = ["more_info"]
+import sphinx_needs as _sn
+from packaging.version import Version as _V
+
+if _V(_sn.__version__) >= _V("8.0.0"):
+    needs_fields = {"more_info": {"nullable": True}}
+else:
+    needs_extra_options = ["more_info"]
 tr_extra_options = ["more_info"]
 
 # The name of the Pygments (syntax highlighting) style to use.

--- a/tests/doc_test/basic_doc/conf.py
+++ b/tests/doc_test/basic_doc/conf.py
@@ -18,6 +18,9 @@
 import os
 import sys
 
+import sphinx_needs
+from packaging.version import Version
+
 sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 # -- General configuration ------------------------------------------------
@@ -69,10 +72,7 @@ language = "en"
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-import sphinx_needs as _sn
-from packaging.version import Version as _V
-
-if _V(_sn.__version__) >= _V("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("8.0.0"):
     needs_fields = {"more_info": {"nullable": True}}
 else:
     needs_extra_options = ["more_info"]

--- a/tests/doc_test/doc_test_ctest_file/conf.py
+++ b/tests/doc_test/doc_test_ctest_file/conf.py
@@ -18,6 +18,9 @@
 import os
 import sys
 
+import sphinx_needs
+from packaging.version import Version
+
 sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 # -- General configuration ------------------------------------------------
@@ -75,11 +78,12 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-import sphinx_needs as _sn
-from packaging.version import Version as _V
-
-if _V(_sn.__version__) >= _V("8.0.0"):
-    needs_fields = {"asil": {"nullable": True}, "uses_secure": {"nullable": True}, "more_info": {"nullable": True}}
+if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+    needs_fields = {
+        "asil": {"nullable": True},
+        "uses_secure": {"nullable": True},
+        "more_info": {"nullable": True},
+    }
 else:
     needs_extra_options = ["asil", "uses_secure", "more_info"]
 tr_extra_options = ["more_info"]

--- a/tests/doc_test/doc_test_ctest_file/conf.py
+++ b/tests/doc_test/doc_test_ctest_file/conf.py
@@ -75,7 +75,13 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-needs_extra_options = ["asil", "uses_secure", "more_info"]
+import sphinx_needs as _sn
+from packaging.version import Version as _V
+
+if _V(_sn.__version__) >= _V("8.0.0"):
+    needs_fields = {"asil": {"nullable": True}, "uses_secure": {"nullable": True}, "more_info": {"nullable": True}}
+else:
+    needs_extra_options = ["asil", "uses_secure", "more_info"]
 tr_extra_options = ["more_info"]
 
 # General information about the project.

--- a/tests/doc_test/doc_test_file/conf.py
+++ b/tests/doc_test/doc_test_file/conf.py
@@ -18,6 +18,9 @@
 import os
 import sys
 
+import sphinx_needs
+from packaging.version import Version
+
 sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 # -- General configuration ------------------------------------------------
@@ -75,11 +78,12 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-import sphinx_needs as _sn
-from packaging.version import Version as _V
-
-if _V(_sn.__version__) >= _V("8.0.0"):
-    needs_fields = {"asil": {"nullable": True}, "uses_secure": {"nullable": True}, "more_info": {"nullable": True}}
+if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+    needs_fields = {
+        "asil": {"nullable": True},
+        "uses_secure": {"nullable": True},
+        "more_info": {"nullable": True},
+    }
 else:
     needs_extra_options = ["asil", "uses_secure", "more_info"]
 tr_extra_options = ["more_info"]

--- a/tests/doc_test/doc_test_file/conf.py
+++ b/tests/doc_test/doc_test_file/conf.py
@@ -75,7 +75,13 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-needs_extra_options = ["asil", "uses_secure", "more_info"]
+import sphinx_needs as _sn
+from packaging.version import Version as _V
+
+if _V(_sn.__version__) >= _V("8.0.0"):
+    needs_fields = {"asil": {"nullable": True}, "uses_secure": {"nullable": True}, "more_info": {"nullable": True}}
+else:
+    needs_extra_options = ["asil", "uses_secure", "more_info"]
 tr_extra_options = ["more_info"]
 
 # General information about the project.

--- a/tests/doc_test/json_parser_custom/conf.py
+++ b/tests/doc_test/json_parser_custom/conf.py
@@ -32,7 +32,13 @@ sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
 
-needs_extra_options = ["priority"]
+import sphinx_needs as _sn
+from packaging.version import Version as _V
+
+if _V(_sn.__version__) >= _V("8.0.0"):
+    needs_fields = {"priority": {"nullable": True}}
+else:
+    needs_extra_options = ["priority"]
 tr_extra_options = ["priority"]
 
 tr_json_mapping = {

--- a/tests/doc_test/json_parser_custom/conf.py
+++ b/tests/doc_test/json_parser_custom/conf.py
@@ -18,6 +18,9 @@
 import os
 import sys
 
+import sphinx_needs
+from packaging.version import Version
+
 sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 # -- General configuration ------------------------------------------------
@@ -32,10 +35,7 @@ sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
 
-import sphinx_needs as _sn
-from packaging.version import Version as _V
-
-if _V(_sn.__version__) >= _V("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("8.0.0"):
     needs_fields = {"priority": {"nullable": True}}
 else:
     needs_extra_options = ["priority"]

--- a/tests/doc_test/many_testsuites_doc/conf.py
+++ b/tests/doc_test/many_testsuites_doc/conf.py
@@ -37,7 +37,13 @@ tr_case_id_length = 10
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-needs_extra_options = ["more_info"]
+import sphinx_needs as _sn
+from packaging.version import Version as _V
+
+if _V(_sn.__version__) >= _V("8.0.0"):
+    needs_fields = {"more_info": {"nullable": True}}
+else:
+    needs_extra_options = ["more_info"]
 tr_extra_options = ["more_info"]
 
 # The suffix(es) of source filenames.

--- a/tests/doc_test/many_testsuites_doc/conf.py
+++ b/tests/doc_test/many_testsuites_doc/conf.py
@@ -18,6 +18,9 @@
 import os
 import sys
 
+import sphinx_needs
+from packaging.version import Version
+
 sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 # -- General configuration ------------------------------------------------
@@ -37,10 +40,7 @@ tr_case_id_length = 10
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-import sphinx_needs as _sn
-from packaging.version import Version as _V
-
-if _V(_sn.__version__) >= _V("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("8.0.0"):
     needs_fields = {"more_info": {"nullable": True}}
 else:
     needs_extra_options = ["more_info"]

--- a/tests/doc_test/needs_linking/conf.py
+++ b/tests/doc_test/needs_linking/conf.py
@@ -75,7 +75,13 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-needs_extra_options = ["asil", "uses_secure", "references"]
+import sphinx_needs as _sn
+from packaging.version import Version as _V
+
+if _V(_sn.__version__) >= _V("8.0.0"):
+    needs_fields = {"asil": {"nullable": True}, "uses_secure": {"nullable": True}, "references": {"nullable": True}}
+else:
+    needs_extra_options = ["asil", "uses_secure", "references"]
 
 # General information about the project.
 project = "test-report test docs"

--- a/tests/doc_test/needs_linking/conf.py
+++ b/tests/doc_test/needs_linking/conf.py
@@ -18,6 +18,9 @@
 import os
 import sys
 
+import sphinx_needs
+from packaging.version import Version
+
 sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 # -- General configuration ------------------------------------------------
@@ -75,11 +78,12 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-import sphinx_needs as _sn
-from packaging.version import Version as _V
-
-if _V(_sn.__version__) >= _V("8.0.0"):
-    needs_fields = {"asil": {"nullable": True}, "uses_secure": {"nullable": True}, "references": {"nullable": True}}
+if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+    needs_fields = {
+        "asil": {"nullable": True},
+        "uses_secure": {"nullable": True},
+        "references": {"nullable": True},
+    }
 else:
     needs_extra_options = ["asil", "uses_secure", "references"]
 

--- a/tests/doc_test/testsuites_doc/conf.py
+++ b/tests/doc_test/testsuites_doc/conf.py
@@ -34,7 +34,13 @@ extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-needs_extra_options = ["more_info"]
+import sphinx_needs as _sn
+from packaging.version import Version as _V
+
+if _V(_sn.__version__) >= _V("8.0.0"):
+    needs_fields = {"more_info": {"nullable": True}}
+else:
+    needs_extra_options = ["more_info"]
 tr_extra_options = ["more_info"]
 
 # The suffix(es) of source filenames.

--- a/tests/doc_test/testsuites_doc/conf.py
+++ b/tests/doc_test/testsuites_doc/conf.py
@@ -18,6 +18,9 @@
 import os
 import sys
 
+import sphinx_needs
+from packaging.version import Version
+
 sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 # -- General configuration ------------------------------------------------
@@ -34,10 +37,7 @@ extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-import sphinx_needs as _sn
-from packaging.version import Version as _V
-
-if _V(_sn.__version__) >= _V("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("8.0.0"):
     needs_fields = {"more_info": {"nullable": True}}
 else:
     needs_extra_options = ["more_info"]

--- a/tests/test_test_file.py
+++ b/tests/test_test_file.py
@@ -36,5 +36,26 @@ def test_test_file_needs_extra_options_no_warning(test_app):
 
     assert out.returncode == 0
 
-    # Check no warnings
+    # Check no warnings — Sphinx writes warnings to stderr, not stdout
     assert "WARNING" not in out.stdout.decode("utf-8")
+    assert "WARNING" not in out.stderr.decode("utf-8")
+    assert "ERROR" not in out.stderr.decode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [{"buildername": "html", "srcdir": "doc_test/doc_test_file"}],
+    indirect=True,
+)
+def test_test_file_renders_need_with_counts(test_app):
+    """test-file directive must render a need node with correct count fields.
+
+    Catches regressions where int values (suites, cases, passed, etc.) passed
+    to add_need() are rejected by newer sphinx-needs versions.
+    """
+    app = test_app
+    app.build()
+    assert app.statuscode == 0
+
+    html = Path(app.outdir, "index.html").read_text()
+    assert "TESTFILE_1" in html

--- a/tests/test_test_file.py
+++ b/tests/test_test_file.py
@@ -59,3 +59,20 @@ def test_test_file_renders_need_with_counts(test_app):
 
     html = Path(app.outdir, "index.html").read_text()
     assert "TESTFILE_1" in html
+    
+    # Test 1: Verify HTML contains the need with expected structure
+    from bs4 import BeautifulSoup
+    soup = BeautifulSoup(html, 'html.parser')
+    need = soup.find(class_='need', attrs={'data-need-id': 'TESTFILE_1'})
+    assert need is not None
+    
+    # Test 2: Verify data attributes for integer fields exist
+    required_fields = ['suites', 'cases', 'passed', 'skipped', 'failed', 'errors']
+    for field in required_fields:
+        assert f'data-{field}' in need.attrs, f"Missing data-{field} attribute"
+        value = need[f'data-{field}']
+        assert value.isdigit(), f"data-{field} should be numeric, got: {value}"
+    
+    # Test 3: Optional - Verify actual values are reasonable
+    assert int(need['data-suites']) >= 0  # Should be non-negative
+    assert int(need['data-cases']) >= 0   # Should be non-negative

--- a/tests/test_test_file.py
+++ b/tests/test_test_file.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from bs4 import BeautifulSoup
 
 
 @pytest.mark.parametrize(
@@ -37,9 +38,15 @@ def test_test_file_needs_extra_options_no_warning(test_app):
     assert out.returncode == 0
 
     # Check no warnings — Sphinx writes warnings to stderr, not stdout
-    assert "WARNING" not in out.stdout.decode("utf-8")
-    assert "WARNING" not in out.stderr.decode("utf-8")
-    assert "ERROR" not in out.stderr.decode("utf-8")
+    stderr = out.stderr.decode("utf-8")
+    stdout = out.stdout.decode("utf-8")
+
+    # stdout should not contain warnings (Sphinx doesn't write them there)
+    assert "WARNING" not in stdout, f"Found warnings in stdout (unexpected): {stdout}"
+
+    # stderr should not contain warnings or errors
+    assert "WARNING" not in stderr, f"Found warnings in stderr: {stderr}"
+    assert "ERROR" not in stderr, f"Found errors in stderr: {stderr}"
 
 
 @pytest.mark.parametrize(
@@ -59,20 +66,23 @@ def test_test_file_renders_need_with_counts(test_app):
 
     html = Path(app.outdir, "index.html").read_text()
     assert "TESTFILE_1" in html
-    
-    # Test 1: Verify HTML contains the need with expected structure
-    from bs4 import BeautifulSoup
-    soup = BeautifulSoup(html, 'html.parser')
-    need = soup.find(class_='need', attrs={'data-need-id': 'TESTFILE_1'})
-    assert need is not None
-    
-    # Test 2: Verify data attributes for integer fields exist
-    required_fields = ['suites', 'cases', 'passed', 'skipped', 'failed', 'errors']
+
+    # Verify HTML contains the need table and integer count fields were rendered
+    # sphinx-needs renders needs as <table id="NEED_ID"> with field values in
+    # <span class="needs_<field>"> elements.
+    soup = BeautifulSoup(html, "html.parser")
+    need_table = soup.find("table", id="TESTFILE_1")
+    assert need_table is not None, "Need table with id='TESTFILE_1' not found in HTML"
+
+    # Verify integer count fields are present and contain numeric values
+    required_fields = ["suites", "cases", "passed", "skipped", "failed", "errors"]
     for field in required_fields:
-        assert f'data-{field}' in need.attrs, f"Missing data-{field} attribute"
-        value = need[f'data-{field}']
-        assert value.isdigit(), f"data-{field} should be numeric, got: {value}"
-    
-    # Test 3: Optional - Verify actual values are reasonable
-    assert int(need['data-suites']) >= 0  # Should be non-negative
-    assert int(need['data-cases']) >= 0   # Should be non-negative
+        span = need_table.find(class_=f"needs_{field}")
+        assert span is not None, f"Missing <span class='needs_{field}'> in need table"
+        value = span.get_text(strip=True).replace(f"{field}:", "").strip()
+        try:
+            int(value)
+        except ValueError:
+            raise AssertionError(
+                f"needs_{field} value should be numeric, got: {value!r}"
+            ) from None


### PR DESCRIPTION
## Summary

- Replace deprecated `add_extra_option()` with `add_field()` for sphinx-needs >= 8.0.0, using a version-gated shim that falls back to `add_extra_option()` for older versions
- Add sphinx-needs `8.0.0` to the CI matrix and nox test matrix
- Fix warning checks in tests to inspect `stderr` (where Sphinx actually writes warnings, not `stdout`)
- Add `test_test_file_renders_need_with_counts` to catch regressions where int kwargs to `add_need()` are rejected

## Test plan

- [ ] Run `nox -s "tests-3.12(sphinx='8.1.3', sphinx_needs='8.0.0')"` and verify all tests pass
- [ ] Run against an older sphinx-needs version (e.g. `6.3.0`) to confirm backwards compatibility

## Reason:
Upgrading another sphinx-needs project showed errors:

"sphinx-test-reports passes integer field values (e.g. suites=1) which sphinx-needs 8.0 rejects with InvalidNeedException. "