### PR TITLE
feat: Sphinx-free test-XML to needs.json converter CLI

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,10 @@ Unreleased
 * Feature: New ``tr_deterministic_case_ids`` option derives test-case IDs from
   the source location instead of the need content, so an ID no longer changes
   when a test starts failing differently.
+* Feature: New ``test-reports convert`` command line interface, converting
+  test-result XML into a ``needs.json`` without running Sphinx, so the
+  conversion can run as a cacheable build action and the documentation build
+  only imports the result. See :ref:`cli`.
 
 .. _`release:1.4.0`:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,124 @@
+.. _cli:
+
+Command line interface
+======================
+.. versionadded:: 1.5.0
+
+``Sphinx-Test-Reports`` ships a ``test-reports`` command that converts
+test-result XML into a ``needs.json`` **without running Sphinx**.
+
+Why this exists: parsing test results inside a documentation build couples the
+two, so results cannot be converted without building docs, the conversion cannot
+be cached by a build system, and the data is unavailable to anything else. The
+CLI splits the computation out; the documentation build only imports the result.
+
+The command imports no Sphinx code at all, so it can run as a build action in an
+environment that has no documentation toolchain installed.
+
+Converting a report
+-------------------
+
+.. code-block:: bash
+
+   test-reports convert bazel-testlogs/my_target/test.xml --output needs.json
+
+Several reports can be converted into one file -- a build system typically
+passes them as a file list:
+
+.. code-block:: bash
+
+   test-reports convert report_a.xml report_b.xml --output needs.json
+
+Each test case becomes one need, with the source location under the ``file`` and
+``line`` fields, the result under ``result``, a one-line ``result_text``, and the
+full failure evidence (every ``<failure>``/``<skipped>`` part plus captured
+output) in the need content.
+
+Consuming the result
+--------------------
+
+The output is a schema-conform ``needs.json``, so it can be imported as local
+needs:
+
+.. code-block:: rst
+
+   .. needimport:: needs.json
+
+or mounted as external needs via ``needs_external_needs`` in ``conf.py``.
+
+Every need carries the synthesized source URL twice: as ``external_url``, which
+Sphinx-Needs uses when rendering a link to an external need, and as a plain
+``remote_url`` field, so needs imported as *local* needs keep a clickable link
+through a ``needs_string_links`` entry.
+
+Linking test cases to requirements
+----------------------------------
+
+XML ``<properties>`` become need fields under their own names. To turn one into a
+link field instead, map it -- the value is split on commas:
+
+.. code-block:: bash
+
+   test-reports convert test.xml --output needs.json \
+       --link-property PartiallyVerifies=partially_verifies \
+       --link-property FullyVerifies=fully_verifies
+
+Mapped link fields are written even when a case has no such property, so a schema
+can require them.
+
+Source links
+------------
+
+Source URLs need both a repository and a commit; they are refused separately,
+because half the metadata cannot produce a URL:
+
+.. code-block:: bash
+
+   test-reports convert test.xml --output needs.json \
+       --remote-url git@github.com:org/repo.git \
+       --commit "$(git rev-parse HEAD)"
+
+Git remotes are accepted in ``scp`` form and normalised. Without this metadata --
+as in a hermetic sandbox -- the URL fields stay empty rather than carrying a
+placeholder that looks real and then 404s.
+
+Forges that lay out blob URLs differently are handled with ``--url-pattern``,
+which accepts the placeholders ``{base}``, ``{commit}``, ``{file}`` and
+``{line}``:
+
+.. code-block:: bash
+
+   test-reports convert test.xml --output needs.json \
+       --remote-url https://gitlab.com/org/repo --commit abc123 \
+       --url-pattern "{base}/-/blob/{commit}/{file}#L{line}"
+
+Reproducible output
+-------------------
+
+The written file is byte-stable: keys are sorted and no timestamp is recorded.
+Converting the same report twice produces identical bytes, so the output works as
+a cached build-action output and as diffable evidence.
+
+Missing source locations
+------------------------
+
+If no test case in a report carries a ``line`` attribute, the command says so on
+stderr. The usual cause is pytest's default ``junit_family = xunit2``, which
+filters ``file`` and ``line`` off ``<testcase>``; ``xunit1`` (or ``legacy``)
+emits them.
+
+All options
+-----------
+
+.. code-block:: text
+
+   test-reports convert FILE [FILE ...] --output PATH
+                        [--project NAME] [--version KEY]
+                        [--need-type TYPE] [--tags TAGS]
+                        [--link-property PROPERTY=LINK_FIELD]
+                        [--remote-url URL] [--commit COMMITISH]
+                        [--url-pattern PATTERN]
+
+``--project`` and ``--version`` fill the ``needs.json`` envelope;
+``--need-type`` (default ``testcase``) sets the need type and the ID prefix;
+``--tags`` is a comma-separated list applied to every created need.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,6 +75,7 @@ Content
    install
    directives/index
    configuration
+   cli
    parsers
    filter
    functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ docs = [
 [dependency-groups]
 dev = ["pre-commit~=3.0", "nox>=2025.2.9", "mypy>=1.16.0"]
 
+[project.scripts]
+test-reports = "sphinxcontrib.test_reports.cli:main"
+
 [tool.flit.module]
 name = "sphinxcontrib.test_reports"
 
@@ -88,6 +91,9 @@ show_error_codes = true
 exclude = [
   "^sphinxcontrib/test_reports/__init__\\.py$",
   "^sphinxcontrib/test_reports/config\\.py$",
+  # argparse.Namespace attributes are Any by construction, which
+  # disallow_any_expr rejects; needs a typed settings object first.
+  "^sphinxcontrib/test_reports/cli\\.py$",
   "^sphinxcontrib/test_reports/directives/__init__\\.py$",
   "^sphinxcontrib/test_reports/directives/test_case\\.py$",
   "^sphinxcontrib/test_reports/directives/test_common\\.py$",

--- a/sphinxcontrib/test_reports/__init__.py
+++ b/sphinxcontrib/test_reports/__init__.py
@@ -1,4 +1,18 @@
-# from sphinxcontrib.test_reports.needs.dyn_functions import Results4Needs
-from sphinxcontrib.test_reports.test_reports import setup
+"""Sphinx-Test-Reports.
+
+``setup`` is resolved lazily (PEP 562) so that importing a submodule of this
+package does not import Sphinx. The converter CLI and the modules it uses must
+stay usable as a build action, without the documentation toolchain installed;
+Sphinx still finds ``setup`` through normal attribute access when it loads this
+package as an extension.
+"""
 
 __all__ = ["setup"]
+
+
+def __getattr__(name: str) -> object:
+    if name == "setup":
+        from sphinxcontrib.test_reports.test_reports import setup
+
+        return setup
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -1,0 +1,184 @@
+"""``test-reports`` command line interface.
+
+Converts test-result XML into needs.json *outside* Sphinx, so a build system can
+schedule and cache the conversion and the documentation build only imports the
+result. Nothing in the import chain of this module may import Sphinx; the test
+suite asserts that.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sphinxcontrib.test_reports.junitparser import JUnitParser
+from sphinxcontrib.test_reports.needs_export import DEFAULT_VERSION, build_needs_file
+from sphinxcontrib.test_reports.remote import DEFAULT_URL_PATTERN, normalise_remote_url
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="test-reports",
+        description="Convert test-result XML into sphinx-needs data.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    convert = subcommands.add_parser(
+        "convert",
+        help="Convert one or more test-result XML files into needs.json.",
+        description=(
+            "Convert one or more test-result XML files into a needs.json that "
+            "can be consumed with needimport or needs_external_needs."
+        ),
+    )
+    convert.add_argument(
+        "files",
+        nargs="+",
+        metavar="FILE",
+        help="Test-result XML files (a build system passes these as a file list).",
+    )
+    convert.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        metavar="PATH",
+        help="Where to write the needs.json.",
+    )
+    convert.add_argument(
+        "--project",
+        default="",
+        help="Project name recorded in the needs.json envelope.",
+    )
+    convert.add_argument(
+        "--version",
+        default=DEFAULT_VERSION,
+        help=f"Version key in the envelope (default: {DEFAULT_VERSION}).",
+    )
+    convert.add_argument(
+        "--need-type",
+        default="testcase",
+        help="Need type for each test case (default: testcase).",
+    )
+    convert.add_argument(
+        "--tags",
+        default="",
+        help="Comma-separated tags applied to every created need.",
+    )
+    convert.add_argument(
+        "--link-property",
+        action="append",
+        default=[],
+        metavar="PROPERTY=LINK_FIELD",
+        help=(
+            "Promote an XML property to a link field, comma-splitting its value "
+            "(repeatable), e.g. PartiallyVerifies=partially_verifies."
+        ),
+    )
+    convert.add_argument(
+        "--remote-url",
+        default="",
+        help="Repository URL used to synthesize source links; git remotes are accepted.",
+    )
+    convert.add_argument(
+        "--commit",
+        default="",
+        help="Commit-ish the reports were produced from.",
+    )
+    convert.add_argument(
+        "--url-pattern",
+        default=DEFAULT_URL_PATTERN,
+        help=f"Source-URL template (default: {DEFAULT_URL_PATTERN}).",
+    )
+    return parser
+
+
+def _parse_link_properties(values: list[str]) -> dict[str, str]:
+    mapping = {}
+    for value in values:
+        property_name, separator, link_field = value.partition("=")
+        if not separator or not property_name.strip() or not link_field.strip():
+            raise ValueError(
+                f"--link-property expects PROPERTY=LINK_FIELD, got {value!r}"
+            )
+        mapping[property_name.strip()] = link_field.strip()
+    return mapping
+
+
+def _warn_about_absent_source_lines(path: Path, suites: list) -> None:
+    """Report the most common cause of a missing source location.
+
+    pytest emits ``file``/``line`` as ``<testcase>`` attributes only under
+    ``junit_family = xunit1`` (or ``legacy``); its default ``xunit2`` filters
+    them out, which silently costs the source location of every case.
+    """
+    cases = [case for suite in suites for case in suite.get("testcases", [])]
+    if cases and all(case.get("line", -1) == -1 for case in cases):
+        print(
+            f"warning: {path}: no <testcase> carries a 'line' attribute, so no "
+            "source location could be recorded. pytest emits file/line only "
+            "with junit_family = xunit1 (or legacy); its default xunit2 drops "
+            "them.",
+            file=sys.stderr,
+        )
+
+
+def _convert(arguments: argparse.Namespace) -> int:
+    try:
+        link_properties = _parse_link_properties(list(arguments.link_property))
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    if bool(arguments.remote_url) != bool(arguments.commit):
+        print(
+            "error: --remote-url and --commit must be given together; without "
+            "both, no source URL can be synthesized.",
+            file=sys.stderr,
+        )
+        return 2
+
+    suites: list = []
+    for name in arguments.files:
+        path = Path(name)
+        if not path.is_file():
+            print(f"error: no such file: {path}", file=sys.stderr)
+            return 1
+        try:
+            parsed = JUnitParser(str(path)).parse()
+        except Exception as error:  # noqa: BLE001 - report, never traceback
+            print(f"error: {path}: {error}", file=sys.stderr)
+            return 1
+        _warn_about_absent_source_lines(path, parsed)
+        suites.extend(parsed)
+
+    payload = build_needs_file(
+        suites,
+        project=arguments.project,
+        version=arguments.version,
+        need_type=arguments.need_type,
+        tags=[tag.strip() for tag in arguments.tags.split(",") if tag.strip()],
+        link_properties=link_properties,
+        base_url=normalise_remote_url(arguments.remote_url),
+        commit=arguments.commit,
+        url_pattern=arguments.url_pattern,
+    )
+
+    output = Path(arguments.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    # Sorted keys and a fixed indent keep the output byte-stable across runs.
+    output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    """Entry point. Returns a process exit code instead of raising."""
+    arguments = _build_parser().parse_args(argv)
+    if arguments.command == "convert":
+        return _convert(arguments)
+    return 2  # pragma: no cover - argparse rejects unknown commands
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sphinxcontrib/test_reports/needs_export.py
+++ b/sphinxcontrib/test_reports/needs_export.py
@@ -1,0 +1,236 @@
+"""Turn parsed test reports into a needs.json payload.
+
+Sphinx-free: the conversion runs as a build action, and the documentation build
+only imports the result.
+
+Two rules shape the output:
+
+* **Every field is always present.** Absent XML attributes become empty values
+  rather than missing keys, so a schema can simply require a field and a
+  consumer never has to distinguish "unset" from "absent".
+* **Nothing depends on the wall clock or on dict ordering**, so the file is a
+  cacheable build artifact and a diffable piece of evidence.
+"""
+
+import re
+from typing import Iterable, Iterator, Mapping, Sequence, Union
+
+from sphinxcontrib.test_reports.identity import (
+    UNKNOWN,
+    case_display_name,
+    deterministic_case_id,
+)
+from sphinxcontrib.test_reports.remote import DEFAULT_URL_PATTERN, source_url
+
+#: A need field value as it appears in needs.json.
+FieldValue = Union[str, list[str]]
+NeedItem = dict[str, FieldValue]
+
+#: Version key used when the caller does not supply one. needs.json requires a
+#: ``current_version``, but a converted report has no baseline history.
+DEFAULT_VERSION = "1.0"
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_WHITESPACE = re.compile(r"\s+")
+
+#: The parser keeps the historical spelling ``failure`` -- it is a documented
+#: need field value and a CSS class. Exported data has no such obligation and
+#: uses the migration-target vocabulary (passed|failed|error|skipped|disabled),
+#: which is also what S-CORE's metamodel spells.
+RESULT_NAMES = {"failure": "failed"}
+
+
+def flatten_message(message: str) -> str:
+    """One-line, ANSI-free rendering of a failure message.
+
+    Used for ``result_text``, which exists to be readable in tables and
+    reports; the untruncated detail stays in the need content.
+    """
+    return _WHITESPACE.sub(" ", _ANSI.sub("", message)).strip()
+
+
+def _contains(haystack: str, needle: str) -> bool:
+    """Whitespace-insensitive containment, for de-duplicating failure text."""
+    return _WHITESPACE.sub(" ", needle).strip() in _WHITESPACE.sub(" ", haystack)
+
+
+def _literal_block(title: str, body: str) -> str:
+    """An RST literal block, indented so the need content stays valid."""
+    indented = "\n".join(f"   {line.lstrip()}" for line in body.split("\n"))
+    return f"\n**{title}**::\n\n{indented}\n"
+
+
+def build_content(case: Mapping[str, object]) -> str:
+    """Need content carrying the complete failure evidence.
+
+    googletest reports one ``<failure>`` per failed assertion, each with its own
+    message and body, plus captured output -- keeping only the first of them
+    loses exactly the detail a reader needs.
+    """
+    sections: list[str] = []
+
+    parts = _result_parts(case)
+    for index, part in enumerate(parts, start=1):
+        kind = str(part.get("kind", "result")).capitalize()
+        label = f"{kind} {index}" if len(parts) > 1 else kind
+        message = str(part.get("message", ""))
+        text = str(part.get("text", ""))
+        # googletest repeats the body in the message attribute; a second copy
+        # is noise, so the message is only shown when it adds something.
+        if message and not _contains(text, message):
+            sections.append(_literal_block(f"{label} message", message))
+        if text:
+            sections.append(_literal_block(label, text))
+
+    for key, title in (("system-out", "System-out"), ("system-err", "System-err")):
+        captured = str(case.get(key, ""))
+        if captured:
+            sections.append(_literal_block(title, captured))
+
+    return "".join(sections)
+
+
+def _result_parts(case: Mapping[str, object]) -> list[Mapping[str, object]]:
+    """The case's result parts, as a typed view over the parser's output."""
+    raw = case.get("parts")
+    if not isinstance(raw, list):
+        return []
+    return [part for part in raw if isinstance(part, Mapping)]
+
+
+def _first_message(case: Mapping[str, object]) -> str:
+    for part in _result_parts(case):
+        message = str(part.get("message", ""))
+        if message and message != UNKNOWN:
+            return flatten_message(message)
+    return ""
+
+
+def _optional(value: object, absent: object) -> str:
+    """String form of an attribute, empty when the parser reported it absent."""
+    return "" if value is None or value == absent else str(value)
+
+
+def _mappings(value: object) -> list[Mapping[str, object]]:
+    """Typed view over a list of dicts coming from the parser."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _iter_cases(
+    suites: Iterable[Mapping[str, object]],
+) -> Iterator[tuple[str, Mapping[str, object]]]:
+    """Yield ``(suite_name, case)`` pairs, descending into nested suites."""
+    for suite in suites:
+        name = str(suite.get("name", ""))
+        for case in _mappings(suite.get("testcases")):
+            yield name, case
+        yield from _iter_cases(_mappings(suite.get("testsuite_nested")))
+
+
+def build_need(
+    suite_name: str,
+    case: Mapping[str, object],
+    *,
+    need_type: str = "testcase",
+    tags: Sequence[str] = (),
+    link_properties: Mapping[str, str] | None = None,
+    base_url: str = "",
+    commit: str = "",
+    url_pattern: str = DEFAULT_URL_PATTERN,
+) -> NeedItem:
+    """One test case as a need item."""
+    link_properties = link_properties or {}
+
+    classname = _optional(case.get("classname"), UNKNOWN)
+    name = _optional(case.get("name"), UNKNOWN)
+    source_file = _optional(case.get("file"), UNKNOWN)
+    source_line = _optional(case.get("line"), -1)
+    time = _optional(case.get("time"), -1)
+
+    url = source_url(base_url, commit, source_file, source_line, url_pattern)
+
+    need: NeedItem = {
+        "id": deterministic_case_id(
+            classname=classname, name=name, file=source_file, prefix=need_type
+        ),
+        "type": need_type,
+        "title": case_display_name(classname, name),
+        "content": build_content(case),
+        "tags": list(tags),
+        "name": name,
+        "classname": classname,
+        "suite": suite_name,
+        "file": source_file,
+        "line": source_line,
+        "time": time,
+        "result": RESULT_NAMES.get(
+            str(case.get("result", "")), str(case.get("result", ""))
+        ),
+        "result_text": _first_message(case),
+        # The same URL twice on purpose: external_url drives the external-needs
+        # rendering, while a plain field stays usable for needs imported as
+        # local needs (via a needs_string_links entry).
+        "external_url": url,
+        "remote_url": url,
+    }
+
+    properties = case.get("properties") or {}
+    if not isinstance(properties, Mapping):
+        properties = {}
+
+    # Link fields are emitted even when empty, so a schema can require them.
+    for property_name, link_field in link_properties.items():
+        raw = str(properties.get(property_name, ""))
+        need[link_field] = [item.strip() for item in raw.split(",") if item.strip()]
+
+    for property_name, value in properties.items():
+        if property_name in link_properties or property_name in need:
+            continue
+        need[property_name] = str(value)
+
+    return need
+
+
+def build_needs_file(
+    suites: Iterable[Mapping[str, object]],
+    *,
+    project: str = "",
+    version: str = DEFAULT_VERSION,
+    need_type: str = "testcase",
+    tags: Sequence[str] = (),
+    link_properties: Mapping[str, str] | None = None,
+    base_url: str = "",
+    commit: str = "",
+    url_pattern: str = DEFAULT_URL_PATTERN,
+) -> dict[str, object]:
+    """The complete needs.json payload for a set of parsed reports.
+
+    No ``created`` key is written: a wall clock inside a cacheable build output
+    would change the file on every run.
+    """
+    needs: dict[str, NeedItem] = {}
+    for suite_name, case in _iter_cases(suites):
+        need = build_need(
+            suite_name,
+            case,
+            need_type=need_type,
+            tags=tags,
+            link_properties=link_properties,
+            base_url=base_url,
+            commit=commit,
+            url_pattern=url_pattern,
+        )
+        needs[str(need["id"])] = need
+
+    return {
+        "project": project,
+        "current_version": version,
+        "versions": {
+            version: {
+                "needs": needs,
+                "needs_amount": len(needs),
+            }
+        },
+    }

--- a/sphinxcontrib/test_reports/remote.py
+++ b/sphinxcontrib/test_reports/remote.py
@@ -1,0 +1,66 @@
+"""Web URLs for test sources.
+
+Sphinx-free, like every module the converter CLI depends on.
+
+Only the small amount of URL handling the converter actually needs lives here:
+normalising a git remote into a browsable base, and formatting a line-anchored
+source URL. sphinx-codelinks carries a fuller implementation (giturlparse-based,
+covering more forges); when the two extensions are consolidated the machinery
+should be shared rather than duplicated -- which is why this stays deliberately
+minimal instead of growing a second forge matrix.
+"""
+
+import re
+
+#: GitHub and GitHub-compatible forges. GitLab needs ``{base}/-/blob/...``.
+DEFAULT_URL_PATTERN = "{base}/blob/{commit}/{file}#L{line}"
+
+#: ``git@host:org/repo.git`` and ``ssh://git@host/org/repo.git``.
+_SCP_STYLE = re.compile(
+    r"^(?:ssh://)?(?:[^@/]+@)?(?P<host>[^:/]+)[:/](?P<path>.+?)(?:\.git)?/?$"
+)
+
+
+def normalise_remote_url(remote_url: str) -> str:
+    """Turn a git remote into a browsable ``https`` base URL.
+
+    An already-browsable URL is returned unchanged apart from a trailing
+    ``.git``/``/``; anything unrecognised is passed through, so an explicitly
+    configured base is never mangled.
+    """
+    url = remote_url.strip()
+    if not url:
+        return ""
+
+    if url.startswith(("http://", "https://")):
+        stripped = url.rstrip("/")
+        return stripped.removesuffix(".git")
+
+    match = _SCP_STYLE.match(url)
+    if match is None:
+        return url.rstrip("/")
+
+    host = match.group("host")
+    path = match.group("path")
+    return f"https://{host}/{path}"
+
+
+def source_url(
+    base_url: str,
+    commit: str,
+    file: str,
+    line: str,
+    pattern: str = DEFAULT_URL_PATTERN,
+) -> str:
+    """Line-anchored URL of a test source, or ``""`` without repo metadata.
+
+    A hermetic build has no git remote, so the absence of metadata must yield an
+    empty field rather than a placeholder URL that looks real and 404s.
+    When the line is unknown the anchor is dropped instead of pointing at a
+    fabricated line.
+    """
+    if not base_url or not commit or not file:
+        return ""
+
+    effective_pattern = pattern if line else pattern.split("#")[0]
+    return effective_pattern.format(base=base_url, commit=commit, file=file, line=line)

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -92,7 +92,7 @@ except ImportError:
             log.debug(f"Field '{name}' already registered, skipping")
 
 
-def setup(app: Sphinx):
+def setup(app: Sphinx) -> dict[str, str | bool]:
     """
     Setup following directives:
     * test_results

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -1,0 +1,394 @@
+"""Tests for the Sphinx-free ``test-reports convert`` CLI (TR-A).
+
+This is the keystone of the build-system story: a test-XML to needs.json
+conversion that runs as a build action *outside* Sphinx, so the docs build only
+imports the result. Two properties are load-bearing and therefore tested
+explicitly rather than assumed:
+
+* the CLI must not import Sphinx -- otherwise a Bazel action pulls the whole
+  documentation toolchain into the test-result conversion;
+* the output must be byte-stable, because it is a cached build artifact and
+  qualification evidence.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+UTILS = Path(__file__).parent / "doc_test" / "utils"
+GTEST_XML = UTILS / "gtest_data.xml"
+PYTEST_XML = UTILS / "pytest_data.xml"
+
+
+def _convert(tmp_path, *args, xml=GTEST_XML):
+    """Run the converter and return (exit_code, parsed output or None)."""
+    from sphinxcontrib.test_reports.cli import main
+
+    output = tmp_path / "needs.json"
+    code = main(["convert", str(xml), "--output", str(output), *args])
+    data = json.loads(output.read_text(encoding="utf-8")) if output.exists() else None
+    return code, data
+
+
+def _needs(data):
+    version = data["current_version"]
+    return data["versions"][version]["needs"]
+
+
+class TestNoSphinxImport:
+    """The converter has to be usable without the documentation toolchain."""
+
+    def test_importing_the_cli_does_not_import_sphinx(self):
+        script = (
+            "import sys;"
+            "import sphinxcontrib.test_reports.cli;"
+            "leaked = sorted(m for m in sys.modules"
+            " if m == 'sphinx' or m.startswith(('sphinx.', 'sphinx_needs')));"
+            "print(','.join(leaked))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        assert result.stdout.strip() == ""
+
+
+class TestEnvelope:
+    def test_output_passes_the_sphinx_needs_schema(self, tmp_path):
+        from sphinx_needs.needsfile import check_needs_data
+
+        code, data = _convert(tmp_path)
+
+        assert code == 0
+        assert check_needs_data(data).schema == []
+
+    def test_envelope_carries_project_and_current_version(self, tmp_path):
+        _, data = _convert(tmp_path, "--project", "Score Docs-as-Code")
+
+        assert data["project"] == "Score Docs-as-Code"
+        assert data["current_version"] in data["versions"]
+
+    def test_needs_amount_matches_the_number_of_cases(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        version = data["versions"][data["current_version"]]
+        assert version["needs_amount"] == len(version["needs"]) == 5
+
+    def test_no_timestamp_is_written(self, tmp_path):
+        """A wall clock would defeat action caching and evidence diffs."""
+        _, data = _convert(tmp_path)
+
+        assert "created" not in data
+        assert "created" not in data["versions"][data["current_version"]]
+
+    def test_output_is_byte_stable_across_runs(self, tmp_path):
+        from sphinxcontrib.test_reports.cli import main
+
+        first = tmp_path / "first.json"
+        second = tmp_path / "second.json"
+        for output in (first, second):
+            assert main(["convert", str(GTEST_XML), "--output", str(output)]) == 0
+
+        assert first.read_bytes() == second.read_bytes()
+
+
+class TestNeedContent:
+    def test_ids_match_the_deterministic_scheme(self, tmp_path):
+        from sphinxcontrib.test_reports.identity import deterministic_case_id
+
+        _, data = _convert(tmp_path)
+
+        expected = deterministic_case_id(
+            classname="MathTest", name="Addition", file="src/math_test.cc"
+        )
+        assert expected in _needs(data)
+
+    def test_source_location_is_emitted_verbatim(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["file"] == "src/math_test.cc"
+        assert need["line"] == "12"
+
+    def test_type_and_title_are_score_shaped(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["type"] == "testcase"
+        assert need["title"] == "MathTest__Addition"
+
+    def test_result_vocabulary_includes_disabled(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__DISABLED_Division_jnyzp"]
+        assert need["result"] == "disabled"
+
+    def test_content_keeps_every_failure_part(self, tmp_path):
+        """R2: the debug output has to survive the conversion."""
+        _, data = _convert(tmp_path)
+
+        content = _needs(data)["testcase__MathTest__Subtraction_srmht"]["content"]
+        assert "Expected equality of these values" in content
+        assert "Actual: false" in content
+        assert "overflow guard hit" in content
+
+    def test_result_text_is_the_first_failure_message(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Subtraction_srmht"]
+        assert need["result_text"].startswith("src/math_test.cc:22")
+        assert "\n" not in need["result_text"]
+
+    def test_properties_become_fields(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["TestType"] == "requirements-based"
+
+    def test_tags_are_configurable(self, tmp_path):
+        _, data = _convert(tmp_path, "--tags", "TEST")
+
+        assert _needs(data)["testcase__MathTest__Addition_hcuyy"]["tags"] == ["TEST"]
+
+
+class TestLinkProperties:
+    def test_a_property_can_be_promoted_to_a_link_field(self, tmp_path):
+        _, data = _convert(
+            tmp_path, "--link-property", "PartiallyVerifies=partially_verifies"
+        )
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["partially_verifies"] == ["REQ_1", "REQ_2"]
+        assert "PartiallyVerifies" not in need
+
+    def test_link_fields_are_always_present_even_when_empty(self, tmp_path):
+        """A converter must emit its fields unconditionally, so schemas can require them."""
+        _, data = _convert(
+            tmp_path, "--link-property", "PartiallyVerifies=partially_verifies"
+        )
+
+        need = _needs(data)["testcase__MathTest__DISABLED_Division_jnyzp"]
+        assert need["partially_verifies"] == []
+
+    def test_malformed_link_property_is_rejected(self, tmp_path):
+        from sphinxcontrib.test_reports.cli import main
+
+        code = main(
+            [
+                "convert",
+                str(GTEST_XML),
+                "--output",
+                str(tmp_path / "out.json"),
+                "--link-property",
+                "NoEqualsSign",
+            ]
+        )
+
+        assert code != 0
+
+
+class TestRemoteUrls:
+    def test_external_url_and_remote_url_are_synthesized(self, tmp_path):
+        _, data = _convert(
+            tmp_path,
+            "--remote-url",
+            "https://github.com/org/repo",
+            "--commit",
+            "abc123",
+        )
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        expected = "https://github.com/org/repo/blob/abc123/src/math_test.cc#L12"
+        assert need["external_url"] == expected
+        assert need["remote_url"] == expected
+
+    def test_scp_style_remote_is_normalised(self, tmp_path):
+        _, data = _convert(
+            tmp_path,
+            "--remote-url",
+            "git@github.com:org/repo.git",
+            "--commit",
+            "abc123",
+        )
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["remote_url"].startswith("https://github.com/org/repo/blob/abc123/")
+
+    def test_url_pattern_is_configurable(self, tmp_path):
+        _, data = _convert(
+            tmp_path,
+            "--remote-url",
+            "https://gitlab.com/org/repo",
+            "--commit",
+            "abc123",
+            "--url-pattern",
+            "{base}/-/blob/{commit}/{file}#L{line}",
+        )
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["remote_url"] == (
+            "https://gitlab.com/org/repo/-/blob/abc123/src/math_test.cc#L12"
+        )
+
+    def test_without_repo_metadata_the_url_fields_are_empty(self, tmp_path):
+        """A hermetic sandbox has no git remote; that must not drop the need."""
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["remote_url"] == ""
+        assert need["external_url"] == ""
+
+
+class TestMultipleInputs:
+    def test_several_reports_are_merged_into_one_file(self, tmp_path):
+        from sphinxcontrib.test_reports.cli import main
+
+        output = tmp_path / "needs.json"
+        code = main(
+            ["convert", str(GTEST_XML), str(PYTEST_XML), "--output", str(output)]
+        )
+        data = json.loads(output.read_text(encoding="utf-8"))
+
+        assert code == 0
+        assert len(_needs(data)) > 5
+
+    def test_a_missing_input_file_exits_nonzero(self, tmp_path):
+        from sphinxcontrib.test_reports.cli import main
+
+        code = main(
+            [
+                "convert",
+                str(tmp_path / "nope.xml"),
+                "--output",
+                str(tmp_path / "out.json"),
+            ]
+        )
+
+        assert code != 0
+
+
+class TestDiagnostics:
+    def test_absent_line_attributes_warn_about_junit_family(self, tmp_path, capsys):
+        """pytest's default junit_family drops file/line; say so, don't guess."""
+        from sphinxcontrib.test_reports.cli import main
+
+        main(
+            [
+                "convert",
+                str(PYTEST_XML),
+                "--output",
+                str(tmp_path / "out.json"),
+            ]
+        )
+
+        assert "junit_family" in capsys.readouterr().err
+
+    def test_reports_with_line_attributes_do_not_warn(self, tmp_path, capsys):
+        from sphinxcontrib.test_reports.cli import main
+
+        main(["convert", str(GTEST_XML), "--output", str(tmp_path / "out.json")])
+
+        assert "junit_family" not in capsys.readouterr().err
+
+
+def test_the_cli_is_runnable_as_a_module():
+    result = subprocess.run(
+        [sys.executable, "-m", "sphinxcontrib.test_reports.cli", "convert", "--help"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "--output" in result.stdout
+
+
+def test_console_script_is_installed():
+    """The name that goes into a BUILD file has to be a real entry point."""
+    script = Path(sys.executable).parent / "test-reports"
+    if not script.exists():
+        pytest.skip("package not installed into this environment")
+
+    result = subprocess.run(
+        [str(script), "convert", "--help"], capture_output=True, text=True
+    )
+
+    assert result.returncode == 0
+    assert "--output" in result.stdout
+
+
+@pytest.mark.parametrize("flag", ["--remote-url", "--commit"])
+def test_url_synthesis_needs_both_parts(tmp_path, flag):
+    """Half the metadata cannot produce a URL; fail loudly instead of guessing."""
+    from sphinxcontrib.test_reports.cli import main
+
+    code = main(
+        [
+            "convert",
+            str(GTEST_XML),
+            "--output",
+            str(tmp_path / "out.json"),
+            flag,
+            "value",
+        ]
+    )
+
+    assert code != 0
+
+
+class TestResultVocabulary:
+    """The export uses the migration-target vocabulary, not the parser's.
+
+    The parser reports ``failure`` and must keep doing so -- it is a documented
+    need field value and a CSS class (``tr_failure``). The exported needs.json
+    is a new surface with no such obligation, and its consumers' metamodels
+    (S-CORE's included) spell it ``failed``.
+    """
+
+    def test_failure_is_exported_as_failed(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        assert (
+            _needs(data)["testcase__MathTest__Subtraction_srmht"]["result"] == "failed"
+        )
+
+    @pytest.mark.parametrize(
+        ("need_id", "expected"),
+        [
+            ("testcase__MathTest__Addition_hcuyy", "passed"),
+            ("testcase__MathTest__DISABLED_Division_jnyzp", "disabled"),
+            ("testcase__ParamTest_0__Legacy_owuvz", "skipped"),
+        ],
+    )
+    def test_other_results_are_unchanged(self, tmp_path, need_id, expected):
+        _, data = _convert(tmp_path)
+
+        assert _needs(data)[need_id]["result"] == expected
+
+
+class TestContentIsNotDuplicated:
+    """googletest repeats the failure text in the message attribute.
+
+    Emitting both verbatim shows the same stack trace twice in the rendered
+    need; the message block is only worth its space when it says something the
+    body does not.
+    """
+
+    def test_a_message_contained_in_the_body_is_not_repeated(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        content = _needs(data)["testcase__MathTest__Subtraction_srmht"]["content"]
+        assert content.count("Expected equality of these values") == 1
+        assert "message" not in content
+
+    def test_a_message_absent_from_the_body_is_kept(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        content = _needs(data)["testcase__ParamTest_0__Legacy_owuvz"]["content"]
+        assert "Skipped via GTEST_SKIP" in content
+        assert "not applicable on this platform" in content

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -61,12 +61,18 @@ class TestNoSphinxImport:
 
 class TestEnvelope:
     def test_output_passes_the_sphinx_needs_schema(self, tmp_path):
-        from sphinx_needs.needsfile import check_needs_data
+        """The output must validate against sphinx-needs' own needs.json schema."""
+        needsfile = pytest.importorskip("sphinx_needs.needsfile")
+        if not hasattr(needsfile, "check_needs_data"):
+            # Older sphinx-needs releases do not ship the schema check; the
+            # envelope contract itself is version-independent, so skip rather
+            # than pin the whole suite to the newest sphinx-needs.
+            pytest.skip("sphinx-needs has no check_needs_data")
 
         code, data = _convert(tmp_path)
 
         assert code == 0
-        assert check_needs_data(data).schema == []
+        assert needsfile.check_needs_data(data).schema == []
 
     def test_envelope_carries_project_and_current_version(self, tmp_path):
         _, data = _convert(tmp_path, "--project", "Score Docs-as-Code")


### PR DESCRIPTION
Last of four. **Stacked on #143.**

The gap with nothing behind it: there was no CLI at all, so producing test-case needs required running a documentation build. Parsing test results inside the docs build couples the two — results cannot be converted without building docs, the conversion cannot be cached by a build system, and the data is unavailable to anything else.

```bash
test-reports convert bazel-testlogs/*/test.xml --output needs.json \
    --remote-url git@github.com:org/repo.git --commit "$(git rev-parse HEAD)" \
    --link-property PartiallyVerifies=partially_verifies
```

The docs build then only imports the result, via `needimport` or `needs_external_needs`.

## Two properties are load-bearing, so both are tested rather than assumed

- **No Sphinx import.** Otherwise a build action pulls the whole documentation toolchain into a test-result conversion — the antipattern this work exists to remove. `__init__.py` now resolves `setup` lazily (PEP 562), because importing *any* submodule previously imported Sphinx. A test asserts that no `sphinx`/`sphinx_needs` module is loaded after importing the CLI.
- **Byte-stable output.** Sorted keys, fixed indent, no `created` timestamp — the file is a cached build-action output and, in a qualification context, evidence; a wall clock inside it would change it on every run. `created` is optional in the needs.json schema, so this stays conform, and a test validates the output with sphinx-needs' own `check_needs_data`.

## What each need carries

The deterministic ID from #143, the source location under `file`/`line`, `result`, a one-line `result_text`, and the full failure evidence in the content. XML properties become fields; `--link-property` promotes chosen ones to link fields, comma-split and emitted even when empty so a schema can require them.

The synthesized source URL appears **twice**: as `external_url`, which sphinx-needs uses when rendering a link to an external need, and as a plain `remote_url` field, so needs imported as *local* needs keep a clickable link through a `needs_string_links` entry.

## Three decisions worth a reviewer's attention

- **`--remote-url` and `--commit` are both-or-neither**, and without them the URL fields are empty rather than a placeholder that looks real and then 404s. Git remotes in scp form are normalised; `--url-pattern` covers forges that lay out blob URLs differently (GitLab's `/-/blob/`). The URL handling is deliberately minimal — `sphinx-codelinks` already has a fuller giturlparse-based implementation, and the two should be shared rather than duplicated a second time.
- **The export normalises the parser's `failure` to `failed`.** The parser cannot change (documented field value, `tr_failure` CSS class), but exported data has no such obligation and consuming metamodels spell it `failed`. This does mean the directive path and the CLI report the same case differently; it is deliberate and documented.
- **googletest repeats the failure body in the message attribute**, so the message block is emitted only when it says something the body does not — otherwise every failing case shows its stack trace twice.

Reports without `line` attributes get a warning naming `junit_family`. The directive path stays silent on purpose: warning there would newly break `-W` docs builds of existing pytest projects.

## Verification

35 new tests. 139 passing, mypy strict and pre-commit clean, docs build clean with `-W`. New `docs/cli.rst`.