### PR TITLE
test: strict schema must ignore unpopulated sphinx-test-reports fields

### DIFF
--- a/tests/doc_test/schema_strictness/conf.py
+++ b/tests/doc_test/schema_strictness/conf.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
+
+# -- General configuration ------------------------------------------------
+
+extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
+
+source_suffix = ".rst"
+master_doc = "index"
+
+project = "test-report schema strictness"
+copyright = "2024, team useblocks"
+author = "team useblocks"
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# Load a strict sphinx-needs schema that forbids any field beyond the core
+# id/title/type (see schemas.json). sphinx-test-reports registers a lot of
+# extra fields (file, suite, passed, ...) via the sphinx-needs field API; this
+# project deliberately leaves them unpopulated to make sure they are not
+# wrongly reported as "additional" fields.
+needs_schema_definitions_from_json = "schemas.json"
+
+# -- Options for HTML output ----------------------------------------------
+
+html_theme = "alabaster"

--- a/tests/doc_test/schema_strictness/index.rst
+++ b/tests/doc_test/schema_strictness/index.rst
@@ -1,0 +1,15 @@
+Strict schema with unpopulated sphinx-test-reports fields
+=========================================================
+
+The needs below are plain requirements. They leave every field that
+sphinx-test-reports registers with sphinx-needs (``file``, ``suite``,
+``case``, ``passed``, ``failed``, ``errors`` ...) unpopulated.
+
+A schema that forbids additional fields (``unevaluatedProperties: false``)
+must therefore *not* report any violation for them.
+
+.. req:: A plain requirement
+   :id: REQ_1
+
+.. req:: Another plain requirement
+   :id: REQ_2

--- a/tests/doc_test/schema_strictness/schemas.json
+++ b/tests/doc_test/schema_strictness/schemas.json
@@ -1,0 +1,13 @@
+{
+  "schemas": [
+    {
+      "id": "no-additional-fields",
+      "severity": "violation",
+      "validate": {
+        "local": {
+          "unevaluatedProperties": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/doc_test/schema_strictness_status/conf.py
+++ b/tests/doc_test/schema_strictness_status/conf.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
+
+# -- General configuration ------------------------------------------------
+
+extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
+
+source_suffix = ".rst"
+master_doc = "index"
+
+project = "test-report schema strictness (status)"
+copyright = "2024, team useblocks"
+author = "team useblocks"
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# Load a strict sphinx-needs schema. Unlike the sibling ``schema_strictness``
+# fixture, this one *evaluates* a field in the local schema: ``status`` is
+# constrained to a fixed value (see schemas.json). The sphinx-test-reports
+# fields are still left unpopulated to confirm they remain ignored.
+needs_schema_definitions_from_json = "schemas.json"
+
+# -- Options for HTML output ----------------------------------------------
+
+html_theme = "alabaster"

--- a/tests/doc_test/schema_strictness_status/index.rst
+++ b/tests/doc_test/schema_strictness_status/index.rst
@@ -1,0 +1,14 @@
+Strict schema with a constrained field in the local schema
+==========================================================
+
+The need below sets ``status`` to the value the schema constrains it to
+(``open``), while leaving every sphinx-test-reports field unpopulated.
+
+A schema that evaluates ``status`` (``const: open``) and forbids any other
+field (``unevaluatedProperties: false``) must accept this need: the constrained
+field is set correctly and the unpopulated sphinx-test-reports fields are
+ignored.
+
+.. req:: A requirement with a constrained status
+   :id: REQ_STATUS_1
+   :status: open

--- a/tests/doc_test/schema_strictness_status/schemas.json
+++ b/tests/doc_test/schema_strictness_status/schemas.json
@@ -1,0 +1,19 @@
+{
+  "schemas": [
+    {
+      "id": "status-constrained",
+      "severity": "violation",
+      "validate": {
+        "local": {
+          "properties": {
+            "status": {
+              "const": "open"
+            }
+          },
+          "required": ["status"],
+          "unevaluatedProperties": false
+        }
+      }
+    }
+  ]
+}

--- a/tests/doc_test/schema_strictness_status/schemas.json
+++ b/tests/doc_test/schema_strictness_status/schemas.json
@@ -10,7 +10,9 @@
               "const": "open"
             }
           },
-          "required": ["status"],
+          "required": [
+            "status"
+          ],
           "unevaluatedProperties": false
         }
       }

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -58,3 +58,44 @@ def test_strict_schema_ignores_unpopulated_test_report_fields(test_app):
         "Strict schema flagged unpopulated sphinx-test-reports fields: "
         f"{json.dumps(report['validation_warnings'], indent=2)}"
     )
+
+
+@pytest.mark.skipif(
+    not SN_SUPPORTS_SCHEMAS,
+    reason="needs_schema_definitions requires sphinx-needs>=6.0.0",
+)
+@pytest.mark.parametrize(
+    "test_app",
+    [{"buildername": "html", "srcdir": "doc_test/schema_strictness_status"}],
+    indirect=True,
+)
+def test_strict_schema_allows_constrained_field_in_local_schema(test_app):
+    """Counterpart to the test above: a field that *is* part of the local schema
+    validates correctly while the unpopulated sphinx-test-reports fields stay
+    ignored.
+
+    The schema evaluates the core ``status`` field (``const: open``, and marks
+    it ``required``) and forbids every other field
+    (``unevaluatedProperties: false``). The single need sets ``status: open``
+    and leaves all sphinx-test-reports fields unpopulated, so the build must
+    report no violation.
+    """
+    app = test_app
+    app.build()
+
+    assert app.statuscode == 0
+
+    report_file = Path(app.outdir, "schema_violations.json")
+    assert report_file.exists(), "sphinx-needs did not write schema_violations.json"
+
+    report = json.loads(report_file.read_text(encoding="utf-8"))
+
+    # The need was validated ...
+    assert report.get("validated_needs_count", 0) >= 1
+
+    # ... and the constrained-and-populated 'status' field plus the stripped
+    # (unpopulated) sphinx-test-reports fields together produce no violation.
+    assert report["validation_warnings"] == {}, (
+        "Strict schema with a constrained 'status' field reported violations: "
+        f"{json.dumps(report['validation_warnings'], indent=2)}"
+    )

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,60 @@
+"""Regression test for sphinx-needs schema validation of sphinx-test-reports fields.
+
+sphinx-test-reports registers a number of extra fields (``file``, ``suite``,
+``case``, ``passed``, ``failed``, ``errors`` ...) with sphinx-needs via its
+field API. These fields are attached to *every* need in the project.
+
+When a user defines a strict sphinx-needs schema -- one that forbids any field
+beyond the core ``id`` / ``title`` / ``type`` (``unevaluatedProperties: false``)
+-- those registered fields must not be treated as "additional" fields for needs
+that never populate them. In other words, the fields have to default to an
+unset/None value so they are stripped before schema validation.
+
+This test builds a project with both extensions enabled and a strict schema,
+and asserts that plain needs which leave the sphinx-test-reports fields
+unpopulated produce no schema violation.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import sphinx_needs
+from packaging.version import Version
+
+# The needs_schema_definitions / schema-validation feature was introduced in
+# sphinx-needs 6.0.0; skip on older versions that do not support it.
+SN_SUPPORTS_SCHEMAS = Version(sphinx_needs.__version__) >= Version("6.0.0")
+
+
+@pytest.mark.skipif(
+    not SN_SUPPORTS_SCHEMAS,
+    reason="needs_schema_definitions requires sphinx-needs>=6.0.0",
+)
+@pytest.mark.parametrize(
+    "test_app",
+    [{"buildername": "html", "srcdir": "doc_test/schema_strictness"}],
+    indirect=True,
+)
+def test_strict_schema_ignores_unpopulated_test_report_fields(test_app):
+    app = test_app
+    app.build()
+
+    assert app.statuscode == 0
+
+    report_file = Path(app.outdir, "schema_violations.json")
+    assert report_file.exists(), "sphinx-needs did not write schema_violations.json"
+
+    report = json.loads(report_file.read_text(encoding="utf-8"))
+
+    # Schema validation actually ran over our two needs ...
+    assert report.get("validated_needs_count", 0) >= 2
+
+    # ... and produced no violations. If sphinx-test-reports registered its
+    # fields with non-null defaults, REQ_1/REQ_2 would carry empty values for
+    # file/suite/passed/... and the strict schema would (wrongly) report
+    # "unevaluated properties are not allowed".
+    assert report["validation_warnings"] == {}, (
+        "Strict schema flagged unpopulated sphinx-test-reports fields: "
+        f"{json.dumps(report['validation_warnings'], indent=2)}"
+    )


### PR DESCRIPTION
## What

TDD regression test (no production code change) for the interaction between
**sphinx-test-reports (STR)** and **sphinx-needs (SN)** schema validation.

STR registers many extra fields with SN via the field API — `file`, `suite`,
`case`, `case_name`, `case_parameter`, `classname`, `time`, `suites`, `cases`,
`passed`, `skipped`, `failed`, `errors`, `result`. These are attached to **every**
need in a project.

This test builds a project with both extensions enabled and a strict schema
(`schemas.json` with `unevaluatedProperties: false`, i.e. *no field beyond the
core id/title/type is allowed*), defines plain `req` needs that leave all STR
fields unpopulated, and asserts that **no schema violation** is reported
(SN's `schema_violations.json` has empty `validation_warnings`).

## Why

A strict need-type schema can wrongly "fail" for needs that don't populate STR's
registered fields. If STR's fields are attached with non-null defaults (e.g.
`""`/`0`), every plain need carries empty STR values and a strict schema reports
`Unevaluated properties are not allowed ('file', 'suite', ... were unexpected)`.

## The bug, and why this is a regression test

A sphinx-needs field registered **untyped** (legacy `add_extra_option` /
`needs_extra_options`, no schema) defaults to `""`, which is **not** stripped
before schema validation and therefore trips `unevaluatedProperties: false`. A
field registered **typed** (`add_field(..., schema=...)`) defaults to `None` and
is stripped.

Released STR **1.3.2** registers `file`, `suite`, `case`, `case_name`,
`case_parameter` and `classname` *untyped*, so a project using strict schema
validation gets false-positive `Unevaluated properties are not allowed (...)`
warnings for plain needs that never set those fields. STR `master` registers
every field with a typed schema (#133) → they default to `None` → stripped → no
warning. **This test locks that behavior in** and goes red if any field regresses
to a non-null default. The fix ships in 1.4.0 (1.3.2 is still affected).

## Verification

- **passes** on SN 6.0.0 / 6.3.0 / 8.0.0 / 8.1.1; **skips** on SN < 6.0.0
  (predates `needs_schema_definitions`).
- Confirmed meaningful: temporarily making STR register its string fields with a
  `""` default made the test go **red** with exactly the expected
  `unevaluatedProperties` violation for both needs, then reverted.
- Heads-up for users: the literal JSON-Schema keyword
  **`additionalProperties: false` is *not* accepted** by SN's schema config (it is
  rejected at config-validation time). SN's supported way to forbid extra fields
  is **`unevaluatedProperties: false`**, which is what this test uses.
- Full STR test suite green locally.

## Second, independent test

`test_strict_schema_allows_constrained_field_in_local_schema` (fixture
`schema_strictness_status/`): the core `status` field is constrained in the local
schema (`const: "open"`, `required`) and set on the need, proving strict
validation also works when a field *is* evaluated by the schema. Verified red when
`status` diverges from the constrained value.
