### PR TITLE
docs: tidy the Sphinx-Needs ecosystem cards (fixes flaky linkcheck)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,37 +92,22 @@ In the last years, we have created additional information and extensions, which 
 
     .. grid-item-card::
         :columns: 12 6 6 6
-        :link: https://sphinx-needs.readthedocs.io/en/latest/
-        :img-top: /_static/sphinx-needs-card.png
-        :class-card: border
-
-        Sphinx-Needs.com
-        ^^^^^^^^^^^^^^^^
-        The website presents the essential Sphinx-Needs functions and related extensions.
-
-        Also, it is a good entry point to understand the benefits and get an idea about the complete ecosystem of Sphinx-Needs.
-        +++
-
-        .. button-link:: https://sphinx-needs.readthedocs.io/en/latest/
-            :color: primary
-            :outline:
-            :align: center
-            :expand:
-
-            :octicon:`globe;1em;sd-text-primary` Sphinx-Needs.com
-
-    .. grid-item-card::
-        :columns: 12 6 6 6
-        :link: https://sphinx-needs.readthedocs.io/en/latest/
         :img-top: /_static/sphinx-needs-card.png
         :class-card: border
 
         Sphinx-Needs
         ^^^^^^^^^^^^
-        Create, update, link, filter and present need objects like Requirements, Specifications, Bugs and many more.
-
-        The base extension provides all of its functionality under the MIT license for free.
+        Create, update, link, filter and present need objects like Requirements,
+        Specifications, Bugs and many more — the free, MIT-licensed base extension.
         +++
+
+        .. button-link:: https://useblocks.com/open-source/sphinx-needs
+            :color: primary
+            :outline:
+            :align: center
+            :expand:
+
+            :octicon:`globe;1em;sd-text-primary` Website @ useblocks.com
 
         .. button-link:: https://sphinx-needs.readthedocs.io/en/latest/
             :color: primary

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,8 +92,11 @@ In the last years, we have created additional information and extensions, which 
 
     .. grid-item-card::
         :columns: 12 6 6 6
-        :img-top: /_static/sphinx-needs-card.png
         :class-card: border
+
+        .. image:: /_static/sphinx-needs-card.png
+            :height: 120px
+            :align: center
 
         Sphinx-Needs
         ^^^^^^^^^^^^
@@ -120,8 +123,11 @@ In the last years, we have created additional information and extensions, which 
     .. grid-item-card::
         :columns: 12 6 6 6
         :link: https://sphinx-test-reports.readthedocs.io/en/latest/
-        :img-top: /_static/sphinx-test-reports-logo.png
         :class-card: border
+
+        .. image:: /_static/sphinx-test-reports-logo.png
+            :height: 120px
+            :align: center
 
         Sphinx-Test-Reports
         ^^^^^^^^^^^^^^^^^^^
@@ -150,8 +156,11 @@ we have created other Sphinx extensions to support the work of teams in the auto
     .. grid-item-card::
         :columns: 12 6 6 6
         :link: https://sphinx-collections.readthedocs.io/en/latest/
-        :img-top: /_static/sphinx_collections_logo.png
         :class-card: border
+
+        .. image:: /_static/sphinx_collections_logo.png
+            :height: 120px
+            :align: center
 
         Sphinx Collections
         ^^^^^^^^^^^^^^^^^^
@@ -171,8 +180,11 @@ we have created other Sphinx extensions to support the work of teams in the auto
     .. grid-item-card::
         :columns: 12 6 6 6
         :link: https://sphinx-bazel.readthedocs.io/en/latest/
-        :img-top: /_static/sphinx_bazel_logo.png
         :class-card: border
+
+        .. image:: /_static/sphinx_bazel_logo.png
+            :height: 120px
+            :align: center
 
         Sphinx Bazel
         ^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,15 +83,15 @@ Content
    changelog
 
 
-Sphinx-Needs Ecosystem
-----------------------
-In the last years, we have created additional information and extensions, which are based on or related to Sphinx-Needs:
+Other Sphinx extensions
+-----------------------
+In the last years, we have created several Sphinx extensions based on or related to Sphinx-Needs, to support the work of teams in (for example) the automotive industry:
 
-.. grid:: 2
+.. grid:: 3
     :gutter: 2
 
     .. grid-item-card::
-        :columns: 12 6 6 6
+        :columns: 12 6 4 4
         :class-card: border
 
         .. image:: /_static/sphinx-needs-card.png
@@ -121,40 +121,7 @@ In the last years, we have created additional information and extensions, which 
             :octicon:`book;1em;sd-text-primary` Technical Docs
 
     .. grid-item-card::
-        :columns: 12 6 6 6
-        :link: https://sphinx-test-reports.readthedocs.io/en/latest/
-        :class-card: border
-
-        .. image:: /_static/sphinx-test-reports-logo.png
-            :height: 120px
-            :align: center
-
-        Sphinx-Test-Reports
-        ^^^^^^^^^^^^^^^^^^^
-        Extension to import test results from XML files as **need** objects.
-
-        Created **need** objects can be filtered and linked to specification objects.
-        +++
-
-        .. button-link:: https://sphinx-test-reports.readthedocs.io/en/latest/
-            :color: primary
-            :outline:
-            :align: center
-            :expand:
-
-            :octicon:`book;1em;sd-text-primary` Technical Docs
-
-
-Other Sphinx extensions
-~~~~~~~~~~~~~~~~~~~~~~~
-During the use of Sphinx-Needs in popular companies’ internal projects,
-we have created other Sphinx extensions to support the work of teams in the automotive industry:
-
-.. grid:: 2
-    :gutter: 2
-
-    .. grid-item-card::
-        :columns: 12 6 6 6
+        :columns: 12 6 4 4
         :link: https://sphinx-collections.readthedocs.io/en/latest/
         :class-card: border
 
@@ -178,7 +145,7 @@ we have created other Sphinx extensions to support the work of teams in the auto
             :octicon:`book;1em;sd-text-primary` Technical Docs
 
     .. grid-item-card::
-        :columns: 12 6 6 6
+        :columns: 12 6 4 4
         :link: https://sphinx-bazel.readthedocs.io/en/latest/
         :class-card: border
 


### PR DESCRIPTION
## Problem

`Docs-Linkcheck` has been flaky — it failed on ~28% of recent runs (22 of the last 80), in outage-shaped clusters unrelated to the PR under test.

Root cause: the landing page's ecosystem section linked to `https://sphinx-needs.com`, which has a partial **server-side TLS fault** — some edge nodes return a TLS `internal_error` alert during the handshake, so it resolves from ~70% of GitHub runners and fails from the rest. (Reproducible with both Python `ssl` and `openssl`, while `github.com` / `readthedocs.io` / `useblocks.com` all handshake fine.) Because linkcheck is a required gate, a single bad route blocked unrelated PRs.

#133 swapped that link to `sphinx-needs.readthedocs.io`, which stopped the flakiness but left the section cluttered: two near-identical Sphinx-Needs cards, a redundant Sphinx-Test-Reports card (linking to these very docs), and full-bleed images of wildly different sizes (the small 154×225 Sphinx-Test-Reports logo upscaled to a blurry full-card height).

## Change

Rework the landing-page ecosystem section in `docs/index.rst`:

- **Merge** the two Sphinx-Needs cards into one, with two buttons:
  - **Website @ useblocks.com** → `https://useblocks.com/open-source/sphinx-needs` — the working HTTPS redirect target of `sphinx-needs.com`
  - **Technical Docs** → `https://sphinx-needs.readthedocs.io/en/latest/`
- **Drop** the redundant Sphinx-Test-Reports card (it pointed at the documentation it was shown in).
- **Collapse** the "Sphinx-Needs Ecosystem" and "Other Sphinx extensions" sections into a single "Other Sphinx extensions" section listing the three related projects (Sphinx-Needs, Sphinx Collections, Sphinx Bazel) in one 3-up row.
- **Tidy the logos**: replace the full-bleed `:img-top:` images with centered, height-capped (120px) logos in the card body — crisp, equally sized, compact. Plain `.. image::`, no theme-specific CSS, so it survives a theme change.

## Verification

`https://useblocks.com/open-source/sphinx-needs` → **HTTP 200, 0 redirects, TLS 1.3** (the exact request linkcheck makes). No `sphinx-needs.com` references remain in the repo.

---

Out of scope for this PR: the underlying defect is the broken TLS edge node on the useblocks-owned `sphinx-needs.com` (it also affects real visitors), and linkcheck still gates merges on third-party availability — making the job non-blocking or scheduled would be the durable fix.
