### PR TITLE
Handle JUnit <error> result state in parse_testcase()

### DIFF
--- a/sphinxcontrib/test_reports/css/common.css
+++ b/sphinxcontrib/test_reports/css/common.css
@@ -10,6 +10,10 @@ tr.tr_skipped{
     background-color: rgba(0,0,0,0.1) !important;
 }
 
+tr.tr_error, div.tr_error {
+    background-color: rgba(255,165,0,0.2) !important;
+}
+
 td.status p {
     padding: 3px 5px;
     text-align: center;
@@ -29,4 +33,9 @@ td.status p.tr_failure{
 td.status p.tr_skipped{
     border: 1px solid #555;
     color: #555;
+}
+
+td.status p.tr_error{
+    border: 1px solid #cc6600;
+    color: #cc6600;
 }

--- a/sphinxcontrib/test_reports/junitparser.py
+++ b/sphinxcontrib/test_reports/junitparser.py
@@ -70,8 +70,14 @@ class JUnitParser:
                 tc_dict["result"] = "failure"
                 tc_dict["type"] = result.attrib.get("type", "unknown")
                 # tc_dict["text"] = re.sub(r"[\n\t]*", "", result.text)  # Removes newlines and tabs
-                tc_dict["text"] = result.text
-                tc_dict["message"] = ""
+                tc_dict["text"] = result.text or ""
+                tc_dict["message"] = result.attrib.get("message", "")
+            elif hasattr(testcase, "error"):
+                result = testcase.error
+                tc_dict["result"] = "error"
+                tc_dict["type"] = result.attrib.get("type", "unknown")
+                tc_dict["text"] = result.text or ""
+                tc_dict["message"] = result.attrib.get("message", "unknown")
             else:
                 tc_dict["result"] = "passed"
                 tc_dict["type"] = ""

--- a/tests/doc_test/utils/xml_data_error.xml
+++ b/tests/doc_test/utils/xml_data_error.xml
@@ -1,0 +1,12 @@
+<testsuite name="error_suite" tests="4" errors="1" failures="1" skips="0">
+    <testcase classname="foo1" name="ASuccessfulTest" time="0.001"/>
+    <testcase classname="foo2" name="AFailingTest" time="0.002">
+        <failure type="AssertionError" message="expected true">some failure details</failure>
+    </testcase>
+    <testcase classname="foo3" name="AnErrorTest" time="0.003">
+        <error type="RuntimeError" message="unexpected crash">stack trace here</error>
+    </testcase>
+    <testcase classname="foo4" name="ASkippedTest" time="0.000">
+        <skipped type="skip" message="not applicable"/>
+    </testcase>
+</testsuite>

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -16,6 +16,9 @@ xml_nose_path = os.path.join(
 )
 
 xml_ctest_path = os.path.join(os.path.dirname(__file__), "doc_test/utils", "ctest.xml")
+xml_error_path = os.path.join(
+    os.path.dirname(__file__), "doc_test/utils", "xml_data_error.xml"
+)
 
 
 def test_init_parser():
@@ -148,3 +151,33 @@ def test_parse_ctest_xml():
     assert test_suite["testcases"][3]["result"] == "failure"
     assert test_suite["testcases"][4]["name"] == "skipped_test"
     assert test_suite["testcases"][4]["result"] == "skipped"
+
+
+def test_parse_error_xml():
+    from sphinxcontrib.test_reports.junitparser import JUnitParser
+
+    parser = JUnitParser(xml_error_path)
+    test_suites = parser.parse()
+
+    assert len(test_suites) == 1
+    test_suite = test_suites[0]
+
+    assert test_suite["name"] == "error_suite"
+    assert test_suite["tests"] == 4
+    assert test_suite["errors"] == 1
+    assert test_suite["failures"] == 1
+
+    assert test_suite["testcases"][0]["name"] == "ASuccessfulTest"
+    assert test_suite["testcases"][0]["result"] == "passed"
+
+    assert test_suite["testcases"][1]["name"] == "AFailingTest"
+    assert test_suite["testcases"][1]["result"] == "failure"
+
+    assert test_suite["testcases"][2]["name"] == "AnErrorTest"
+    assert test_suite["testcases"][2]["result"] == "error"
+    assert test_suite["testcases"][2]["type"] == "RuntimeError"
+    assert test_suite["testcases"][2]["message"] == "unexpected crash"
+    assert test_suite["testcases"][2]["text"] == "stack trace here"
+
+    assert test_suite["testcases"][3]["name"] == "ASkippedTest"
+    assert test_suite["testcases"][3]["result"] == "skipped"


### PR DESCRIPTION
## Summary

Fixes #132

- `parse_testcase()` now explicitly handles the JUnit `<error>` element, which represents unexpected exceptions or infrastructure crashes
- Previously, `<error>` test cases were silently classified as `"passed"` (false-positive verdict)
- Adds CSS styling for the `tr_error` result type (orange, distinct from failure red and skip gray)
- Also guards against `None` text in `<failure>` elements (consistency with the `<skipped>` branch)

## Changes

- **`sphinxcontrib/test_reports/junitparser.py`** — Add `elif hasattr(testcase, "error")` branch before the `else` clause
- **`sphinxcontrib/test_reports/css/common.css`** — Add `tr_error` row and status badge styles
- **`tests/doc_test/utils/xml_data_error.xml`** — New test fixture with all four result states
- **`tests/test_junit_parser.py`** — New `test_parse_error_xml()` covering error parsing

## Test plan

- [x] New `test_parse_error_xml` verifies error result, type, message, and text extraction
- [x] All 31 existing tests continue to pass
- [x] No changes to rendering logic needed — existing `"tr_" + result` pattern handles the new state automatically