### PR TITLE
feat: support the googletest XML dialect

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,13 @@ Unreleased
 ----------
 :Released: under development
 
+* Feature: Support the googletest XML dialect: ``status="notrun"`` is reported
+  as ``disabled`` instead of ``passed``, all ``<failure>``/``<skipped>`` parts
+  of a test case are kept instead of only the first, ``RecordProperty`` values
+  in attribute form are read (on ``<testcase>`` for googletest < 1.8.1 and on
+  ``<testsuite>`` for suite-level properties up to 1.15.x), and ``timestamp``,
+  ``value_param`` and ``type_param`` are parsed. ``<system-err>`` is captured.
+
 .. _`release:1.4.0`:
 
 1.4.0

--- a/sphinxcontrib/test_reports/config.py
+++ b/sphinxcontrib/test_reports/config.py
@@ -13,5 +13,10 @@ DEFAULT_OPTIONS = [
     "text",
     "message",
     "system-out",
+    "system-err",
+    "parts",
     "properties",
+    "timestamp",
+    "value_param",
+    "type_param",
 ]

--- a/sphinxcontrib/test_reports/junitparser.py
+++ b/sphinxcontrib/test_reports/junitparser.py
@@ -50,13 +50,15 @@ TESTSUITE_KNOWN_ATTRIBUTES = frozenset(
 RESULT_PART_KINDS = ("skipped", "failure", "error")
 
 
-def _child_tag(child):
+def _child_tag(child: objectify.ObjectifiedElement) -> str | None:
     """Tag name of an lxml child, or ``None`` for comments and instructions."""
     tag = child.tag
     return tag if isinstance(tag, str) else None
 
 
-def _collect_properties(xml_object, known_attributes):
+def _collect_properties(
+    xml_object: objectify.ObjectifiedElement, known_attributes: frozenset[str]
+) -> dict[str, str]:
     """Read ``RecordProperty`` values from both dialect forms.
 
     Unknown attributes are the legacy/attribute form; ``<properties>`` children
@@ -77,7 +79,9 @@ def _collect_properties(xml_object, known_attributes):
     return properties
 
 
-def _collect_result_parts(testcase):
+def _collect_result_parts(
+    testcase: objectify.ObjectifiedElement,
+) -> list[dict[str, str]]:
     """Every ``<failure>``/``<error>``/``<skipped>`` child, in document order.
 
     googletest emits one element per failed assertion and ``GTEST_SKIP`` can
@@ -85,7 +89,7 @@ def _collect_result_parts(testcase):
     The per-part ``type``/``message`` defaults match what the flat, historical
     ``type``/``message`` keys have always reported for that kind.
     """
-    parts = []
+    parts: list[dict[str, str]] = []
     for child in testcase.iterchildren():
         kind = _child_tag(child)
         if kind not in RESULT_PART_KINDS:
@@ -103,7 +107,7 @@ def _collect_result_parts(testcase):
     return parts
 
 
-def _collect_captured_output(xml_object, tag):
+def _collect_captured_output(xml_object: objectify.ObjectifiedElement, tag: str) -> str:
     """Join every ``<system-out>``/``<system-err>`` block of an element."""
     blocks = [
         child.text or ""
@@ -189,9 +193,10 @@ class JUnitParser:
                 tc_dict["text"] = first_part["text"]
                 tc_dict["message"] = first_part["message"]
             else:
+                # No result child at all, so the case either passed or never
+                # ran; failures, errors and skips are all handled above.
                 # googletest reports a disabled test as status="notrun"
-                # (result="suppressed") with no result child at all -- which
-                # otherwise reads as a pass.
+                # (result="suppressed"), which otherwise reads as a pass.
                 disabled = (
                     testcase.attrib.get("status") == "notrun"
                     or testcase.attrib.get("result") == "suppressed"

--- a/sphinxcontrib/test_reports/junitparser.py
+++ b/sphinxcontrib/test_reports/junitparser.py
@@ -6,6 +6,112 @@ import os
 
 from lxml import etree, objectify
 
+#: Attributes the JUnit/googletest dialects define themselves. Every *other*
+#: attribute is a ``RecordProperty`` value in attribute form: googletest wrote
+#: test-case properties as attributes before 1.8.1 (the form its official docs
+#: still show), and suite-level properties stayed attribute-only up to 1.15.x.
+TESTCASE_KNOWN_ATTRIBUTES = frozenset(
+    {
+        "assertions",
+        "classname",
+        "file",
+        "line",
+        "name",
+        "result",
+        "status",
+        "time",
+        "timestamp",
+        "type_param",
+        "value_param",
+    }
+)
+
+TESTSUITE_KNOWN_ATTRIBUTES = frozenset(
+    {
+        "disabled",
+        "errors",
+        "failures",
+        "hostname",
+        "id",
+        "name",
+        "package",
+        "random_seed",
+        "skip",
+        "skipped",
+        "skips",
+        "tests",
+        "time",
+        "timestamp",
+    }
+)
+
+#: ``<testcase>`` children carrying a result, in the precedence order used to
+#: classify a case that has more than one kind of them.
+RESULT_PART_KINDS = ("skipped", "failure", "error")
+
+
+def _child_tag(child):
+    """Tag name of an lxml child, or ``None`` for comments and instructions."""
+    tag = child.tag
+    return tag if isinstance(tag, str) else None
+
+
+def _collect_properties(xml_object, known_attributes):
+    """Read ``RecordProperty`` values from both dialect forms.
+
+    Unknown attributes are the legacy/attribute form; ``<properties>`` children
+    are the modern form and therefore win on conflict.
+    """
+    properties = {
+        name: value
+        for name, value in xml_object.attrib.items()
+        if name not in known_attributes
+    }
+
+    if hasattr(xml_object, "properties") and hasattr(xml_object.properties, "property"):
+        for prop in xml_object.properties.property:
+            name = prop.attrib.get("name", "")
+            if name:
+                properties[name] = prop.attrib.get("value", "")
+
+    return properties
+
+
+def _collect_result_parts(testcase):
+    """Every ``<failure>``/``<error>``/``<skipped>`` child, in document order.
+
+    googletest emits one element per failed assertion and ``GTEST_SKIP`` can
+    fire repeatedly, so reading only the first part silently drops evidence.
+    The per-part ``type``/``message`` defaults match what the flat, historical
+    ``type``/``message`` keys have always reported for that kind.
+    """
+    parts = []
+    for child in testcase.iterchildren():
+        kind = _child_tag(child)
+        if kind not in RESULT_PART_KINDS:
+            continue
+        parts.append(
+            {
+                "kind": kind,
+                "type": child.attrib.get("type", "unknown"),
+                "message": child.attrib.get(
+                    "message", "" if kind == "failure" else "unknown"
+                ),
+                "text": child.text or "",
+            }
+        )
+    return parts
+
+
+def _collect_captured_output(xml_object, tag):
+    """Join every ``<system-out>``/``<system-err>`` block of an element."""
+    blocks = [
+        child.text or ""
+        for child in xml_object.iterchildren()
+        if _child_tag(child) == tag
+    ]
+    return "\n".join(block for block in blocks if block)
+
 
 class JUnitParser:
     def __init__(self, junit_xml, junit_xsd=None):
@@ -53,53 +159,54 @@ class JUnitParser:
                 "line": int(testcase.attrib.get("line", -1)),
                 "name": testcase.attrib.get("name", "unknown"),
                 "time": float(testcase.attrib.get("time", -1)),
+                # googletest attributes; empty (never absent) so that consumers
+                # can emit every field unconditionally.
+                "timestamp": testcase.attrib.get("timestamp", ""),
+                "value_param": testcase.attrib.get("value_param", ""),
+                "type_param": testcase.attrib.get("type_param", ""),
             }
 
-            # The following data is normally a subnode (e.g. skipped/failure).
-            # We integrate it right into the testcase for better handling
-            if hasattr(testcase, "skipped"):
-                result = testcase.skipped
-                tc_dict["result"] = "skipped"
-                tc_dict["type"] = result.attrib.get("type", "unknown")
-                # tc_dict["text"] = re.sub(r"[\n\t]*", "", result.text)  # Removes newlines  and tabs
-                # result.text can be None for pytest xfail test cases
-                tc_dict["text"] = result.text or ""
-                tc_dict["message"] = result.attrib.get("message", "unknown")
-            elif hasattr(testcase, "failure"):
-                result = testcase.failure
-                tc_dict["result"] = "failure"
-                tc_dict["type"] = result.attrib.get("type", "unknown")
-                # tc_dict["text"] = re.sub(r"[\n\t]*", "", result.text)  # Removes newlines and tabs
-                tc_dict["text"] = result.text or ""
-                tc_dict["message"] = result.attrib.get("message", "")
-            elif hasattr(testcase, "error"):
-                result = testcase.error
-                tc_dict["result"] = "error"
-                tc_dict["type"] = result.attrib.get("type", "unknown")
-                tc_dict["text"] = result.text or ""
-                tc_dict["message"] = result.attrib.get("message", "unknown")
+            # The result data is normally a subnode (e.g. skipped/failure).
+            # We integrate it right into the testcase for better handling, and
+            # keep *every* part -- the flat type/text/message keys below stay on
+            # the first one for backwards compatibility.
+            parts = _collect_result_parts(testcase)
+            tc_dict["parts"] = parts
+
+            first_part = next(
+                (
+                    part
+                    for kind in RESULT_PART_KINDS
+                    for part in parts
+                    if part["kind"] == kind
+                ),
+                None,
+            )
+            if first_part is not None:
+                tc_dict["result"] = first_part["kind"]
+                tc_dict["type"] = first_part["type"]
+                # part text can be None for pytest xfail test cases
+                tc_dict["text"] = first_part["text"]
+                tc_dict["message"] = first_part["message"]
             else:
-                tc_dict["result"] = "passed"
+                # googletest reports a disabled test as status="notrun"
+                # (result="suppressed") with no result child at all -- which
+                # otherwise reads as a pass.
+                disabled = (
+                    testcase.attrib.get("status") == "notrun"
+                    or testcase.attrib.get("result") == "suppressed"
+                )
+                tc_dict["result"] = "disabled" if disabled else "passed"
                 tc_dict["type"] = ""
                 tc_dict["text"] = ""
                 tc_dict["message"] = ""
 
-            if hasattr(testcase, "system-out"):
-                tc_dict["system-out"] = testcase["system-out"].text
-            else:
-                tc_dict["system-out"] = ""
+            tc_dict["system-out"] = _collect_captured_output(testcase, "system-out")
+            tc_dict["system-err"] = _collect_captured_output(testcase, "system-err")
 
-            # Extract <properties> child elements as a dict
-            props = {}
-            if hasattr(testcase, "properties") and hasattr(
-                testcase.properties, "property"
-            ):
-                for prop in testcase.properties.property:
-                    name = prop.attrib.get("name", "")
-                    value = prop.attrib.get("value", "")
-                    if name:
-                        props[name] = value
-            tc_dict["properties"] = props
+            tc_dict["properties"] = _collect_properties(
+                testcase, TESTCASE_KNOWN_ATTRIBUTES
+            )
 
             return tc_dict
 
@@ -130,17 +237,9 @@ class JUnitParser:
                 "testsuite_nested": [],
             }
 
-            # Extract <properties> child elements as a dict
-            props = {}
-            if hasattr(testsuite, "properties") and hasattr(
-                testsuite.properties, "property"
-            ):
-                for prop in testsuite.properties.property:
-                    name = prop.attrib.get("name", "")
-                    value = prop.attrib.get("value", "")
-                    if name:
-                        props[name] = value
-            ts_dict["properties"] = props
+            ts_dict["properties"] = _collect_properties(
+                testsuite, TESTSUITE_KNOWN_ATTRIBUTES
+            )
 
             # add nested testsuite objects to
             if hasattr(testsuite, "testsuite"):

--- a/tests/doc_test/utils/gtest_data.xml
+++ b/tests/doc_test/utils/gtest_data.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="5" failures="1" disabled="1" errors="0" time="0.035" timestamp="2026-08-31T10:00:00" name="AllTests">
+  <testsuite name="MathTest" tests="3" failures="1" disabled="1" errors="0" time="0.02" timestamp="2026-08-31T10:00:00" Owner="platform-team" Component="math">
+    <testcase name="Addition" file="src/math_test.cc" line="12" status="run" result="completed" time="0.001" timestamp="2026-08-31T10:00:01" classname="MathTest">
+      <properties>
+        <property name="PartiallyVerifies" value="REQ_1, REQ_2"/>
+        <property name="TestType" value="requirements-based"/>
+      </properties>
+    </testcase>
+    <testcase name="Subtraction" file="src/math_test.cc" line="20" status="run" result="completed" time="0.002" classname="MathTest">
+      <failure message="src/math_test.cc:22&#10;Expected equality of these values:&#10;  1&#10;  2" type=""><![CDATA[src/math_test.cc:22
+Expected equality of these values:
+  1
+  2]]></failure>
+      <failure message="src/math_test.cc:23&#10;Expected: true" type=""><![CDATA[src/math_test.cc:23
+Expected: true
+  Actual: false]]></failure>
+      <system-out><![CDATA[computing sums]]></system-out>
+      <system-err><![CDATA[overflow guard hit]]></system-err>
+    </testcase>
+    <testcase name="DISABLED_Division" file="src/math_test.cc" line="30" status="notrun" result="suppressed" time="0" classname="MathTest"/>
+  </testsuite>
+  <testsuite name="ParamTest/0" tests="2" failures="0" disabled="0" errors="0" time="0.015">
+    <testcase name="Works/0" file="src/param_test.cc" line="8" status="run" result="completed" time="0.004" classname="ParamTest/0" value_param="42" type_param="int"/>
+    <testcase name="Legacy" file="src/param_test.cc" line="14" status="run" result="skipped" time="0.001" classname="ParamTest/0" Requirement="REQ_9" TestType="interface-test">
+      <skipped message="Skipped via GTEST_SKIP"><![CDATA[src/param_test.cc:15
+not applicable on this platform]]></skipped>
+      <skipped message="second skip part"><![CDATA[trailing detail]]></skipped>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/tests/doc_test/utils/runner_error_data.xml
+++ b/tests/doc_test/utils/runner_error_data.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A test report as a *runner* synthesizes it when the test binary never produced
+  one itself: killed by a signal, crashed, or timed out. googletest does not
+  emit <error> at all, so this deliberately lives outside gtest_data.xml.
+  Bazel writes a report of this shape from the test log when a test binary dies.
+-->
+<testsuites>
+  <testsuite name="crash_suite" tests="3" failures="0" errors="2" disabled="0" time="30.11">
+    <testcase name="KilledBySigterm" classname="CrashSuite" status="run" time="30.0" file="src/crash_test.cc" line="7">
+      <error message="exited with error code 143"><![CDATA[Received SIGTERM
+Test terminated after the 30s timeout]]></error>
+      <system-err><![CDATA[shutting down worker pool]]></system-err>
+    </testcase>
+    <testcase name="ReportsTwoErrors" classname="CrashSuite" status="run" time="0.1" file="src/crash_test.cc" line="19">
+      <error message="first error"><![CDATA[detail one]]></error>
+      <error message="second error"><![CDATA[detail two]]></error>
+    </testcase>
+    <testcase name="Survivor" classname="CrashSuite" status="run" time="0.01" file="src/crash_test.cc" line="30"/>
+  </testsuite>
+</testsuites>

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -181,3 +181,66 @@ def test_parse_error_xml():
 
     assert test_suite["testcases"][3]["name"] == "ASkippedTest"
     assert test_suite["testcases"][3]["result"] == "skipped"
+
+
+xml_runner_error_path = os.path.join(
+    os.path.dirname(__file__), "doc_test/utils", "runner_error_data.xml"
+)
+
+
+def _runner_error_case(name):
+    from sphinxcontrib.test_reports.junitparser import JUnitParser
+
+    suite = JUnitParser(xml_runner_error_path).parse()[0]
+    return next(case for case in suite["testcases"] if case["name"] == name)
+
+
+def test_signal_killed_testcase_is_reported_as_error():
+    """A crashed or signal-killed test must not read as passed.
+
+    ``<error>`` is not a googletest construct -- the *runner* synthesizes a
+    report of this shape when the test binary dies without writing one (Bazel
+    does this from the test log on a crash or timeout).
+    """
+    case = _runner_error_case("KilledBySigterm")
+
+    assert case["result"] == "error"
+    assert case["message"] == "exited with error code 143"
+    assert "Received SIGTERM" in case["text"]
+
+
+def test_error_testcase_keeps_its_source_location_and_captured_output():
+    case = _runner_error_case("KilledBySigterm")
+
+    assert case["file"] == "src/crash_test.cc"
+    assert case["line"] == 7
+    assert case["system-err"] == "shutting down worker pool"
+
+
+def test_all_error_parts_are_kept():
+    """Only the first ``<error>`` used to be read, like failures and skips."""
+    case = _runner_error_case("ReportsTwoErrors")
+
+    assert case["result"] == "error"
+    assert [part["message"] for part in case["parts"]] == [
+        "first error",
+        "second error",
+    ]
+    assert [part["kind"] for part in case["parts"]] == ["error", "error"]
+
+
+def test_a_passing_testcase_next_to_errors_is_still_passed():
+    case = _runner_error_case("Survivor")
+
+    assert case["result"] == "passed"
+    assert case["parts"] == []
+
+
+def test_error_counts_are_taken_from_the_testsuite():
+    from sphinxcontrib.test_reports.junitparser import JUnitParser
+
+    suite = JUnitParser(xml_runner_error_path).parse()[0]
+
+    assert suite["errors"] == 2
+    assert suite["failures"] == 0
+    assert suite["passed"] == 1

--- a/tests/test_junit_parser_gtest.py
+++ b/tests/test_junit_parser_gtest.py
@@ -125,3 +125,13 @@ def test_absent_optional_attributes_are_empty_not_missing():
     assert case["value_param"] == ""
     assert case["type_param"] == ""
     assert case["timestamp"] == ""
+
+
+def test_a_testcase_without_any_properties_yields_an_empty_dict():
+    """Known dialect attributes must not leak in as properties.
+
+    ``Works/0`` carries ``value_param``/``type_param`` and no ``<properties>``
+    element, so the result has to be an empty dict rather than those two
+    attributes.
+    """
+    assert _case("ParamTest/0", "Works/0")["properties"] == {}

--- a/tests/test_junit_parser_gtest.py
+++ b/tests/test_junit_parser_gtest.py
@@ -1,0 +1,127 @@
+"""Tests for the googletest XML dialect (TR-C).
+
+googletest deviates from the pytest/nose JUnit flavour in ways that silently
+produced wrong data before:
+
+* disabled tests are reported as ``status="notrun"`` (previously classified as
+  ``passed``, because no ``<failure>``/``<skipped>`` child is present);
+* a single test case may carry *several* ``<failure>``/``<skipped>`` parts, of
+  which only the first one was read;
+* ``RecordProperty`` values arrive as **attributes** rather than
+  ``<properties>`` children -- on ``<testcase>`` for googletest < 1.8.1 (the
+  form the official docs still show) and on ``<testsuite>`` for suite-level
+  properties up to 1.15.x;
+* parameterised tests carry ``value_param``/``type_param``, and cases carry
+  their own ``timestamp``.
+"""
+
+import os
+
+xml_gtest_path = os.path.join(
+    os.path.dirname(__file__), "doc_test/utils", "gtest_data.xml"
+)
+
+
+def _suites():
+    from sphinxcontrib.test_reports.junitparser import JUnitParser
+
+    return JUnitParser(xml_gtest_path).parse()
+
+
+def _case(suite_name, case_name):
+    for suite in _suites():
+        if suite["name"] == suite_name:
+            for case in suite["testcases"]:
+                if case["name"] == case_name:
+                    return case
+    raise AssertionError(f"case {suite_name}/{case_name} not found")
+
+
+def test_notrun_status_is_reported_as_disabled():
+    """``status="notrun"`` must not fall through to ``passed``."""
+    assert _case("MathTest", "DISABLED_Division")["result"] == "disabled"
+
+
+def test_all_failure_parts_are_kept():
+    """googletest emits one ``<failure>`` per assertion; keep every one."""
+    case = _case("MathTest", "Subtraction")
+
+    parts = case["parts"]
+    assert len(parts) == 2
+    assert parts[0]["kind"] == "failure"
+    assert parts[0]["message"].startswith("src/math_test.cc:22")
+    assert "Expected equality of these values" in parts[0]["text"]
+    assert parts[1]["message"].startswith("src/math_test.cc:23")
+    assert "Actual: false" in parts[1]["text"]
+
+
+def test_first_failure_part_stays_in_the_legacy_flat_keys():
+    """``text``/``message`` keep their meaning for existing consumers."""
+    case = _case("MathTest", "Subtraction")
+
+    assert case["result"] == "failure"
+    assert case["message"] == case["parts"][0]["message"]
+    assert case["text"] == case["parts"][0]["text"]
+
+
+def test_all_skipped_parts_are_kept():
+    case = _case("ParamTest/0", "Legacy")
+
+    assert case["result"] == "skipped"
+    assert [part["message"] for part in case["parts"]] == [
+        "Skipped via GTEST_SKIP",
+        "second skip part",
+    ]
+
+
+def test_system_err_is_captured():
+    """``system-out`` was read, ``system-err`` was dropped entirely."""
+    case = _case("MathTest", "Subtraction")
+
+    assert case["system-out"] == "computing sums"
+    assert case["system-err"] == "overflow guard hit"
+
+
+def test_testcase_attributes_are_read_as_properties():
+    """The pre-1.8.1 / documented attribute form of ``RecordProperty``."""
+    case = _case("ParamTest/0", "Legacy")
+
+    assert case["properties"]["Requirement"] == "REQ_9"
+    assert case["properties"]["TestType"] == "interface-test"
+
+
+def test_known_testcase_attributes_are_not_mistaken_for_properties():
+    """Only *unknown* attributes are properties; the dialect's own are not."""
+    case = _case("MathTest", "Addition")
+
+    assert case["properties"] == {
+        "PartiallyVerifies": "REQ_1, REQ_2",
+        "TestType": "requirements-based",
+    }
+
+
+def test_testsuite_attributes_are_read_as_properties():
+    """Suite-level ``RecordProperty`` is attribute-only up to googletest 1.15."""
+    suite = next(s for s in _suites() if s["name"] == "MathTest")
+
+    assert suite["properties"]["Owner"] == "platform-team"
+    assert suite["properties"]["Component"] == "math"
+    assert "tests" not in suite["properties"]
+    assert "timestamp" not in suite["properties"]
+
+
+def test_parameterised_and_timestamp_attributes_are_parsed():
+    works = _case("ParamTest/0", "Works/0")
+
+    assert works["value_param"] == "42"
+    assert works["type_param"] == "int"
+    assert _case("MathTest", "Addition")["timestamp"] == "2026-08-31T10:00:01"
+
+
+def test_absent_optional_attributes_are_empty_not_missing():
+    """Converters must be able to emit every field unconditionally."""
+    case = _case("MathTest", "Subtraction")
+
+    assert case["value_param"] == ""
+    assert case["type_param"] == ""
+    assert case["timestamp"] == ""


### PR DESCRIPTION
First of a four-PR stack that makes `sphinx-test-reports` able to replace a hand-rolled test-link extension. Each PR is independently reviewable; this one is parser-only.

googletest deviates from the pytest/nose JUnit flavour in ways that silently produced wrong or incomplete data:

- **`status="notrun"` read as `passed`.** A disabled googletest case has no result child element, so it fell through the `skipped`/`failure`/`error` checks into `passed`. It is now `disabled`; the googletest `result="suppressed"` attribute is accepted as an equivalent signal.
- **Only the first failure was kept.** googletest emits one `<failure>` per failed assertion, and `GTEST_SKIP` can fire repeatedly. All parts are now collected under a new `parts` key, each with kind, type, message and body text.
- **`RecordProperty` in attribute form was invisible.** googletest wrote test-case properties as attributes before 1.8.1 (the form its official docs still show), and suite-level properties stayed attribute-only up to 1.15.x. Unknown attributes on `<testcase>`/`<testsuite>` are now read as properties; `<properties>` children remain the modern form and win on conflict.
- **`<system-err>` was dropped entirely**, and `<system-out>` read only its first block. Both are now collected and joined.
- `timestamp`, `value_param` and `type_param` are parsed.

## Backwards compatibility

The flat `type`/`text`/`message` keys still report the first part, including their historical per-kind defaults (`message` defaults to `""` for a failure and `"unknown"` for skipped/error), so existing consumers see no change. The result vocabulary keeps `failure` — it is a documented need field value and the `tr_failure` CSS class — and only gains `disabled`.

Every new key defaults to `""` rather than being absent, so a consumer can emit each field unconditionally, and all of them are added to `DEFAULT_OPTIONS`; otherwise a new parsed key would reach `add_need` as an unexpected keyword argument.

## Verification

10 new tests against a googletest fixture covering the attribute matrix, plus the existing 61 — 71 passing, mypy strict and pre-commit clean, docs build clean with `-W`.