### PR TITLE
feat: expose the test-case source location as need fields

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,12 @@ Unreleased
   in attribute form are read (on ``<testcase>`` for googletest < 1.8.1 and on
   ``<testsuite>`` for suite-level properties up to 1.15.x), and ``timestamp``,
   ``value_param`` and ``type_param`` are parsed. ``<system-err>`` is captured.
+* Feature: The source location of a test case is available as Sphinx-Needs
+  fields, configurable via the new ``tr_source_file_option`` and
+  ``tr_source_line_option``.
+* Bugfix: ``tr_file_option`` is now honoured by the directives, not only by the
+  field registration. Renaming the field previously produced needs carrying an
+  unregistered field.
 
 .. _`release:1.4.0`:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -107,6 +107,60 @@ This may be needed, if a junit-xml files contains many test cases.
 Default: **5**
 
 
+.. _tr_file_option:
+
+tr_file_option
+--------------
+
+Name of the Sphinx-Needs field that carries the path of the test-result *report*
+(the file given to the directive).
+
+Renaming it frees the field names ``file`` and ``line`` for the *test source*
+location, see :ref:`tr_source_file_option`.
+
+Default: **file**
+
+.. _tr_source_file_option:
+
+tr_source_file_option
+---------------------
+.. versionadded:: 1.5.0
+
+Name of the Sphinx-Needs field that carries the source file of a test case,
+taken from the ``file`` attribute of the JUnit/googletest ``<testcase>``
+element.
+
+The default avoids a collision with :ref:`tr_file_option`. To spell the source
+location verbatim as ``file`` and ``line`` -- as some metamodels require --
+rename the report field instead:
+
+.. code-block:: python
+
+   tr_file_option = "report_file"
+   tr_source_file_option = "file"
+   tr_source_line_option = "line"
+
+Each of the three options must name a different field; otherwise the build stops
+with a configuration error.
+
+The field is empty when the XML carries no ``file`` attribute. With pytest this
+is the norm: it emits ``file``/``line`` only with ``junit_family = xunit1`` (or
+``legacy``), while its default ``xunit2`` filters those attributes out.
+
+Default: **case_file**
+
+.. _tr_source_line_option:
+
+tr_source_line_option
+---------------------
+.. versionadded:: 1.5.0
+
+Name of the Sphinx-Needs field that carries the source line of a test case,
+taken from the ``line`` attribute of the ``<testcase>`` element.
+See :ref:`tr_source_file_option`.
+
+Default: **case_line**
+
 .. _tr_extra_options:
 
 tr_extra_options

--- a/sphinxcontrib/test_reports/directives/test_case.py
+++ b/sphinxcontrib/test_reports/directives/test_case.py
@@ -202,7 +202,6 @@ class TestCaseDirective(TestCommonDirective):
             tags=self.test_tags,
             status=self.test_status,
             collapse=self.collapse,
-            file=self.test_file_given,
             suite=suite["name"],
             case=case_full_name,
             case_name=case_name,
@@ -211,6 +210,8 @@ class TestCaseDirective(TestCommonDirective):
             result=result,
             time=time_str,
             style=style,
+            **{self.report_file_field(): self.test_file_given},
+            **self.source_location_fields(case),
             **self.extra_options,
         )
 

--- a/sphinxcontrib/test_reports/directives/test_common.py
+++ b/sphinxcontrib/test_reports/directives/test_common.py
@@ -57,6 +57,34 @@ class TestCommonDirective(Directive):
 
         self.log = logging.getLogger(__name__)
 
+    def report_file_field(self):
+        """Need field carrying the XML report path (renameable via config).
+
+        Renaming it is what frees ``file``/``line`` for the *test source*
+        location, so every directive must honour the option -- not only the
+        field registration.
+        """
+        return getattr(self.app.config, "tr_file_option", "file")
+
+    def source_location_fields(self, case):
+        """Need fields for the ``<testcase>`` file/line attributes.
+
+        The parser reports ``"unknown"``/``-1`` when the attributes are absent,
+        which is the norm for pytest: its default ``junit_family = xunit2``
+        filters them out. Those sentinels become empty strings, so the fields
+        are always present and never carry a fake location.
+        """
+        file_field = getattr(self.app.config, "tr_source_file_option", "case_file")
+        line_field = getattr(self.app.config, "tr_source_line_option", "case_line")
+
+        source_file = case.get("file", "unknown")
+        source_line = case.get("line", -1)
+
+        return {
+            file_field: "" if source_file in ("unknown", None) else str(source_file),
+            line_field: "" if source_line in (-1, None) else str(source_line),
+        }
+
     def collect_extra_options(self):
         """Collect any extra options and their values that were specified in the directive"""
         tr_extra_options = getattr(self.app.config, "tr_extra_options", [])

--- a/sphinxcontrib/test_reports/directives/test_file.py
+++ b/sphinxcontrib/test_reports/directives/test_file.py
@@ -78,13 +78,13 @@ class TestFileDirective(TestCommonDirective):
             tags=self.test_tags,
             status=self.test_status,
             collapse=self.collapse,
-            file=self.test_file_given,
             suites=suites,
             cases=cases,
             passed=passed,
             skipped=skipped,
             failed=failed,
             errors=errors,
+            **{self.report_file_field(): self.test_file_given},
             **self.extra_options,
         )
 

--- a/sphinxcontrib/test_reports/directives/test_suite.py
+++ b/sphinxcontrib/test_reports/directives/test_suite.py
@@ -104,13 +104,13 @@ class TestSuiteDirective(TestCommonDirective):
             tags=self.test_tags,
             status=self.test_status,
             collapse=self.collapse,
-            file=self.test_file_given,
             suite=suite["name"],
             cases=cases,
             passed=passed,
             skipped=skipped,
             failed=failed,
             errors=errors,
+            **{self.report_file_field(): self.test_file_given},
             **self.extra_options,
         )
 

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -28,6 +28,7 @@ from sphinxcontrib.test_reports.directives.test_suite import (
     TestSuiteDirective,
 )
 from sphinxcontrib.test_reports.environment import install_styles_static_files
+from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 from sphinxcontrib.test_reports.functions import tr_link
 
 sphinx_version = sphinx.__version__
@@ -99,7 +100,14 @@ def setup(app: Sphinx):
     * test_report
     """
 
+    # Name of the need field carrying the path of the XML *report*.
     app.add_config_value("tr_file_option", "file", "html")
+    # Names of the need fields carrying the *test source* location taken from
+    # the <testcase> file/line attributes. Defaults avoid the collision with
+    # tr_file_option above; set both to "file"/"line" (and tr_file_option to
+    # something else) to match a metamodel that spells them verbatim.
+    app.add_config_value("tr_source_file_option", "case_file", "html")
+    app.add_config_value("tr_source_line_option", "case_line", "html")
 
     log = logging.getLogger(__name__)
     log.info("Setting up sphinx-test-reports extension")
@@ -224,10 +232,38 @@ def tr_preparation(app, *args):
     app.add_directive(app.config.tr_case[0], TestCaseDirective)
 
 
+def check_field_name_collisions(config) -> None:
+    """Reject configurations where two field options name the same need field.
+
+    The report path and the test-source location are separate fields; if two
+    options resolve to one name, ``add_need`` receives the same keyword twice
+    and fails with a bare ``TypeError`` from inside a directive.
+    """
+    options = {
+        "tr_file_option": getattr(config, "tr_file_option", "file"),
+        "tr_source_file_option": getattr(config, "tr_source_file_option", "case_file"),
+        "tr_source_line_option": getattr(config, "tr_source_line_option", "case_line"),
+    }
+
+    for name, value in options.items():
+        clashing = [
+            other
+            for other, other_value in options.items()
+            if other != name and other_value == value
+        ]
+        if clashing:
+            raise InvalidConfigurationError(
+                f"{name} and {', '.join(sorted(clashing))} are all set to "
+                f"'{value}'; each must name a different need field."
+            )
+
+
 def sphinx_needs_update(app: Sphinx, config: Config) -> None:
     """
     sphinx-needs configuration
     """
+
+    check_field_name_collisions(config)
 
     needs_version = Version(sphinx_needs.__version__)
     use_schema = needs_version >= Version("6.0.0")
@@ -235,6 +271,16 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
     if use_schema:
         _register_field(
             app, getattr(config, "tr_file_option", "file"), schema={"type": "string"}
+        )
+        _register_field(
+            app,
+            getattr(config, "tr_source_file_option", "case_file"),
+            schema={"type": "string"},
+        )
+        _register_field(
+            app,
+            getattr(config, "tr_source_line_option", "case_line"),
+            schema={"type": "string"},
         )
         _register_field(app, "suite", schema={"type": "string"})
         _register_field(app, "case", schema={"type": "string"})
@@ -251,6 +297,8 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
         _register_field(app, "result", schema={"type": "string"})
     else:
         _register_field(app, getattr(config, "tr_file_option", "file"))
+        _register_field(app, getattr(config, "tr_source_file_option", "case_file"))
+        _register_field(app, getattr(config, "tr_source_line_option", "case_line"))
         _register_field(app, "suite")
         _register_field(app, "case")
         _register_field(app, "case_name")

--- a/tests/doc_test/source_location/conf.py
+++ b/tests/doc_test/source_location/conf.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
+
+extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
+
+source_suffix = ".rst"
+master_doc = "index"
+
+project = "source-location-test"
+copyright = "2026, test"
+author = "test"
+version = "1.0"
+release = "1.0"
+language = "en"
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+html_theme = "alabaster"

--- a/tests/doc_test/source_location/index.rst
+++ b/tests/doc_test/source_location/index.rst
@@ -1,0 +1,14 @@
+Source Location Test
+====================
+
+.. test-file:: GTest Report
+   :id: SRCLOC_TF_1
+   :file: ../utils/gtest_data.xml
+   :auto_suites:
+   :auto_cases:
+
+.. test-file:: Pytest Report Without Line Attributes
+   :id: SRCLOC_TF_2
+   :file: ../utils/pytest_data.xml
+   :auto_suites:
+   :auto_cases:

--- a/tests/doc_test/source_location_renamed/conf.py
+++ b/tests/doc_test/source_location_renamed/conf.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
+
+extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
+
+source_suffix = ".rst"
+master_doc = "index"
+
+project = "source-location-renamed-test"
+copyright = "2026, test"
+author = "test"
+version = "1.0"
+release = "1.0"
+language = "en"
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+html_theme = "alabaster"
+
+# Free up "file"/"line" for the *source* location by renaming the field that
+# carries the XML report path (the S-CORE metamodel spells the source location
+# verbatim as file/line).
+tr_file_option = "report_file"
+tr_source_file_option = "file"
+tr_source_line_option = "line"

--- a/tests/doc_test/source_location_renamed/index.rst
+++ b/tests/doc_test/source_location_renamed/index.rst
@@ -1,0 +1,14 @@
+Source Location Renamed Test
+============================
+
+.. test-file:: GTest Report
+   :id: SRCLOCR_TF_1
+   :file: ../utils/gtest_data.xml
+   :auto_suites:
+   :auto_cases:
+
+.. test-file:: Pytest Report Without Line Attributes
+   :id: SRCLOCR_TF_2
+   :file: ../utils/pytest_data.xml
+   :auto_suites:
+   :auto_cases:

--- a/tests/test_source_location.py
+++ b/tests/test_source_location.py
@@ -1,0 +1,154 @@
+"""Tests for the test-case source location as need fields (TR-D).
+
+The JUnit/googletest ``<testcase>`` attributes ``file`` and ``line`` point at
+the *test source*. They were parsed but never reached ``add_need``, because the
+need field ``file`` already carries the path of the XML *report* -- and
+``tr_file_option``, which exists to rename that field, was only half wired: the
+registration honoured it while the directives kept passing ``file=``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def _field_values(html, field):
+    """All rendered values of a sphinx-needs meta field."""
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    return [
+        span.get_text(strip=True)
+        for span in soup.select(f"span.needs_{field} span.needs_data")
+    ]
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [{"buildername": "html", "srcdir": "doc_test/source_location"}],
+    indirect=True,
+)
+class TestSourceLocationDefaultFieldNames:
+    """Out of the box the source location lands on ``case_file``/``case_line``."""
+
+    def test_build_succeeds(self, test_app):
+        app = test_app
+        app.build()
+        assert app.statuscode == 0
+
+    def test_source_file_is_a_need_field(self, test_app):
+        app = test_app
+        app.build()
+        html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
+
+        assert "src/math_test.cc" in _field_values(html, "case_file")
+
+    def test_source_line_is_a_need_field(self, test_app):
+        app = test_app
+        app.build()
+        html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
+
+        assert "12" in _field_values(html, "case_line")
+
+    def test_report_path_stays_on_the_file_field(self, test_app):
+        """The existing meaning of ``file`` is unchanged by default."""
+        app = test_app
+        app.build()
+        html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
+
+        assert any(
+            value.endswith("gtest_data.xml") for value in _field_values(html, "file")
+        )
+
+    def test_missing_line_attribute_renders_empty_not_the_sentinel(self, test_app):
+        """pytest's default junit_family drops file/line; -1 must not leak."""
+        app = test_app
+        app.build()
+        html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
+
+        assert "-1" not in _field_values(html, "case_line")
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [{"buildername": "html", "srcdir": "doc_test/source_location_renamed"}],
+    indirect=True,
+)
+class TestSourceLocationRenamedFieldNames:
+    """``tr_file_option`` frees ``file``/``line`` for the source location."""
+
+    def test_build_succeeds(self, test_app):
+        app = test_app
+        app.build()
+        assert app.statuscode == 0
+
+    def test_source_location_uses_the_configured_names(self, test_app):
+        app = test_app
+        app.build()
+        html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
+
+        assert "src/math_test.cc" in _field_values(html, "file")
+        assert "12" in _field_values(html, "line")
+
+    def test_report_path_moved_to_the_renamed_field(self, test_app):
+        """The half-wired rename: directives must honour tr_file_option too."""
+        app = test_app
+        app.build()
+        html = Path(app.outdir, "index.html").read_text(encoding="utf-8")
+
+        assert any(
+            value.endswith("gtest_data.xml")
+            for value in _field_values(html, "report_file")
+        )
+
+
+class TestFieldNameCollisionIsRejected:
+    """Two options resolving to one field name must fail loudly, not crash.
+
+    Without the check, ``add_need`` is called with the same keyword twice and
+    raises a bare ``TypeError`` from deep inside a directive.
+    """
+
+    class _Config:
+        def __init__(self, **values):
+            self.__dict__.update(values)
+
+    def test_report_and_source_file_sharing_a_name_is_an_error(self):
+        from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
+        from sphinxcontrib.test_reports.test_reports import check_field_name_collisions
+
+        config = self._Config(
+            tr_file_option="file",
+            tr_source_file_option="file",
+            tr_source_line_option="line",
+        )
+
+        with pytest.raises(InvalidConfigurationError) as exc:
+            check_field_name_collisions(config)
+
+        assert "tr_file_option" in str(exc.value)
+        assert "tr_source_file_option" in str(exc.value)
+
+    def test_source_file_and_source_line_sharing_a_name_is_an_error(self):
+        from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
+        from sphinxcontrib.test_reports.test_reports import check_field_name_collisions
+
+        config = self._Config(
+            tr_file_option="report_file",
+            tr_source_file_option="location",
+            tr_source_line_option="location",
+        )
+
+        with pytest.raises(InvalidConfigurationError):
+            check_field_name_collisions(config)
+
+    def test_distinct_names_are_accepted(self):
+        from sphinxcontrib.test_reports.test_reports import check_field_name_collisions
+
+        config = self._Config(
+            tr_file_option="report_file",
+            tr_source_file_option="file",
+            tr_source_line_option="line",
+        )
+
+        assert check_field_name_collisions(config) is None


### PR DESCRIPTION
Second of four. **Stacked on #141** — review that one first; this PR's diff against it is small.

The JUnit/googletest `<testcase>` attributes `file` and `line` point at the test source. The parser read them, but they never reached `add_need`.

## The blocker, and the latent bug behind it

The need field `file` already carries the path of the XML *report*. `tr_file_option` exists to rename that field — but it was only half wired: the field *registration* honoured it while all three directives kept passing a hardcoded `file=`. So setting `tr_file_option = "report_file"` did not free the name `file`; it produced a need carrying an unregistered field, and the build failed inside `add_need`. That is fixed here, which is what makes the rest possible.

## What this adds

- All three directives pass the report path under the configured field name, so `tr_file_option` works end to end.
- Two new options name the fields carrying the source location: `tr_source_file_option` (default `case_file`) and `tr_source_line_option` (default `case_line`). Both are registered and always emitted by the `test-case` directive.
- The defaults avoid the collision. A project whose metamodel spells the source location verbatim as `file`/`line` gets there by renaming the report field instead — field names are configuration, not policy.
- The parser's absent-attribute sentinels (`"unknown"`, `-1`) become empty strings, so a report without file/line yields empty fields rather than a fake location. This is the norm for pytest: its default `junit_family = xunit2` filters those attributes off `<testcase>` entirely, and only `xunit1`/`legacy` emit them.
- Two options resolving to the same field name previously produced a bare `TypeError` from inside a directive (`add_need` receiving one keyword twice). It is now an `InvalidConfigurationError` naming both options.

`tr_file_option` was undocumented despite already existing; it is documented here alongside the two new options.

## Verification

11 new tests — two Sphinx fixture projects (default names, and renamed so the source location occupies `file`/`line`) plus unit tests for the collision check. 82 passing, mypy strict and pre-commit clean, docs build clean with `-W`.