### PR TITLE
🚀 Release v1.4.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,45 @@ Unreleased
 ----------
 :Released: under development
 
+.. _`release:1.4.0`:
+
+1.4.0
+-----
+:Released: 16.06.2026
+
+This release adds Sphinx-Needs 8 support and the ability to map JUnit XML
+``<properties>`` onto Sphinx-Needs fields and links. It also registers every
+field that Sphinx-Test-Reports adds with a typed schema, so unset fields no
+longer trigger false-positive ``unevaluatedProperties: false`` schema-validation
+warnings, and it fixes JUnit ``<error>`` test cases being reported as passed.
+
+* Feature: Map JUnit XML ``<properties>`` to Sphinx-Needs fields and links via
+  the new ``tr_property_link_types`` and ``tr_extra_options`` options.
+  `#135 <https://github.com/useblocks/sphinx-test-reports/pull/135>`_
+* Improvement: Support Sphinx-Needs 8 by registering fields through the new
+  ``add_field`` API, falling back to ``add_extra_option`` on older versions.
+  `#133 <https://github.com/useblocks/sphinx-test-reports/pull/133>`_
+* Bugfix: Register ``file``, ``suite``, ``case``, ``case_name``,
+  ``case_parameter`` and ``classname`` with a typed (string) schema so they
+  default to an unset/``None`` value and are stripped before schema validation.
+  Previously they were registered untyped and defaulted to ``""``, which caused
+  false-positive ``Unevaluated properties are not allowed`` warnings on needs
+  that did not set them when a schema used ``unevaluatedProperties: false``.
+  `#133 <https://github.com/useblocks/sphinx-test-reports/pull/133>`_
+* Bugfix: Handle the JUnit ``<error>`` result state in ``parse_testcase()``;
+  ``<error>`` test cases were previously misclassified as ``passed``.
+  `#134 <https://github.com/useblocks/sphinx-test-reports/pull/134>`_
+* Testing: Run the test suite against Sphinx-Needs 6.3.0.
+  `#130 <https://github.com/useblocks/sphinx-test-reports/pull/130>`_
+* Testing: Add a regression test that a strict schema ignores unpopulated
+  Sphinx-Test-Reports fields.
+  `#137 <https://github.com/useblocks/sphinx-test-reports/pull/137>`_
+* Docs: Clarify the Sphinx-Needs type names (``testfile``, ``testsuite``,
+  ``testcase``) versus the hyphenated directives.
+  `#136 <https://github.com/useblocks/sphinx-test-reports/pull/136>`_
+* Docs: Note that numeric ``cases`` filtering requires Sphinx-Needs >= 6.
+  `#139 <https://github.com/useblocks/sphinx-test-reports/pull/139>`_
+
 .. _`release:1.3.2`:
 
 1.3.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,9 +32,9 @@ copyright = f"team useblocks, 2017-{now.year}"
 author = "team useblocks"
 
 # The short X.Y version
-version = "1.3"
+version = "1.4"
 # The full version, including alpha/beta/rc tags
-release = "1.3.2"
+release = "1.4.0"
 
 needs_id_regex = ".*"
 needs_css = "dark.css"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sphinx-test-reports"
-version = "1.3.2"
+version = "1.4.0"
 description = "Sphinx extension for showing test results and test environment information inside sphinx documentations"
 readme = "README.rst"
 license = { text = "MIT" }

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -38,7 +38,7 @@ else:
 
 # fmt: on
 
-VERSION = "1.3.2"
+VERSION = "1.4.0"
 
 # Field descriptions for better semantics
 FIELD_DESCRIPTIONS = {


### PR DESCRIPTION
## Release v1.4.0

Bumps the version (`pyproject.toml`, `docs/conf.py`, `test_reports.py`) and adds
the 1.4.0 changelog for everything merged since 1.3.2.

**Highlights**
- Feature (#135): map JUnit XML `<properties>` to Sphinx-Needs fields/links.
- Sphinx-Needs 8 support (#133): fields registered via the new `add_field` API.
- Bugfix (#133): `file`, `suite`, `case`, `case_name`, `case_parameter` and
  `classname` are now registered with a typed schema → default to `None` →
  stripped before schema validation, fixing false-positive
  `Unevaluated properties are not allowed` warnings under
  `unevaluatedProperties: false`. Released 1.3.2 registered them untyped
  (default `""`), which leaked.
- Bugfix (#134): JUnit `<error>` test cases were misclassified as `passed`; now
  handled correctly in `parse_testcase()`.
- Testing (#130, #137): run against Sphinx-Needs 6.3.0; regression test that a
  strict schema ignores unpopulated Sphinx-Test-Reports fields.
- Docs (#136, #139): clarify Sphinx-Needs type names vs. the hyphenated
  directives; note that numeric `cases` filtering requires Sphinx-Needs >= 6.

