### PR TITLE
feat(config): declarative [test_reports] section in ubproject.toml

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,12 @@ Unreleased
 * Feature: New ``tr_deterministic_case_ids`` option derives test-case IDs from
   the source location instead of the need content, so an ID no longer changes
   when a test starts failing differently.
+* Feature: Declarative configuration in the ``[test_reports]`` section of
+  ``ubproject.toml``, the file shared with the other useblocks tooling, so a
+  project is described once instead of being restated in ``conf.py``. The file
+  is searched for upwards from the ``confdir``, stopping at the project root;
+  the new ``tr_config_from_toml`` names or disables it. Precedence is ``-D`` >
+  ``ubproject.toml`` > ``conf.py`` > default. See :ref:`tr_config_from_toml`.
 * Support: Python 3.10 is no longer supported. It reached the end of upstream
   support, and dropping it lets the package read TOML with ``tomllib`` from the
   standard library instead of carrying a backport.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,8 @@ Unreleased
 * Feature: Declarative configuration in the ``[test_reports]`` section of
   ``ubproject.toml``, the file shared with the other useblocks tooling, so a
   project is described once instead of being restated in ``conf.py``. The file
-  is searched for upwards from the ``confdir``, stopping at the project root;
+  is searched for upwards from the ``confdir``, stopping at the repository
+  root;
   the new ``tr_config_from_toml`` names or disables it. Precedence is ``-D`` >
   ``ubproject.toml`` > ``conf.py`` > default. See :ref:`tr_config_from_toml`.
 * Support: Python 3.10 is no longer supported. It reached the end of upstream

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,5 +1,7 @@
 :hide-navigation:
 
+.. _configuration:
+
 Configuration
 =============
 The following options can be set inside the ``conf.py`` file of your Sphinx project.
@@ -401,3 +403,88 @@ An example of a JSON file, which supports the below configuration, can be seen i
          }
       }
    }
+
+Declarative configuration (ubproject.toml)
+------------------------------------------
+.. versionadded:: 1.5.0
+
+All of the above can also be configured declaratively, in the
+``[test_reports]`` section of your project's ``ubproject.toml`` -- the same
+shared file other useblocks tooling (sphinx-needs, sphinx-codelinks,
+sphinx-mounts, ubCode) reads. It describes the project once, so every tool
+acting on it works from the same settings instead of each restating them.
+
+.. code-block:: toml
+
+   [test_reports]
+   file_option = "report_file"
+   source_file_option = "file"
+   source_line_option = "line"
+   deterministic_case_ids = true
+   extra_options = ["more_info", "priority"]
+   property_link_types = { request = "req" }
+   rootdir = "docs"
+
+   # Need types: named tables (recommended) ...
+   [test_reports.case]
+   directive = "test-case"
+   type = "testcase"
+   name = "Test-Case"
+   prefix = "TC_"
+   color = "#999999"
+   style = "rectangle"
+
+   # ... or the positional list spelling of conf.py:
+   # case = ["test-case", "testcase", "Test-Case", "TC_", "#999999", "rectangle"]
+
+**Keys.** Every key is named like its ``tr_*`` config value without the prefix
+(``file_option`` configures ``tr_file_option``, and so on). A key carrying the
+wrong type is an error -- that is the typo class this validation exists to
+catch. An *unknown* key is reported as a warning and ignored: the file is
+shared with tools on independent release cadences, so a key this version does
+not model must not take your build down. Add ``"test_reports.unknown_key"`` to
+Sphinx's ``suppress_warnings`` to silence that report in a project that builds
+with ``-W``.
+
+Sub-tables belonging to other tools are left alone. Settings for converting
+test reports into a ``needs.json`` outside Sphinx live under
+``[test_reports.convert]``, which this extension does not read.
+
+**Precedence.** ``-D`` on the ``sphinx-build`` command line beats the TOML
+file, which beats ``conf.py``, which beats the built-in default. The
+declarative file is the source of truth for the project; the command line stays
+the per-invocation escape hatch.
+
+**Paths.** Relative values of ``rootdir`` and ``report_template`` are resolved
+against the directory containing the TOML file (not against ``conf.py`` or the
+working directory), so both consumers resolve them identically and the file
+stays self-describing when moved as a unit.
+
+**Deterministic IDs.** A build that imports a ``needs.json`` carrying
+deterministic case IDs, next to locally created test-case needs, must set
+``deterministic_case_ids = true`` so both ID schemes agree.
+
+.. _tr_config_from_toml:
+
+tr_config_from_toml
+~~~~~~~~~~~~~~~~~~~
+.. versionadded:: 1.5.0
+
+Name of the declarative configuration file whose ``[test_reports]`` section is
+applied to the ``tr_*`` values above. Defaults to ``ubproject.toml``.
+
+With the default name, the file is searched for in your ``confdir`` and its
+parent directories, stopping at the project root (a directory holding ``.git``
+or ``pyproject.toml``). That is what lets the canonical layout work -- the
+shared ``ubproject.toml`` at the repository root, ``conf.py`` in ``docs/`` --
+and lets a tool started anywhere below the root find exactly the same file by
+searching upward in the same way. A missing default file is not an error.
+
+Set to any other value to name a file explicitly; it is resolved against the
+``confdir``, is not searched for, and a warning is emitted if it does not
+exist. Set to ``None`` to switch declarative configuration off entirely.
+
+.. code-block:: python
+
+   tr_config_from_toml = "../ubproject.toml"   # explicit path
+   tr_config_from_toml = None                  # disable

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -442,13 +442,19 @@ acting on it works from the same settings instead of each restating them.
 wrong type is an error -- that is the typo class this validation exists to
 catch. An *unknown* key is reported as a warning and ignored: the file is
 shared with tools on independent release cadences, so a key this version does
-not model must not take your build down. Add ``"test_reports.unknown_key"`` to
-Sphinx's ``suppress_warnings`` to silence that report in a project that builds
-with ``-W``.
+not model must not take your build down.
 
-Sub-tables belonging to other tools are left alone. Settings for converting
-test reports into a ``needs.json`` outside Sphinx live under
-``[test_reports.convert]``, which this extension does not read.
+One sub-table belongs to another tool and is left alone: the settings for
+converting test reports into a ``needs.json`` outside Sphinx live under
+``[test_reports.convert]``, which this extension does not read. Any other
+sub-table is treated like any other unknown key -- reported and ignored.
+
+**Warnings.** The two warnings this feature emits carry a type, so either can
+be silenced through Sphinx's ``suppress_warnings`` in a project that builds
+with ``-W``: ``test_reports.unknown_key`` for the unknown-key report above, and
+``test_reports.missing_config`` for an explicitly named file that does not
+exist (see :ref:`tr_config_from_toml`). A known key with the wrong type is an
+error, not a warning, and cannot be suppressed.
 
 **Precedence.** ``-D`` on the ``sphinx-build`` command line beats the TOML
 file, which beats ``conf.py``, which beats the built-in default. The
@@ -474,15 +480,22 @@ Name of the declarative configuration file whose ``[test_reports]`` section is
 applied to the ``tr_*`` values above. Defaults to ``ubproject.toml``.
 
 With the default name, the file is searched for in your ``confdir`` and its
-parent directories, stopping at the project root (a directory holding ``.git``
-or ``pyproject.toml``). That is what lets the canonical layout work -- the
-shared ``ubproject.toml`` at the repository root, ``conf.py`` in ``docs/`` --
-and lets a tool started anywhere below the root find exactly the same file by
-searching upward in the same way. A missing default file is not an error.
+parent directories, up to the repository root (the directory holding ``.git``).
+That is what lets the canonical layout work -- the shared ``ubproject.toml`` at
+the repository root, ``conf.py`` in ``docs/`` -- and lets a tool started
+anywhere below the root find exactly the same file by searching upward in the
+same way. Only the repository root bounds the search: a ``pyproject.toml`` on
+the way up does not, so a ``docs/`` directory with its own ``pyproject.toml``
+and the documentation of a workspace member in a monorepo
+(``packages/<name>/docs/conf.py``) both find the file at the root. A missing
+default file is not an error; ``sphinx-build -v`` reports where the search
+ended.
 
 Set to any other value to name a file explicitly; it is resolved against the
-``confdir``, is not searched for, and a warning is emitted if it does not
-exist. Set to ``None`` to switch declarative configuration off entirely.
+``confdir``, is not searched for, and a warning of type
+``test_reports.missing_config`` is emitted if it does not exist -- the build
+then runs on the ``conf.py`` configuration. Set to ``None`` to switch
+declarative configuration off entirely.
 
 .. code-block:: python
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,6 +9,8 @@ The following options can be set inside the ``conf.py`` file of your Sphinx proj
 .. contents::
    :local:
 
+.. _tr_rootdir:
+
 tr_rootdir
 ----------
 ``tr_rootdir`` takes a path, which is used as *root dir* for all provided file paths in other directives.
@@ -72,6 +74,8 @@ By default ``tr_case`` is set to::
    ['test-case', 'testcase', 'test-case', 'TC_', '#999999', 'node']
 
 Please read :ref:`tr_file` for more details.
+
+.. _tr_report_template:
 
 tr_report_template
 ------------------
@@ -423,6 +427,8 @@ acting on it works from the same settings instead of each restating them.
    deterministic_case_ids = true
    extra_options = ["more_info", "priority"]
    property_link_types = { request = "req" }
+   # Base directory the directives look their report files up under -- not an
+   # output directory. Relative to this file, see Paths below.
    rootdir = "docs"
 
    # Need types: named tables (recommended) ...
@@ -462,10 +468,15 @@ file, which beats ``conf.py``, which beats the built-in default. The
 declarative file is the source of truth for the project; the command line stays
 the per-invocation escape hatch.
 
-**Paths.** Relative values of ``rootdir`` and ``report_template`` are resolved
-against the directory containing the TOML file (not against ``conf.py`` or the
-working directory), so both consumers resolve them identically and the file
-stays self-describing when moved as a unit.
+**Paths.** ``rootdir`` (:ref:`tr_rootdir`) is the directory the relative report
+paths in the directives are resolved against -- with ``rootdir = "docs"``,
+``.. test-file:: reports/pytest.xml`` reads ``docs/reports/pytest.xml``. It is
+an input location, not an output directory: nothing is written there.
+``report_template`` (:ref:`tr_report_template`) names a custom template file.
+Relative values of both are resolved against the directory containing the TOML
+file (not against ``conf.py`` or the working directory), so both consumers
+resolve them identically and the file stays self-describing when moved as a
+unit.
 
 **Deterministic IDs.** A build that imports a ``needs.json`` carrying
 deterministic case IDs, next to locally created test-case needs, must set

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -444,10 +444,11 @@ catch. An *unknown* key is reported as a warning and ignored: the file is
 shared with tools on independent release cadences, so a key this version does
 not model must not take your build down.
 
-One sub-table belongs to another tool and is left alone: the settings for
-converting test reports into a ``needs.json`` outside Sphinx live under
-``[test_reports.convert]``, which this extension does not read. Any other
-sub-table is treated like any other unknown key -- reported and ignored.
+One sub-table belongs to another tool and is left alone: ``[test_reports.build]``
+holds the settings of the ``test-reports build`` command line, one sub-table per
+artifact it produces -- ``[test_reports.build.needs]`` for turning test reports
+into a ``needs.json`` outside Sphinx -- none of which this extension does. Any
+other sub-table is treated like any other unknown key -- reported and ignored.
 
 **Warnings.** The two warnings this feature emits carry a type, so either can
 be silenced through Sphinx's ``suppress_warnings`` in a project that builds

--- a/sphinxcontrib/test_reports/__init__.py
+++ b/sphinxcontrib/test_reports/__init__.py
@@ -21,14 +21,16 @@ def __getattr__(name: str) -> object:
             # with getattr(), which only tolerates AttributeError. Resolving
             # lazily would let a missing sphinx-needs escape as a raw
             # traceback, so the message Sphinx would have produced is raised
-            # here instead -- when Sphinx is there to receive it.
+            # here instead -- when Sphinx is there to receive it. The wrapped
+            # exception goes in the second argument only: ExtensionError.__str__
+            # renders it as "(exception: ...)", so spelling it out in the
+            # message too would print it twice.
             try:
                 from sphinx.errors import ExtensionError
             except ImportError:
                 raise error from None
             raise ExtensionError(
-                f"Could not import extension {__name__} (exception: {error})",
-                error,
+                f"Could not import extension {__name__}", error
             ) from error
 
         return setup

--- a/sphinxcontrib/test_reports/__init__.py
+++ b/sphinxcontrib/test_reports/__init__.py
@@ -1,4 +1,35 @@
-# from sphinxcontrib.test_reports.needs.dyn_functions import Results4Needs
-from sphinxcontrib.test_reports.test_reports import setup
+"""Sphinx-Test-Reports.
+
+``setup`` is resolved lazily (PEP 562) so that importing a submodule of this
+package does not import Sphinx: :mod:`sphinxcontrib.test_reports.projectconfig`
+is read by consumers that are not a documentation build, in environments where
+the documentation toolchain is not installed, and every import of it runs this
+file first. Sphinx still finds ``setup`` through normal attribute access when it
+loads this package as an extension.
+"""
 
 __all__ = ["setup"]
+
+
+def __getattr__(name: str) -> object:
+    if name == "setup":
+        try:
+            from sphinxcontrib.test_reports.test_reports import setup
+        except ImportError as error:
+            # Sphinx wraps an ImportError from importing the *package* in a
+            # clean "Could not import extension" message, but fetches `setup`
+            # with getattr(), which only tolerates AttributeError. Resolving
+            # lazily would let a missing sphinx-needs escape as a raw
+            # traceback, so the message Sphinx would have produced is raised
+            # here instead -- when Sphinx is there to receive it.
+            try:
+                from sphinx.errors import ExtensionError
+            except ImportError:
+                raise error from None
+            raise ExtensionError(
+                f"Could not import extension {__name__} (exception: {error})",
+                error,
+            ) from error
+
+        return setup
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -1,0 +1,397 @@
+"""Declarative project configuration for sphinx-test-reports.
+
+Reads the ``[test_reports]`` section of a project's ``ubproject.toml`` -- the
+declarative file shared with the other useblocks tooling (sphinx-needs,
+sphinx-codelinks, sphinx-mounts, ubCode) -- so that a project is described once
+instead of being restated in every tool that acts on it.
+
+**Nothing in this module may import Sphinx.** The section describes the project,
+not this extension, and a report-to-``needs.json`` converter has to be able to
+read it as a build action without the documentation toolchain installed.
+
+The keys are the Sphinx-facing configuration (:data:`BRIDGE_KEYS`), spelled
+like the ``tr_*`` config values without the prefix. The section may also carry
+sub-tables for tools other than the Sphinx extension -- a report converter
+reads ``[test_reports.convert]`` -- which this reader does not interpret.
+
+**Error policy.** A known key carrying the wrong type is fatal: that is the
+typo class this validation exists to catch, and letting it through would
+silently change what gets produced. An *unknown* key is only reported. The
+file is shared with tools on independent release cadences, so a key this
+reader does not model is routine rather than a mistake -- and aborting on it
+would take down every build of the project on every older sphinx-test-reports,
+including builds the key would not have changed. This is the same posture
+sphinx-mounts takes for ``[[source.mounts]]``.
+"""
+
+import tomllib
+from pathlib import Path
+from typing import Callable, Mapping, NoReturn, Sequence
+
+#: Default file the configuration is read from. Looked up by walking up from
+#: the ``confdir`` (Sphinx) or the working directory (a converter); see
+#: :func:`find_project_config`. ``ubproject.toml`` is the convention shared
+#: with other useblocks tooling so a single declarative file describes the
+#: project to every downstream consumer -- Sphinx, ubCode, a converter --
+#: without
+#: any of them having to execute Python.
+DEFAULT_TOML_FILENAME = "ubproject.toml"
+
+#: The section this extension owns inside the shared file. Spelled
+#: ``snake_case`` like every other section of ``ubproject.schema.json``
+#: (``build_tags``, ``format_rst``, ``needs_json``, ``rst_lint``, ...); note
+#: that ``[reports]`` is already taken, and means report *templates*.
+SECTION = "test_reports"
+
+#: Directory entries that end the upward search of
+#: :func:`find_project_config`. A directory carrying one of these is a project
+#: root, so a consumer below it must not silently adopt the configuration of
+#: an unrelated parent project. ``ubproject.toml`` itself is not listed --
+#: finding it is the success case, checked first.
+_ROOT_MARKERS = (".git", "pyproject.toml")
+
+#: Section keys bridged onto their ``tr_*`` Sphinx config values.
+BRIDGE_KEYS = (
+    "file",
+    "suite",
+    "case",
+    "file_option",
+    "source_file_option",
+    "source_line_option",
+    "rootdir",
+    "report_template",
+    "suite_id_length",
+    "case_id_length",
+    "import_encoding",
+    "extra_options",
+    "property_link_types",
+    "json_mapping",
+    "deterministic_case_ids",
+)
+
+#: Keys holding a path. Relative values are anchored against the directory
+#: containing the TOML file, not against ``confdir`` or the process working
+#: directory: the file is self-describing, and moving it as a unit keeps its
+#: relative paths meaningful. It also makes every consumer resolve a
+#: relative path identically.
+PATH_KEYS = ("rootdir", "report_template")
+
+#: The keys whose need-type setting accepts both the positional ``conf.py``
+#: list and a named table; :func:`_normalise_type_entry` reduces both to the
+#: list form. ``None`` in :data:`_KEY_TYPES` marks exactly these.
+_DUAL_SPELLING_KEYS = ("file", "suite", "case")
+
+#: Sub-tables of the section that belong to another consumer. They are
+#: recognised so they do not draw an unknown-key warning, and deliberately not
+#: interpreted: ``convert`` holds the settings for turning test reports into a
+#: ``needs.json`` outside Sphinx, which this extension never does.
+FOREIGN_TABLES = ("convert",)
+
+#: Expected Python type per key. ``bool`` must be checked *before* ``int``
+#: (bool is an int subclass). ``None`` marks the dual-spelling keys, which are
+#: normalised separately; path keys are validated as ``str`` and anchored
+#: afterwards.
+_KEY_TYPES: dict[str, type[object] | None] = {
+    "file": None,
+    "suite": None,
+    "case": None,
+    "file_option": str,
+    "source_file_option": str,
+    "source_line_option": str,
+    "rootdir": str,
+    "report_template": str,
+    "suite_id_length": int,
+    "case_id_length": int,
+    "import_encoding": str,
+    "extra_options": list,
+    "property_link_types": dict,
+    "json_mapping": dict,
+    "deterministic_case_ids": bool,
+    "convert": dict,
+}
+
+#: Required type of the *values* inside a table-valued key. Without this a
+#: table passes validation on its outer shape alone, and a mistake such as
+#: ``property_link_types = { request = ["req"] }`` reaches the directives,
+#: which fail with a bare ``TypeError`` on an unhashable field name.
+#: ``None`` means the nested shape is free-form -- ``json_mapping`` mirrors an
+#: arbitrary parser mapping -- so only the outer table is checked.
+_DICT_VALUE_TYPES: dict[str, type[object] | None] = {
+    "property_link_types": str,
+    "json_mapping": None,
+    "convert": None,
+}
+
+#: Field order of the positional ``tr_file``-style lists, and the table keys
+#: that spell the same thing readably.
+_TYPE_ENTRY_FIELDS = ("directive", "type", "name", "prefix", "color", "style")
+
+#: ``tomllib.TOMLDecodeError`` bound through an annotation: the attribute
+#: expression itself is typed loosely enough to trip the strict ``Any`` bans,
+#: and an ``except`` clause has no annotation of its own to absorb it.
+_TOML_DECODE_ERROR: type[Exception] = tomllib.TOMLDecodeError
+
+
+class TomlConfigError(Exception):
+    """Raised when the declarative config cannot be parsed or is malformed.
+
+    Deliberately *not* a ``SphinxError``: this module must stay importable
+    without Sphinx. The Sphinx-side bridge re-raises it as an
+    ``InvalidConfigurationError`` to abort the build; a non-Sphinx consumer
+    reports it and exits non-zero.
+    """
+
+
+def find_project_config(
+    start: Path, filename: str = DEFAULT_TOML_FILENAME
+) -> Path | None:
+    """Search *start* and its parents for *filename*.
+
+    The declarative file conventionally sits at the project root while its
+    consumers run from below it -- ``conf.py`` in ``docs/``, a build action
+    from wherever CI invoked it -- so anchoring strictly at the caller's own
+    directory would leave the shared file unread by one of them, silently.
+
+    The walk stops at the first directory holding *filename*, and at a
+    directory that looks like a project root (:data:`_ROOT_MARKERS`) even when
+    it does not hold the file, so a consumer never adopts the configuration of
+    an unrelated parent project.
+
+    :return: The file, or ``None`` when the search reached a project root or
+        the filesystem root without finding one.
+    """
+    for directory in (start, *start.parents):
+        candidate = directory / filename
+        if candidate.is_file():
+            return candidate
+        if any((directory / marker).exists() for marker in _ROOT_MARKERS):
+            return None
+    return None
+
+
+def load_project_config(
+    path: Path, warn: Callable[[str], None] | None = None
+) -> dict[str, object] | None:
+    """Read and normalise the ``[test_reports]`` section of a TOML file.
+
+    :param path: Absolute path to the TOML file (``ubproject.toml`` or whatever
+        the caller resolved).
+    :param warn: Called with a message for every non-fatal problem -- today,
+        an unknown key. Callers pass their own logger so this module stays
+        Sphinx-free; ``None`` discards the reports.
+    :return: The normalised section as a plain dict; ``None`` when the file
+        does not exist (an absence is not an error -- callers decide whether
+        that is fine, e.g. neither consumer minds a missing *default* file but
+        both complain about an explicitly given one). An existing file without
+        the section yields ``{}``.
+    :raises TomlConfigError: If the file cannot be read, is not valid TOML, the
+        section has the wrong shape, or a known key has the wrong type.
+    """
+    if not path.is_file():
+        return None
+    data = _read_toml(path)
+
+    section = data.get(SECTION)
+    if section is None:
+        return {}
+    if not isinstance(section, dict):
+        msg = f"{path}: [{SECTION}] must be a table, got {type(section).__name__}"
+        raise TomlConfigError(msg)
+
+    return _normalise_section(section, path, warn)
+
+
+def _read_toml(path: Path) -> dict[str, object]:
+    """Parse *path*, reporting every read failure as a ``TomlConfigError``.
+
+    ``is_file()`` succeeding does not mean the open will: the file may be
+    unreadable, or replaced between the check and the open. Both consumers
+    handle ``TomlConfigError`` and neither handles a bare ``OSError``, so an
+    unwrapped one surfaces as a traceback instead of a configuration error.
+    """
+    try:
+        with path.open("rb") as handle:
+            # tomllib is typed ``-> dict[str, Any]``; everything downstream of
+            # here is ``object`` so the strict Any bans hold for the rest of
+            # the module.
+            data: dict[str, object] = tomllib.load(handle)
+    except _TOML_DECODE_ERROR as error:
+        msg = f"{path}: invalid TOML: {error}"
+        raise TomlConfigError(msg) from error
+    except OSError as error:
+        msg = f"{path}: cannot be read: {error}"
+        raise TomlConfigError(msg) from error
+    return data
+
+
+def _normalise_section(
+    section: Mapping[str, object], path: Path, warn: Callable[[str], None] | None
+) -> dict[str, object]:
+    """Validate every key and return a normalised copy of *section*.
+
+    Normalisation: relative paths become absolute (anchored at the TOML file's
+    directory), the ``file``/``suite``/``case`` need-type settings accept both
+    the positional-list spelling of ``conf.py`` and a named table.
+
+    Unknown keys are reported through *warn* and dropped -- see the module
+    docstring for why they are not fatal.
+    """
+    unknown = sorted(set(section) - set(_KEY_TYPES))
+    if unknown and warn is not None:
+        warn(
+            f"{path}: ignoring unknown key(s) in [{SECTION}]: "
+            f"{', '.join(unknown)}. Supported keys: "
+            f"{', '.join(sorted(_KEY_TYPES))}"
+        )
+
+    normalised: dict[str, object] = {}
+    for key, value in section.items():
+        if key in unknown:
+            continue
+        expected = _KEY_TYPES[key]
+        # bool first: bool is an int subclass, and for int keys a TOML
+        # ``true`` must be rejected, not silently accepted.
+        if expected is int and isinstance(value, bool):
+            _wrong_type(key, value, expected, path)
+        if expected is not None and not isinstance(value, expected):
+            _wrong_type(key, value, expected, path)
+        if key in FOREIGN_TABLES:
+            normalised[key] = value
+        elif key in _DUAL_SPELLING_KEYS:
+            normalised[key] = _normalise_type_entry(key, value, path)
+        else:
+            if expected is list:
+                _check_list_items(key, value, path)
+            elif expected is dict:
+                _check_table_values(key, value, path)
+            normalised[key] = value
+
+    return _anchor_paths(normalised, path.parent)
+
+
+def _check_list_items(key: str, value: object, path: Path) -> None:
+    """Every element of an array-valued key must be a string."""
+    if not isinstance(value, Sequence):
+        return
+    for item in value:
+        if not isinstance(item, str):
+            _wrong_type(key, value, list, path)
+
+
+def _check_table_values(key: str, value: object, path: Path) -> None:
+    """Every value of a table-valued key must have the declared type.
+
+    Skipped for keys whose nested shape is free-form (:data:`_DICT_VALUE_TYPES`
+    maps them to ``None``).
+    """
+    expected = _DICT_VALUE_TYPES.get(key)
+    if expected is None or not isinstance(value, Mapping):
+        return
+    for name, item in value.items():
+        if not isinstance(item, expected):
+            msg = (
+                f"{path}: [{SECTION}] {key}.{name} must be "
+                f"{_type_label(expected)}, got {type(item).__name__}: {item!r}"
+            )
+            raise TomlConfigError(msg)
+
+
+def _wrong_type(
+    key: str, value: object, expected: type[object] | None, path: Path
+) -> NoReturn:
+    msg = (
+        f"{path}: [{SECTION}] {key} must be "
+        f"{_type_label(expected)}, got {type(value).__name__}: {value!r}"
+    )
+    raise TomlConfigError(msg)
+
+
+def _type_label(expected: type[object] | None) -> str:
+    if expected is None:
+        return "a 6-element array or a table"
+    if expected is int:
+        return "an integer"
+    if expected is bool:
+        return "a boolean"
+    if expected is str:
+        return "a string"
+    if expected is list:
+        return "an array of strings"
+    if expected is dict:
+        return "a table"
+    return expected.__name__
+
+
+def _normalise_type_entry(key: str, value: object, path: Path) -> list[str]:
+    """The ``file``/``suite``/``case`` settings in one of two spellings.
+
+    Positional (exactly what ``conf.py`` accepts)::
+
+        file = ["test-file", "testfile", "Test-File", "TF_", "#ffffff", "node"]
+
+    Named -- the recommended TOML spelling, since six bare strings in a row
+    cannot be told apart::
+
+        [test_reports.file]
+        directive = "test-file"
+        type = "testfile"
+        name = "Test-File"
+        prefix = "TF_"
+        color = "#ffffff"
+        style = "node"
+    """
+    if isinstance(value, list):
+        entry = [item for item in value if isinstance(item, str)]
+        if len(entry) != len(_TYPE_ENTRY_FIELDS) or len(entry) != len(value):
+            msg = (
+                f"{path}: [{SECTION}] {key} as an array must hold exactly "
+                f"{len(_TYPE_ENTRY_FIELDS)} strings "
+                f"({'/'.join(_TYPE_ENTRY_FIELDS)}), got {value!r}"
+            )
+            raise TomlConfigError(msg)
+        return entry
+
+    if isinstance(value, Mapping):
+        table: dict[str, object] = {str(name): item for name, item in value.items()}
+        missing = [field for field in _TYPE_ENTRY_FIELDS if field not in table]
+        unknown = sorted(set(table) - set(_TYPE_ENTRY_FIELDS))
+        wrong = sorted(
+            field
+            for field in _TYPE_ENTRY_FIELDS
+            if field in table and not isinstance(table[field], str)
+        )
+        problems = []
+        if missing:
+            problems.append(f"missing {', '.join(missing)}")
+        if unknown:
+            problems.append(f"unknown {', '.join(unknown)}")
+        if wrong:
+            problems.append(f"non-string {', '.join(wrong)}")
+        if problems:
+            msg = (
+                f"{path}: [{SECTION}] [{SECTION}.{key}]: "
+                f"{'; '.join(problems)}. Expected the keys "
+                f"{'/'.join(_TYPE_ENTRY_FIELDS)}."
+            )
+            raise TomlConfigError(msg)
+        return [str(table[field]) for field in _TYPE_ENTRY_FIELDS]
+
+    msg = (
+        f"{path}: [{SECTION}] {key} must be a 6-element array or a table, "
+        f"got {type(value).__name__}"
+    )
+    raise TomlConfigError(msg)
+
+
+def _anchor_paths(section: dict[str, object], base: Path) -> dict[str, object]:
+    """Resolve :data:`PATH_KEYS` against *base* (the TOML file's directory).
+
+    Joined but deliberately not ``resolve()``d: *base* is already absolute, and
+    resolving would collapse symlinks that the ``conf.py`` spelling of the same
+    option preserves, so the two spellings would not name the same directory.
+    """
+    for key in PATH_KEYS:
+        value = section.get(key)
+        if isinstance(value, str) and not Path(value).is_absolute():
+            section[key] = str(base / value)
+    return section

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -54,10 +54,22 @@ SECTION = "test_reports"
 #: ``pyproject.toml`` beside ``conf.py``, or a workspace member in a monorepo
 #: (``packages/<name>/pyproject.toml`` with the docs below it), sits *inside*
 #: the project whose shared file is at the repository root, and a marker there
-#: would end the search before it reached the file -- silently.
+#: would end the search before it reached the file -- silently. It does bound
+#: the walk where there is no repository at all, see :data:`_DIST_MARKERS`.
 #: ``ubproject.toml`` itself is not listed -- finding it is the success case,
 #: checked first in every directory.
 _ROOT_MARKERS = (".git",)
+
+#: Directory entries that end the search when *no* :data:`_ROOT_MARKERS` marker
+#: exists anywhere above the starting directory. A tree outside any repository
+#: -- an unpacked sdist, a CI artefact directory, an exported docs tree -- has
+#: nothing to bound the walk, so it would reach the filesystem root and adopt
+#: the configuration of whatever unrelated directory happens to sit above it.
+#: The distribution root is the outermost thing that still belongs to such a
+#: tree. It bounds the search only as a fallback, never inside a repository:
+#: there, a ``pyproject.toml`` on the way up is a workspace member or a
+#: ``docs/`` dependency set, and must not end the search.
+_DIST_MARKERS = ("pyproject.toml",)
 
 #: Section keys bridged onto their ``tr_*`` Sphinx config values.
 BRIDGE_KEYS = (
@@ -164,12 +176,13 @@ def find_project_config(
     from wherever CI invoked it -- so anchoring strictly at the caller's own
     directory would leave the shared file unread by one of them, silently.
 
-    The walk ends at the first directory holding *filename*, or at the
-    repository root (:data:`_ROOT_MARKERS`) when that does not hold the file
-    either: nothing above the root belongs to the project, so a consumer never
-    adopts the configuration of an unrelated parent. Nothing else bounds the
-    search -- in particular a ``pyproject.toml`` on the way up does not, see
-    :data:`_ROOT_MARKERS` for why.
+    The walk ends at the first directory holding *filename*, or at the project
+    boundary when that does not hold the file either: nothing above the
+    boundary belongs to the project, so a consumer never adopts the
+    configuration of an unrelated parent. The boundary is the repository root
+    (:data:`_ROOT_MARKERS`), or -- outside any repository only -- the
+    distribution root (:data:`_DIST_MARKERS`); see both for why a
+    ``pyproject.toml`` bounds the one case and not the other.
 
     :param start: Directory to start from. Made absolute -- without resolving
         symlinks -- so that a relative path has parents to walk.
@@ -179,27 +192,45 @@ def find_project_config(
         missing file is not necessarily a problem -- most projects have none
         -- but a fruitless search must not be silent, or a misplaced file
         cannot be diagnosed.
-    :return: The file, or ``None`` when the search reached the repository root
+    :return: The file, or ``None`` when the search reached the project boundary
         or the filesystem root without finding one.
     """
     start = start.absolute()
-    boundary = "the filesystem root"
-    for directory in (start, *start.parents):
+    directories = (start, *start.parents)
+    boundary, described = _boundary(directories)
+    for directory in directories:
         candidate = directory / filename
         if candidate.is_file():
             return candidate
-        marker = _root_marker(directory)
-        if marker is not None:
-            boundary = f"the repository root {directory} (holding {marker})"
+        if directory == boundary:
             break
     if report is not None:
-        report(f"no {filename} in {start} or its parents up to {boundary}")
+        report(f"no {filename} in {start} or its parents up to {described}")
     return None
 
 
-def _root_marker(directory: Path) -> str | None:
-    """The entry of :data:`_ROOT_MARKERS` that *directory* holds, if any."""
-    for marker in _ROOT_MARKERS:
+def _boundary(directories: tuple[Path, ...]) -> tuple[Path | None, str]:
+    """The directory the upward search must not walk past, and its description.
+
+    A repository root anywhere above the start wins: inside a repository the
+    only thing that bounds the project is the repository itself. Only when
+    there is none does the distribution root bound the walk -- which is what
+    keeps a tree outside any repository from reaching the filesystem root.
+    """
+    for markers, label in (
+        (_ROOT_MARKERS, "repository"),
+        (_DIST_MARKERS, "distribution"),
+    ):
+        for directory in directories:
+            marker = _marker(directory, markers)
+            if marker is not None:
+                return directory, f"the {label} root {directory} (holding {marker})"
+    return None, "the filesystem root"
+
+
+def _marker(directory: Path, markers: tuple[str, ...]) -> str | None:
+    """The entry of *markers* that *directory* holds, if any."""
+    for marker in markers:
         if (directory / marker).exists():
             return marker
     return None

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -11,9 +11,11 @@ read it as a build action without the documentation toolchain installed.
 
 The keys are the Sphinx-facing configuration (:data:`BRIDGE_KEYS`), spelled
 like the ``tr_*`` config values without the prefix. One sub-table belongs to
-another consumer: a report converter reads ``[test_reports.convert]``, which
-this reader passes through without interpreting it (:data:`FOREIGN_TABLES`).
-Any other sub-table is an unknown key like any other.
+another consumer: ``[test_reports.build]`` holds what the ``test-reports
+build`` command line produces -- ``[test_reports.build.needs]`` for its
+``needs.json`` -- which this reader passes through without interpreting it
+(:data:`FOREIGN_TABLES`). Any other sub-table is an unknown key like any
+other.
 
 **Error policy.** A known key carrying the wrong type is fatal: that is the
 typo class this validation exists to catch, and letting it through would
@@ -90,9 +92,10 @@ _DUAL_SPELLING_KEYS = ("file", "suite", "case")
 
 #: Sub-tables of the section that belong to another consumer. They are
 #: recognised so they do not draw an unknown-key warning, and deliberately not
-#: interpreted: ``convert`` holds the settings for turning test reports into a
-#: ``needs.json`` outside Sphinx, which this extension never does.
-FOREIGN_TABLES = ("convert",)
+#: interpreted: ``build`` holds the settings of the ``test-reports build``
+#: command line, one sub-table per artifact it produces (``build.needs`` for a
+#: ``needs.json``), and this extension produces none of them.
+FOREIGN_TABLES = ("build",)
 
 #: Expected Python type per key. ``bool`` must be checked *before* ``int``
 #: (bool is an int subclass). ``None`` marks the dual-spelling keys, which are
@@ -114,7 +117,7 @@ _KEY_TYPES: dict[str, type[object] | None] = {
     "property_link_types": dict,
     "json_mapping": dict,
     "deterministic_case_ids": bool,
-    "convert": dict,
+    "build": dict,
 }
 
 #: Required type of the *values* inside a table-valued key. Without this a
@@ -126,7 +129,7 @@ _KEY_TYPES: dict[str, type[object] | None] = {
 _DICT_VALUE_TYPES: dict[str, type[object] | None] = {
     "property_link_types": str,
     "json_mapping": None,
-    "convert": None,
+    "build": None,
 }
 
 #: Field order of the positional ``tr_file``-style lists, and the table keys

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -10,9 +10,10 @@ not this extension, and a report-to-``needs.json`` converter has to be able to
 read it as a build action without the documentation toolchain installed.
 
 The keys are the Sphinx-facing configuration (:data:`BRIDGE_KEYS`), spelled
-like the ``tr_*`` config values without the prefix. The section may also carry
-sub-tables for tools other than the Sphinx extension -- a report converter
-reads ``[test_reports.convert]`` -- which this reader does not interpret.
+like the ``tr_*`` config values without the prefix. One sub-table belongs to
+another consumer: a report converter reads ``[test_reports.convert]``, which
+this reader passes through without interpreting it (:data:`FOREIGN_TABLES`).
+Any other sub-table is an unknown key like any other.
 
 **Error policy.** A known key carrying the wrong type is fatal: that is the
 typo class this validation exists to catch, and letting it through would
@@ -43,12 +44,18 @@ DEFAULT_TOML_FILENAME = "ubproject.toml"
 #: that ``[reports]`` is already taken, and means report *templates*.
 SECTION = "test_reports"
 
-#: Directory entries that end the upward search of
-#: :func:`find_project_config`. A directory carrying one of these is a project
-#: root, so a consumer below it must not silently adopt the configuration of
-#: an unrelated parent project. ``ubproject.toml`` itself is not listed --
-#: finding it is the success case, checked first.
-_ROOT_MARKERS = (".git", "pyproject.toml")
+#: Directory entries that end the upward search of :func:`find_project_config`.
+#: A directory carrying one is the repository root, and nothing above it belongs
+#: to the project, so a consumer never adopts the configuration of an unrelated
+#: parent. ``pyproject.toml`` is deliberately *not* a marker: it marks a Python
+#: distribution, not the project. A ``docs/`` directory with its own
+#: ``pyproject.toml`` beside ``conf.py``, or a workspace member in a monorepo
+#: (``packages/<name>/pyproject.toml`` with the docs below it), sits *inside*
+#: the project whose shared file is at the repository root, and a marker there
+#: would end the search before it reached the file -- silently.
+#: ``ubproject.toml`` itself is not listed -- finding it is the success case,
+#: checked first in every directory.
+_ROOT_MARKERS = (".git",)
 
 #: Section keys bridged onto their ``tr_*`` Sphinx config values.
 BRIDGE_KEYS = (
@@ -143,29 +150,55 @@ class TomlConfigError(Exception):
 
 
 def find_project_config(
-    start: Path, filename: str = DEFAULT_TOML_FILENAME
+    start: Path,
+    filename: str = DEFAULT_TOML_FILENAME,
+    report: Callable[[str], None] | None = None,
 ) -> Path | None:
     """Search *start* and its parents for *filename*.
 
-    The declarative file conventionally sits at the project root while its
+    The declarative file conventionally sits at the repository root while its
     consumers run from below it -- ``conf.py`` in ``docs/``, a build action
     from wherever CI invoked it -- so anchoring strictly at the caller's own
     directory would leave the shared file unread by one of them, silently.
 
-    The walk stops at the first directory holding *filename*, and at a
-    directory that looks like a project root (:data:`_ROOT_MARKERS`) even when
-    it does not hold the file, so a consumer never adopts the configuration of
-    an unrelated parent project.
+    The walk ends at the first directory holding *filename*, or at the
+    repository root (:data:`_ROOT_MARKERS`) when that does not hold the file
+    either: nothing above the root belongs to the project, so a consumer never
+    adopts the configuration of an unrelated parent. Nothing else bounds the
+    search -- in particular a ``pyproject.toml`` on the way up does not, see
+    :data:`_ROOT_MARKERS` for why.
 
-    :return: The file, or ``None`` when the search reached a project root or
-        the filesystem root without finding one.
+    :param start: Directory to start from. Made absolute -- without resolving
+        symlinks -- so that a relative path has parents to walk.
+    :param report: Called with one message when the search ends without the
+        file, naming the directory whose marker ended it. Callers pass their
+        own logger so this module stays Sphinx-free; ``None`` discards it. A
+        missing file is not necessarily a problem -- most projects have none
+        -- but a fruitless search must not be silent, or a misplaced file
+        cannot be diagnosed.
+    :return: The file, or ``None`` when the search reached the repository root
+        or the filesystem root without finding one.
     """
+    start = start.absolute()
+    boundary = "the filesystem root"
     for directory in (start, *start.parents):
         candidate = directory / filename
         if candidate.is_file():
             return candidate
-        if any((directory / marker).exists() for marker in _ROOT_MARKERS):
-            return None
+        marker = _root_marker(directory)
+        if marker is not None:
+            boundary = f"the repository root {directory} (holding {marker})"
+            break
+    if report is not None:
+        report(f"no {filename} in {start} or its parents up to {boundary}")
+    return None
+
+
+def _root_marker(directory: Path) -> str | None:
+    """The entry of :data:`_ROOT_MARKERS` that *directory* holds, if any."""
+    for marker in _ROOT_MARKERS:
+        if (directory / marker).exists():
+            return marker
     return None
 
 
@@ -384,11 +417,14 @@ def _normalise_type_entry(key: str, value: object, path: Path) -> list[str]:
 
 
 def _anchor_paths(section: dict[str, object], base: Path) -> dict[str, object]:
-    """Resolve :data:`PATH_KEYS` against *base* (the TOML file's directory).
+    """Anchor :data:`PATH_KEYS` at *base* (the TOML file's directory).
 
-    Joined but deliberately not ``resolve()``d: *base* is already absolute, and
-    resolving would collapse symlinks that the ``conf.py`` spelling of the same
-    option preserves, so the two spellings would not name the same directory.
+    Joined, deliberately not ``resolve()``d: *base* is already absolute, and
+    this module does not touch the filesystem to second-guess the form of the
+    path it was handed. Whether symlinks in it are collapsed is the consumer's
+    decision -- Sphinx resolves its ``confdir`` before the bridge ever runs, a
+    converter may pass its working directory as is -- and the loader must not
+    make that decision behind their back.
     """
     for key in PATH_KEYS:
         value = section.get(key)

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -1,5 +1,6 @@
 # fmt: off
 import os
+from pathlib import Path
 
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
@@ -28,6 +29,14 @@ from sphinxcontrib.test_reports.directives.test_suite import (
 from sphinxcontrib.test_reports.environment import install_styles_static_files
 from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 from sphinxcontrib.test_reports.functions import tr_link
+from sphinxcontrib.test_reports.projectconfig import (
+    BRIDGE_KEYS,
+    DEFAULT_TOML_FILENAME,
+    SECTION,
+    TomlConfigError,
+    find_project_config,
+    load_project_config,
+)
 
 # fmt: on
 
@@ -101,7 +110,21 @@ def setup(app: Sphinx):
     # Derive test-case IDs from the source location and case name instead of
     # hashing (type, title, content) -- the latter moves the ID when a test
     # starts failing differently. Off by default: enabling it changes IDs.
+    # Required (not just recommended) when the build consumes a needs.json
+    # produced by the convert CLI, which always writes deterministic IDs.
     app.add_config_value("tr_deterministic_case_ids", False, "html")
+    # Declarative configuration: the [test_reports] section of this file
+    # overrides the tr_* config values above at config-inited. The default is
+    # searched for upwards from the confdir; an explicit value is resolved
+    # against the confdir and must exist. None disables TOML reading entirely
+    # -- which is why NoneType has to be an accepted type here, or Sphinx's own
+    # check_confval_types warns about the documented way to switch it off.
+    app.add_config_value(
+        "tr_config_from_toml",
+        DEFAULT_TOML_FILENAME,
+        "env",
+        types=(str, type(None)),
+    )
 
     log = logging.getLogger(__name__)
     log.info("Setting up sphinx-test-reports extension")
@@ -180,6 +203,12 @@ def setup(app: Sphinx):
 
     # events
     app.connect("env-updated", install_styles_static_files)
+    # The TOML bridge must run BEFORE tr_preparation and sphinx_needs_update,
+    # which read the values it writes. Spelled as an explicit priority rather
+    # than relying on registration order, so reordering these lines cannot
+    # silently break it. (Sphinx's own check_confval_types sits at 800, so it
+    # still validates what the bridge wrote.)
+    app.connect("config-inited", load_toml_config, priority=100)
     app.connect("config-inited", tr_preparation)
     app.connect("config-inited", sphinx_needs_update)
 
@@ -207,6 +236,92 @@ def register_tr_extra_options(app):
                 log.debug(
                     f"{direc}.option_spec now has keys: {list(direc.option_spec.keys())}"
                 )
+
+
+def _command_line_overrides(config: Config) -> set[str]:
+    """Config value names given on the command line with ``-D``.
+
+    Sphinx materialises those overrides *before* ``config-inited`` is emitted,
+    so a plain ``setattr`` here would silently win over them. The mapping is
+    spelled ``_overrides`` on newer Sphinx and ``overrides`` before that.
+    """
+    overrides = getattr(config, "_overrides", None)
+    if overrides is None:
+        overrides = getattr(config, "overrides", None)
+    return set(overrides or ())
+
+
+def load_toml_config(app: Sphinx, config: Config) -> None:
+    """Apply the ``[test_reports]`` section of the declarative config file.
+
+    Connected at a priority ahead of every other ``config-inited`` handler of
+    this extension, so the bridged values are in place when the directives and
+    the sphinx-needs registration read them.
+
+    Precedence is ``-D`` > TOML > ``conf.py`` > built-in default, mirroring the
+    CLI's flag > TOML > default. The file is the declarative source of truth
+    and conf.py the fallback, but ``-D`` stays the per-invocation escape hatch:
+    a key given there is left alone, because Sphinx has already applied it by
+    the time this runs.
+
+    Only :data:`BRIDGE_KEYS` reach the config values; the conversion-only keys
+    (``project``, ``version``, ...) belong to the CLI and are skipped here.
+    """
+    setting = config.tr_config_from_toml
+    if setting is None:
+        return
+
+    log = logging.getLogger(__name__)
+    confdir = Path(app.confdir)
+    if setting == DEFAULT_TOML_FILENAME:
+        # The shared file conventionally sits at the project root while conf.py
+        # sits in docs/, so search upwards -- anchoring at the confdir alone
+        # would leave the root file unread by the build while the CLI, started
+        # at the root, reads it.
+        path = find_project_config(confdir, setting)
+        if path is None:
+            return
+    else:
+        path = Path(confdir, setting)
+        if not path.is_file():
+            log.warning(
+                f"tr_config_from_toml points at {path}, which does not exist; "
+                f"building with the conf.py configuration instead.",
+                type="test_reports",
+                subtype="missing_config",
+            )
+            return
+
+    def warn(message: str) -> None:
+        log.warning(message, type="test_reports", subtype="unknown_key")
+
+    try:
+        section = load_project_config(path, warn)
+    except TomlConfigError as error:
+        raise InvalidConfigurationError(str(error)) from error
+
+    if not section:
+        return
+
+    overridden = _command_line_overrides(config)
+    applied = []
+    skipped = []
+    for key in BRIDGE_KEYS:
+        if key not in section:
+            continue
+        name = f"tr_{key}"
+        if name in overridden:
+            skipped.append(name)
+            continue
+        setattr(config, name, section[key])
+        applied.append(key)
+    if applied:
+        log.info(f"Applied {', '.join(sorted(applied))} from {path}")
+    if skipped:
+        log.info(
+            f"Kept the -D value of {', '.join(sorted(skipped))} over "
+            f"[{SECTION}] in {path}"
+        )
 
 
 def tr_preparation(app, *args):

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -91,7 +91,7 @@ except ImportError:
             )
 
 
-def setup(app: Sphinx):
+def setup(app: Sphinx) -> dict[str, object]:
     """
     Setup following directives:
     * test_results
@@ -115,10 +115,12 @@ def setup(app: Sphinx):
     app.add_config_value("tr_deterministic_case_ids", False, "html")
     # Declarative configuration: the [test_reports] section of this file
     # overrides the tr_* config values above at config-inited. The default is
-    # searched for upwards from the confdir; an explicit value is resolved
-    # against the confdir and must exist. None disables TOML reading entirely
-    # -- which is why NoneType has to be an accepted type here, or Sphinx's own
-    # check_confval_types warns about the documented way to switch it off.
+    # searched for upwards from the confdir to the repository root; an explicit
+    # value is resolved against the confdir and warns if it does not exist (the
+    # build then runs on the conf.py configuration). None disables TOML reading
+    # entirely -- which is why NoneType has to be an accepted type here, or
+    # Sphinx's own check_confval_types warns about the documented way to switch
+    # it off.
     app.add_config_value(
         "tr_config_from_toml",
         DEFAULT_TOML_FILENAME,
@@ -130,7 +132,11 @@ def setup(app: Sphinx):
     log.info("Setting up sphinx-test-reports extension")
 
     # configurations
-    app.add_config_value("tr_rootdir", app.confdir, "html")
+    # The default is Sphinx's confdir, a _StrPath. Without explicit types, a
+    # plain string -- the only thing TOML or a string literal in conf.py can
+    # supply -- fails Sphinx's check_confval_types ("has type 'str', defaults
+    # to '_StrPath'") and takes a -W build down. Every consumer accepts both.
+    app.add_config_value("tr_rootdir", app.confdir, "html", types=(str, os.PathLike))
     app.add_config_value(
         "tr_file",
         ["test-file", "testfile", "Test-File", "TF_", "#ffffff", "node"],
@@ -278,7 +284,10 @@ def load_toml_config(app: Sphinx, config: Config) -> None:
         # sits in docs/, so search upwards -- anchoring at the confdir alone
         # would leave the root file unread by the build while the CLI, started
         # at the root, reads it.
-        path = find_project_config(confdir, setting)
+        # A fruitless search is not a warning -- most projects have no file
+        # -- but it says where it ended (visible with -v), so a misplaced file
+        # does not fail silently.
+        path = find_project_config(confdir, setting, report=log.verbose)
         if path is None:
             return
     else:

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -111,7 +111,8 @@ def setup(app: Sphinx) -> dict[str, object]:
     # hashing (type, title, content) -- the latter moves the ID when a test
     # starts failing differently. Off by default: enabling it changes IDs.
     # Required (not just recommended) when the build consumes a needs.json
-    # produced by the convert CLI, which always writes deterministic IDs.
+    # produced by `test-reports build needs`, which always writes
+    # deterministic IDs.
     app.add_config_value("tr_deterministic_case_ids", False, "html")
     # Declarative configuration: the [test_reports] section of this file
     # overrides the tr_* config values above at config-inited. The default is

--- a/tests/doc_test/ubproject_toml/conf.py
+++ b/tests/doc_test/ubproject_toml/conf.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
+
+extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
+
+source_suffix = ".rst"
+master_doc = "index"
+
+project = "ubproject-toml-test"
+copyright = "2026, test"
+author = "test"
+version = "1.0"
+release = "1.0"
+language = "en"
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+html_theme = "alabaster"
+
+# Deliberately clashes with the ubproject.toml value: the declarative file is
+# the source of truth, so file_option must end up as "report_file", not
+# "confpy_report_file". See tests/test_project_config.py.
+tr_file_option = "confpy_report_file"

--- a/tests/doc_test/ubproject_toml/index.rst
+++ b/tests/doc_test/ubproject_toml/index.rst
@@ -1,0 +1,9 @@
+Ubproject Toml Test
+===================
+
+.. test-file:: GTest Report
+   :id: UBTOML_TF_1
+   :file: ../utils/gtest_data.xml
+   :auto_suites:
+   :auto_cases:
+   :more_info: accepted because tr_extra_options came from ubproject.toml

--- a/tests/doc_test/ubproject_toml/ubproject.toml
+++ b/tests/doc_test/ubproject_toml/ubproject.toml
@@ -1,0 +1,24 @@
+"$schema" = "https://ubcode.useblocks.com/ubproject.schema.json"
+
+[project]
+# Read by ubCode, ignored by sphinx-test-reports.
+name = "ubproject-toml-test"
+version = "1.0"
+
+[test_reports]
+# Same effect as doc_test/source_location_renamed's conf.py, but declarative:
+# free up "file"/"line" for the *source* location by renaming the field that
+# carries the XML report path.
+file_option = "report_file"
+source_file_option = "file"
+source_line_option = "line"
+extra_options = ["more_info"]
+
+[test_reports.case]
+# The named-table spelling of the positional tr_case list in conf.py.
+directive = "test-case"
+type = "testcase"
+name = "Test-Case"
+prefix = "TC_"
+color = "#999999"
+style = "rectangle"

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,0 +1,448 @@
+"""Tests for the declarative configuration (``ubproject.toml``, ``[test_reports]``).
+
+The loader validates and normalises the section, and the Sphinx build bridges
+its keys onto the ``tr_*`` config values. Both must agree on which file
+describes a project, or the build is configured by something other than what
+the project declares.
+"""
+
+import os
+from pathlib import Path
+from shutil import copytree
+
+import pytest
+
+from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
+from sphinxcontrib.test_reports.projectconfig import (
+    BRIDGE_KEYS,
+    DEFAULT_TOML_FILENAME,
+    FOREIGN_TABLES,
+    TomlConfigError,
+    find_project_config,
+    load_project_config,
+)
+
+
+def _write(tmp_path, toml_source, name=DEFAULT_TOML_FILENAME):
+    config = tmp_path / name
+    config.write_text(toml_source, encoding="utf-8")
+    return config
+
+
+class TestLoader:
+    """The Sphinx-free loader: parsing, normalising, anchoring, rejecting."""
+
+    def test_missing_file_is_none(self, tmp_path):
+        assert load_project_config(tmp_path / DEFAULT_TOML_FILENAME) is None
+
+    def test_missing_section_is_empty(self, tmp_path):
+        _write(tmp_path, '[project]\nname = "x"\n')
+        assert load_project_config(tmp_path / DEFAULT_TOML_FILENAME) == {}
+
+    def test_full_section_round_trips(self, tmp_path):
+        _write(
+            tmp_path,
+            """
+            [test_reports]
+            file_option = "report_file"
+            source_file_option = "file"
+            import_encoding = "latin1"
+            deterministic_case_ids = true
+            suite_id_length = 4
+            extra_options = ["more_info"]
+            property_link_types = { request = "req" }
+            """,
+        )
+        config = load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+        assert config["file_option"] == "report_file"
+        assert config["source_file_option"] == "file"
+        assert config["import_encoding"] == "latin1"
+        assert config["deterministic_case_ids"] is True
+        assert config["suite_id_length"] == 4
+        assert config["extra_options"] == ["more_info"]
+        assert config["property_link_types"] == {"request": "req"}
+
+    def test_foreign_sub_table_is_kept_without_a_warning(self, tmp_path):
+        # [test_reports.convert] belongs to the report converter. This reader
+        # must neither complain about it nor apply it to a tr_* value -- the
+        # section describes the project, not just this extension.
+        _write(
+            tmp_path,
+            """
+            [test_reports]
+            file_option = "report_file"
+
+            [test_reports.convert]
+            project = "demo"
+            need_type = "check"
+            """,
+        )
+        reported = []
+        section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME, reported.append)
+        assert reported == []
+        assert section["convert"] == {"project": "demo", "need_type": "check"}
+        assert not set(FOREIGN_TABLES) & set(BRIDGE_KEYS)
+
+    def test_unknown_key_is_reported_but_not_fatal(self, tmp_path):
+        # ubproject.toml is shared with tools on independent release cadences,
+        # so a key this reader does not model must not take the build down --
+        # but a typo has to be visible, and the key must not be passed on.
+        _write(tmp_path, "[test_reports]\ndeterministic_id = true\n")
+        reported = []
+        section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME, reported.append)
+        assert section == {}
+        assert len(reported) == 1
+        assert "deterministic_id" in reported[0]
+        assert "deterministic_case_ids" in reported[0]  # supported keys listed
+
+    def test_unknown_key_needs_no_reporter(self, tmp_path):
+        _write(tmp_path, "[test_reports]\nnope = 1\nfile_option = 'f'\n")
+        assert load_project_config(tmp_path / DEFAULT_TOML_FILENAME) == {
+            "file_option": "f"
+        }
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("property_link_types", '{ request = ["req"] }'),
+            ("property_link_types", "{ request = 3 }"),
+        ],
+    )
+    def test_table_values_are_type_checked(self, tmp_path, key, value):
+        # Without this the value reaches the directives, which fail with a bare
+        # TypeError on an unhashable field name instead of a config error.
+        _write(tmp_path, f"[test_reports]\n{key} = {value}\n")
+        with pytest.raises(TomlConfigError, match=key):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_json_mapping_nesting_stays_free_form(self, tmp_path):
+        # It mirrors an arbitrary parser mapping, so only the outer table is
+        # checked -- validating deeper would reject valid configurations.
+        _write(
+            tmp_path,
+            "[test_reports.json_mapping.json_config.testsuite]\nname = 1\n",
+        )
+        section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+        assert section["json_mapping"] == {"json_config": {"testsuite": {"name": 1}}}
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root reads unreadable files",
+    )
+    def test_unreadable_file_is_a_config_error(self, tmp_path):
+        # is_file() succeeding does not mean the open will; an unwrapped
+        # OSError would surface as a traceback instead of a config error.
+        config = _write(tmp_path, "[test_reports]\nfile_option = 'f'\n")
+        config.chmod(0o000)
+        try:
+            with pytest.raises(TomlConfigError, match="cannot be read"):
+                load_project_config(config)
+        finally:
+            config.chmod(0o644)
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("file_option", "42"),
+            ("suite_id_length", '"four"'),  # string for int
+            ("suite_id_length", "true"),  # bool must not pass for int
+            ("deterministic_case_ids", '"yes"'),  # string for bool
+            ("extra_options", '"more_info"'),  # a bare string is not an array
+            ("property_link_types", '["a"]'),
+        ],
+    )
+    def test_wrong_types_are_rejected(self, tmp_path, key, value):
+        _write(tmp_path, f"[test_reports]\n{key} = {value}\n")
+        with pytest.raises(TomlConfigError, match=key):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_invalid_toml_is_rejected(self, tmp_path):
+        _write(tmp_path, "[test-reports\n")
+        with pytest.raises(TomlConfigError, match="invalid TOML"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_section_must_be_a_table(self, tmp_path):
+        _write(tmp_path, "test_reports = 5\n")
+        with pytest.raises(TomlConfigError, match="must be a table"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_need_type_positional_list_still_works(self, tmp_path):
+        # The conf.py spelling, so existing projects can copy their lists over
+        # verbatim.
+        _write(
+            tmp_path,
+            '[test_reports]\ncase = ["test-case", "testcase", "Test-Case", "TC_", "#999999", "rectangle"]\n',
+        )
+        config = load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+        assert config["case"] == [
+            "test-case",
+            "testcase",
+            "Test-Case",
+            "TC_",
+            "#999999",
+            "rectangle",
+        ]
+
+    def test_need_type_named_table(self, tmp_path):
+        # Six bare strings cannot be told apart; the table spelling names them.
+        _write(
+            tmp_path,
+            """
+            [test_reports.case]
+            directive = "test-case"
+            type = "testcase"
+            name = "Test-Case"
+            prefix = "TC_"
+            color = "#999999"
+            style = "rectangle"
+            """,
+        )
+        config = load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+        assert config["case"] == [
+            "test-case",
+            "testcase",
+            "Test-Case",
+            "TC_",
+            "#999999",
+            "rectangle",
+        ]
+
+    def test_need_type_table_rejects_partial_and_unknown(self, tmp_path):
+        _write(tmp_path, '[test_reports.case]\ndirective = "test-case"\n')
+        with pytest.raises(TomlConfigError, match="missing"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+        _write(
+            tmp_path,
+            """
+            [test_reports.case]
+            directive = "test-case"
+            type = "testcase"
+            name = "Test-Case"
+            prefix = "TC_"
+            color = "#999999"
+            style = "rectangle"
+            typo = true
+            """,
+        )
+        with pytest.raises(TomlConfigError, match="unknown typo"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_relative_paths_anchor_to_the_toml_directory(self, tmp_path):
+        # The file is self-describing: moving it as a unit keeps its relative
+        # paths meaningful, and both consumers resolve them identically.
+        subdir = tmp_path / "config"
+        subdir.mkdir()
+        _write(
+            subdir,
+            '[test_reports]\nrootdir = "docs"\nreport_template = "templates/report.txt"\n',
+            name=subdir / DEFAULT_TOML_FILENAME,
+        )
+        config = load_project_config(subdir / DEFAULT_TOML_FILENAME)
+        assert config["rootdir"] == str(subdir / "docs")
+        assert config["report_template"] == str(subdir / "templates" / "report.txt")
+
+    def test_absolute_paths_stay_untouched(self, tmp_path):
+        _write(tmp_path, f'[test_reports]\nrootdir = "{tmp_path}"\n')
+        config = load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+        assert config["rootdir"] == str(tmp_path)
+
+
+class TestSphinxBridge:
+    """The build reads the same section and honours the same precedence."""
+
+    @pytest.mark.parametrize(
+        "test_app",
+        [{"buildername": "html", "srcdir": "doc_test/ubproject_toml"}],
+        indirect=True,
+    )
+    def test_build_succeeds(self, test_app):
+        test_app.build()
+        assert test_app.statuscode == 0
+
+    @pytest.mark.parametrize(
+        "test_app",
+        [{"buildername": "html", "srcdir": "doc_test/ubproject_toml"}],
+        indirect=True,
+    )
+    def test_toml_beats_conf_py(self, test_app):
+        """conf.py names one field, ubproject.toml another; TOML must win."""
+        test_app.build()
+        html = Path(test_app.outdir, "index.html").read_text(encoding="utf-8")
+        # file_option = "report_file" (TOML) won over "confpy_report_file".
+        assert "needs_report_file" in html
+        # The report path lands on the renamed field, the source location on
+        # file/line -- the rename took effect end to end.
+        assert "gtest_data.xml" in html
+
+    @pytest.mark.parametrize(
+        "test_app",
+        [{"buildername": "html", "srcdir": "doc_test/ubproject_toml"}],
+        indirect=True,
+    )
+    def test_extra_options_from_toml_are_accepted(self, test_app):
+        """:more_info: is only valid because tr_extra_options came from TOML."""
+        test_app.build()
+        html = Path(test_app.outdir, "index.html").read_text(encoding="utf-8")
+        assert "accepted because tr_extra_options came from ubproject.toml" in html
+
+    def test_bridge_rejects_a_broken_section(self, tmp_path):
+        """A malformed section aborts the build as a configuration error.
+
+        The bridge runs on ``config-inited``, so the error surfaces while the
+        application is set up -- before any document is read.
+        """
+        copytree(Path(__file__).parent / "doc_test" / "basic_doc", tmp_path / "docs")
+        _write(tmp_path / "docs", "[test_reports]\nsuite_id_length = 'four'\n")
+
+        from sphinx.application import Sphinx
+
+        docs = tmp_path / "docs"
+        with pytest.raises(InvalidConfigurationError, match="suite_id_length"):
+            Sphinx(
+                srcdir=docs,
+                confdir=docs,
+                outdir=docs / "_build" / "html",
+                doctreedir=docs / "_build" / "doctrees",
+                buildername="html",
+                freshenv=True,
+            )
+
+
+class TestDiscovery:
+    """The upward search that lets both consumers find the same file."""
+
+    def test_finds_the_file_in_the_starting_directory(self, tmp_path):
+        config = _write(tmp_path, "[test_reports]\n")
+        assert find_project_config(tmp_path) == config
+
+    def test_walks_up_to_the_project_root(self, tmp_path):
+        config = _write(tmp_path, "[test_reports]\n")
+        deep = tmp_path / "docs" / "source"
+        deep.mkdir(parents=True)
+        assert find_project_config(deep) == config
+
+    def test_stops_at_a_project_root_without_the_file(self, tmp_path):
+        # An unrelated parent project must not have its configuration adopted.
+        _write(tmp_path, "[test_reports]\n")
+        inner = tmp_path / "packages" / "inner"
+        inner.mkdir(parents=True)
+        (inner / "pyproject.toml").write_text("", encoding="utf-8")
+        assert find_project_config(inner) is None
+
+    def test_the_file_wins_over_the_marker_in_one_directory(self, tmp_path):
+        # Root markers only end a *fruitless* step; a root holding both is the
+        # normal case and must be found.
+        config = _write(tmp_path, "[test_reports]\n")
+        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        assert find_project_config(tmp_path) == config
+
+    def test_missing_file_is_none(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        assert find_project_config(tmp_path) is None
+
+
+class TestPathAnchoring:
+    """Relative paths resolve the same way for both consumers."""
+
+    def test_symlinked_directories_are_preserved(self, tmp_path):
+        # conf.py's spelling of tr_rootdir does not collapse symlinks, so the
+        # TOML spelling must not either, or the two name different directories.
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+        config = _write(link, "[test_reports]\nrootdir = 'reports'\n")
+        section = load_project_config(config)
+        assert section["rootdir"] == str(link / "reports")
+
+
+def _build(srcdir, **kwargs):
+    """Set up a Sphinx application, returning it with its warning output."""
+    from io import StringIO
+
+    from sphinx.application import Sphinx
+
+    warnings = StringIO()
+    app = Sphinx(
+        srcdir=srcdir,
+        confdir=srcdir,
+        outdir=srcdir / "_build" / "html",
+        doctreedir=srcdir / "_build" / "doctrees",
+        buildername="html",
+        freshenv=True,
+        status=None,
+        warning=warnings,
+        **kwargs,
+    )
+    return app, warnings.getvalue()
+
+
+def _basic_doc(tmp_path, toml=None, conf_extra=""):
+    docs = tmp_path / "docs"
+    copytree(Path(__file__).parent / "doc_test" / "basic_doc", docs)
+    # Bound the upward search so the outcome cannot depend on the sandbox.
+    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    if toml is not None:
+        _write(docs, toml)
+    if conf_extra:
+        with (docs / "conf.py").open("a", encoding="utf-8") as handle:
+            handle.write("\n" + conf_extra + "\n")
+    return docs
+
+
+class TestBridgePrecedence:
+    """``-D`` > TOML > conf.py, and the diagnostics for a file that is missing."""
+
+    def test_command_line_override_beats_toml(self, tmp_path):
+        # -D is the per-invocation escape hatch. Sphinx applies it before
+        # config-inited, so the bridge has to leave those keys alone.
+        docs = _basic_doc(tmp_path, "[test_reports]\nfile_option = 'from_toml'\n")
+        app, _ = _build(docs, confoverrides={"tr_file_option": "from_command_line"})
+        assert app.config.tr_file_option == "from_command_line"
+
+    def test_toml_beats_conf_py_without_an_override(self, tmp_path):
+        docs = _basic_doc(
+            tmp_path,
+            "[test_reports]\nfile_option = 'from_toml'\n",
+            conf_extra="tr_file_option = 'from_conf_py'",
+        )
+        app, _ = _build(docs)
+        assert app.config.tr_file_option == "from_toml"
+
+    def test_disabling_toml_reading_is_not_a_type_warning(self, tmp_path):
+        # The documented opt-out must not trip Sphinx's own confval check --
+        # a project building with -W would fail on it.
+        docs = _basic_doc(
+            tmp_path,
+            "[test_reports]\nfile_option = 'from_toml'\n",
+            conf_extra="tr_config_from_toml = None",
+        )
+        app, warnings = _build(docs)
+        assert "tr_config_from_toml" not in warnings
+        assert app.config.tr_file_option == "file"
+
+    def test_missing_explicit_config_warns(self, tmp_path):
+        docs = _basic_doc(tmp_path, conf_extra="tr_config_from_toml = 'nope.toml'")
+        _, warnings = _build(docs)
+        assert "does not exist" in warnings
+
+    def test_missing_default_config_is_silent(self, tmp_path):
+        docs = _basic_doc(tmp_path)
+        _, warnings = _build(docs)
+        assert "ubproject.toml" not in warnings
+
+    def test_unknown_key_warns_but_builds(self, tmp_path):
+        docs = _basic_doc(
+            tmp_path, "[test_reports]\nfile_option = 'ok'\nno_such_key = 1\n"
+        )
+        app, warnings = _build(docs)
+        assert "no_such_key" in warnings
+        assert app.config.tr_file_option == "ok"
+
+    def test_walks_up_from_the_confdir(self, tmp_path):
+        # ubproject.toml at the repo root, conf.py in docs/ -- the layout the
+        # shared file exists for.
+        docs = _basic_doc(tmp_path)
+        _write(tmp_path, "[test_reports]\nfile_option = 'from_the_root'\n")
+        app, _ = _build(docs)
+        assert app.config.tr_file_option == "from_the_root"

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -347,8 +347,10 @@ class TestDiscovery:
     """The upward search that lets both consumers find the same file.
 
     The search is bounded by the repository root -- the directory holding
-    ``.git`` -- and by nothing else: a ``pyproject.toml`` on the way up marks a
-    Python distribution, not the project, and must not end the search.
+    ``.git``: a ``pyproject.toml`` on the way up marks a Python distribution,
+    not the project, and must not end the search. Outside any repository there
+    is no such root, so the distribution root bounds it instead -- otherwise
+    the walk reaches the filesystem root and adopts a stranger's file.
     """
 
     def test_finds_the_file_in_the_starting_directory(self, tmp_path):
@@ -393,6 +395,52 @@ class TestDiscovery:
         docs.mkdir(parents=True)
         (inner / ".git").write_text("gitdir: elsewhere\n", encoding="utf-8")
         assert find_project_config(docs) is None
+
+    def test_stops_at_the_distribution_root_without_a_repository(self, tmp_path):
+        # An unpacked sdist, a CI artefact directory, an exported docs tree:
+        # no .git anywhere, so nothing above would end the walk and a
+        # stranger's file further up would be adopted. The distribution root
+        # bounds the search instead, so it is not.
+        _write(tmp_path, "[test_reports]\n")  # a stranger's, two levels up
+        dist = tmp_path / "downloads" / "sphinx-test-reports-1.4.0"
+        docs = dist / "docs"
+        docs.mkdir(parents=True)
+        (dist / "pyproject.toml").write_text("", encoding="utf-8")
+        assert find_project_config(docs) is None
+
+    def test_the_file_at_the_distribution_root_is_still_found(self, tmp_path):
+        # The distribution root bounds the search without hiding a file that
+        # sits on it: an sdist shipping its own ubproject.toml is configured
+        # by it.
+        dist = tmp_path / "sphinx-test-reports-1.4.0"
+        docs = dist / "docs"
+        docs.mkdir(parents=True)
+        (dist / "pyproject.toml").write_text("", encoding="utf-8")
+        config = _write(dist, "[test_reports]\n")
+        assert find_project_config(docs) == config
+
+    def test_a_repository_marker_outranks_a_distribution_root(self, tmp_path):
+        # The distribution root is only the fallback boundary. Inside a
+        # repository the walk still passes a pyproject.toml on the way up --
+        # the workspace-member layout above depends on it.
+        (tmp_path / ".git").mkdir()
+        config = _write(tmp_path, "[test_reports]\n")
+        member = tmp_path / "packages" / "dist"
+        docs = member / "docs"
+        docs.mkdir(parents=True)
+        (member / "pyproject.toml").write_text("", encoding="utf-8")
+        assert find_project_config(docs) == config
+
+    def test_a_fruitless_search_reports_the_distribution_root(self, tmp_path):
+        dist = tmp_path / "sphinx-test-reports-1.4.0"
+        docs = dist / "docs"
+        docs.mkdir(parents=True)
+        (dist / "pyproject.toml").write_text("", encoding="utf-8")
+        reported = []
+        assert find_project_config(docs, report=reported.append) is None
+        assert len(reported) == 1
+        assert f"distribution root {dist}" in reported[0]
+        assert "pyproject.toml" in reported[0]
 
     def test_the_file_wins_over_the_marker_in_one_directory(self, tmp_path):
         # The root marker only ends a *fruitless* step; a repository root
@@ -640,3 +688,33 @@ class TestSphinxFree:
             [sys.executable, "-c", code], capture_output=True, text=True
         )
         assert result.returncode == 0, result.stderr
+
+    def test_a_missing_sphinx_needs_is_an_extension_error(self):
+        # The lazy `setup` owns the message Sphinx would have produced for a
+        # broken extension import, because Sphinx fetches `setup` with
+        # getattr() and would otherwise show a raw traceback. Sphinx renders
+        # the wrapped exception itself, so the message must not carry it a
+        # second time. Checked in a subprocess: sphinx_needs is importable
+        # here.
+        code = (
+            "import sys\n"
+            "sys.modules['sphinx_needs'] = None\n"  # `from sphinx_needs...` fails
+            "import sphinxcontrib.test_reports as pkg\n"
+            "from sphinx.errors import ExtensionError\n"
+            "try:\n"
+            "    pkg.setup\n"
+            "except ExtensionError as error:\n"
+            "    print(error)\n"
+            "else:\n"
+            "    raise AssertionError('no ExtensionError')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        message = result.stdout.strip()
+        assert message.startswith(
+            "Could not import extension sphinxcontrib.test_reports"
+        )
+        assert message.count("(exception:") == 1
+        assert "sphinx_needs" in message

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -7,6 +7,9 @@ the project declares.
 """
 
 import os
+import subprocess
+import sys
+from io import StringIO
 from pathlib import Path
 from shutil import copytree
 
@@ -17,6 +20,7 @@ from sphinxcontrib.test_reports.projectconfig import (
     BRIDGE_KEYS,
     DEFAULT_TOML_FILENAME,
     FOREIGN_TABLES,
+    SECTION,
     TomlConfigError,
     find_project_config,
     load_project_config,
@@ -227,6 +231,37 @@ class TestLoader:
         with pytest.raises(TomlConfigError, match="unknown typo"):
             load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
 
+    @pytest.mark.parametrize(
+        ("toml_source", "problem"),
+        [
+            # A non-string value inside the named table. Without the check the
+            # value is silently stringified and reaches sphinx-needs.
+            (
+                """
+                [test_reports.case]
+                directive = "test-case"
+                type = "testcase"
+                name = "Test-Case"
+                prefix = "TC_"
+                color = 999999
+                style = "rectangle"
+                """,
+                "non-string color",
+            ),
+            # A non-string element of the positional list.
+            (
+                '[test_reports]\ncase = ["test-case", "testcase", "Test-Case", "TC_", 999999, "rectangle"]\n',
+                "exactly 6 strings",
+            ),
+            # Too few elements.
+            ('[test_reports]\ncase = ["test-case", "testcase"]\n', "exactly 6 strings"),
+        ],
+    )
+    def test_need_type_values_must_be_strings(self, tmp_path, toml_source, problem):
+        _write(tmp_path, toml_source)
+        with pytest.raises(TomlConfigError, match=problem):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
     def test_relative_paths_anchor_to_the_toml_directory(self, tmp_path):
         # The file is self-describing: moving it as a unit keeps its relative
         # paths meaningful, and both consumers resolve them identically.
@@ -309,44 +344,107 @@ class TestSphinxBridge:
 
 
 class TestDiscovery:
-    """The upward search that lets both consumers find the same file."""
+    """The upward search that lets both consumers find the same file.
+
+    The search is bounded by the repository root -- the directory holding
+    ``.git`` -- and by nothing else: a ``pyproject.toml`` on the way up marks a
+    Python distribution, not the project, and must not end the search.
+    """
 
     def test_finds_the_file_in_the_starting_directory(self, tmp_path):
         config = _write(tmp_path, "[test_reports]\n")
         assert find_project_config(tmp_path) == config
 
-    def test_walks_up_to_the_project_root(self, tmp_path):
+    def test_walks_up_to_the_repository_root(self, tmp_path):
+        (tmp_path / ".git").mkdir()
         config = _write(tmp_path, "[test_reports]\n")
         deep = tmp_path / "docs" / "source"
         deep.mkdir(parents=True)
         assert find_project_config(deep) == config
 
-    def test_stops_at_a_project_root_without_the_file(self, tmp_path):
-        # An unrelated parent project must not have its configuration adopted.
+    def test_a_pyproject_toml_beside_conf_py_does_not_end_the_search(self, tmp_path):
+        # docs/ carrying its own pyproject.toml (its own dependency set) still
+        # belongs to the project whose shared file sits at the repository root.
+        (tmp_path / ".git").mkdir()
+        config = _write(tmp_path, "[test_reports]\n")
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "pyproject.toml").write_text("", encoding="utf-8")
+        assert find_project_config(docs) == config
+
+    def test_walks_past_a_workspace_member_pyproject_toml(self, tmp_path):
+        # A uv-workspace member: packages/<dist>/pyproject.toml with the docs
+        # below it, and one ubproject.toml at the repository root describing
+        # the whole monorepo.
+        (tmp_path / ".git").mkdir()
+        config = _write(tmp_path, "[test_reports]\n")
+        member = tmp_path / "packages" / "dist"
+        docs = member / "docs"
+        docs.mkdir(parents=True)
+        (member / "pyproject.toml").write_text("", encoding="utf-8")
+        assert find_project_config(docs) == config
+
+    def test_stops_at_a_nested_repository_without_the_file(self, tmp_path):
+        # A checkout nested inside another repository (a vendored tree, a
+        # submodule) must not adopt the outer repository's configuration.
         _write(tmp_path, "[test_reports]\n")
-        inner = tmp_path / "packages" / "inner"
-        inner.mkdir(parents=True)
-        (inner / "pyproject.toml").write_text("", encoding="utf-8")
-        assert find_project_config(inner) is None
+        inner = tmp_path / "vendor" / "inner"
+        docs = inner / "docs"
+        docs.mkdir(parents=True)
+        (inner / ".git").write_text("gitdir: elsewhere\n", encoding="utf-8")
+        assert find_project_config(docs) is None
 
     def test_the_file_wins_over_the_marker_in_one_directory(self, tmp_path):
-        # Root markers only end a *fruitless* step; a root holding both is the
-        # normal case and must be found.
+        # The root marker only ends a *fruitless* step; a repository root
+        # holding the file is the canonical layout and must be found.
         config = _write(tmp_path, "[test_reports]\n")
-        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        (tmp_path / ".git").mkdir()
         assert find_project_config(tmp_path) == config
 
     def test_missing_file_is_none(self, tmp_path):
         (tmp_path / ".git").mkdir()
         assert find_project_config(tmp_path) is None
 
+    def test_a_fruitless_search_reports_where_it_ended(self, tmp_path):
+        # "Not found" must not be silent: the report names the directory whose
+        # marker ended the search, so a misplaced file can be diagnosed.
+        (tmp_path / ".git").mkdir()
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        reported = []
+        assert find_project_config(docs, report=reported.append) is None
+        assert len(reported) == 1
+        assert str(docs) in reported[0]
+        assert f"repository root {tmp_path}" in reported[0]
+        assert ".git" in reported[0]
+
+    def test_a_successful_search_reports_nothing(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        _write(tmp_path, "[test_reports]\n")
+        reported = []
+        find_project_config(tmp_path / "docs", report=reported.append)
+        assert reported == []
+
+    def test_a_relative_start_is_searched_from_the_working_directory(
+        self, tmp_path, monkeypatch
+    ):
+        # A converter started with a relative path must still see the parents.
+        (tmp_path / ".git").mkdir()
+        config = _write(tmp_path, "[test_reports]\n")
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        monkeypatch.chdir(docs)
+        assert find_project_config(Path(".")) == config
+
 
 class TestPathAnchoring:
-    """Relative paths resolve the same way for both consumers."""
+    """Relative paths anchor at the TOML file's directory, as given."""
 
-    def test_symlinked_directories_are_preserved(self, tmp_path):
-        # conf.py's spelling of tr_rootdir does not collapse symlinks, so the
-        # TOML spelling must not either, or the two name different directories.
+    def test_anchoring_does_not_resolve_the_given_directory(self, tmp_path):
+        # The loader leaves the form of the directory it was handed alone -- a
+        # symlinked path stays symlinked. Whether to resolve it is the
+        # consumer's call (Sphinx resolves its confdir before the bridge runs),
+        # not something the loader decides behind its back.
         real = tmp_path / "real"
         real.mkdir()
         link = tmp_path / "link"
@@ -357,11 +455,14 @@ class TestPathAnchoring:
 
 
 def _build(srcdir, **kwargs):
-    """Set up a Sphinx application, returning it with its warning output."""
-    from io import StringIO
+    """Set up a Sphinx application, returning it with its warning output.
 
+    Pass ``status=StringIO()`` (and ``verbosity=1``) to capture the
+    informational output as well; it is discarded by default.
+    """
     from sphinx.application import Sphinx
 
+    kwargs.setdefault("status", None)
     warnings = StringIO()
     app = Sphinx(
         srcdir=srcdir,
@@ -370,7 +471,6 @@ def _build(srcdir, **kwargs):
         doctreedir=srcdir / "_build" / "doctrees",
         buildername="html",
         freshenv=True,
-        status=None,
         warning=warnings,
         **kwargs,
     )
@@ -381,7 +481,7 @@ def _basic_doc(tmp_path, toml=None, conf_extra=""):
     docs = tmp_path / "docs"
     copytree(Path(__file__).parent / "doc_test" / "basic_doc", docs)
     # Bound the upward search so the outcome cannot depend on the sandbox.
-    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
     if toml is not None:
         _write(docs, toml)
     if conf_extra:
@@ -446,3 +546,97 @@ class TestBridgePrecedence:
         _write(tmp_path, "[test_reports]\nfile_option = 'from_the_root'\n")
         app, _ = _build(docs)
         assert app.config.tr_file_option == "from_the_root"
+
+    def test_walks_past_a_pyproject_toml_beside_conf_py(self, tmp_path):
+        # The docs directory being a distribution of its own does not make it
+        # the project root; the shared file above it must still be found.
+        docs = _basic_doc(tmp_path)
+        (docs / "pyproject.toml").write_text("", encoding="utf-8")
+        _write(tmp_path, "[test_reports]\nfile_option = 'from_the_root'\n")
+        app, _ = _build(docs)
+        assert app.config.tr_file_option == "from_the_root"
+
+    def test_a_fruitless_search_says_where_it_ended(self, tmp_path):
+        # Not an error and not a warning -- most projects have no file -- but
+        # visible with -v, so a misplaced file can be diagnosed.
+        docs = _basic_doc(tmp_path)
+        status = StringIO()
+        _build(docs, status=status, verbosity=1)
+        assert f"repository root {tmp_path}" in status.getvalue()
+
+
+def _documented_toml_example():
+    """The ``[test_reports]`` example of ``docs/configuration.rst``, verbatim.
+
+    Read from the docs rather than copied, so the test fails when the example
+    and the code drift apart -- the example is what a project copies.
+    """
+    text = (Path(__file__).parents[1] / "docs" / "configuration.rst").read_text(
+        encoding="utf-8"
+    )
+    section = text[text.index("Declarative configuration (ubproject.toml)") :]
+    directive = ".. code-block:: toml\n"
+    body = section[section.index(directive) + len(directive) :].splitlines()
+    block = []
+    for line in body[1:]:  # skip the blank line after the directive
+        if line and not line.startswith("   "):
+            break
+        block.append(line[3:])
+    return "\n".join(block) + "\n"
+
+
+class TestConfvalTypes:
+    """The bridged values must pass Sphinx's own confval type check.
+
+    ``check_confval_types`` runs at ``config-inited`` after the bridge and
+    compares each value's type with its default's. ``tr_rootdir`` defaults to
+    Sphinx's ``confdir`` -- a ``_StrPath`` -- so a plain string, the only thing
+    TOML (or a string literal in ``conf.py``) can supply, drew a warning, and a
+    project building with ``-W`` failed on the documented example.
+    """
+
+    def test_rootdir_from_toml_is_not_a_type_warning(self, tmp_path):
+        docs = _basic_doc(tmp_path)
+        _write(tmp_path, '[test_reports]\nrootdir = "docs"\n')
+        app, warnings = _build(docs)
+        assert "tr_rootdir" not in warnings
+        assert app.config.tr_rootdir == str(tmp_path / "docs")
+
+    def test_rootdir_as_a_string_in_conf_py_is_not_a_type_warning(self, tmp_path):
+        docs = _basic_doc(tmp_path, conf_extra='tr_rootdir = "."')
+        _, warnings = _build(docs)
+        assert "tr_rootdir" not in warnings
+
+    def test_the_documented_example_applies_without_warnings(self, tmp_path):
+        docs = _basic_doc(tmp_path)
+        _write(tmp_path, _documented_toml_example())
+        app, warnings = _build(docs)
+        own = [
+            line
+            for line in warnings.splitlines()
+            if "tr_" in line or "ubproject" in line or f"[{SECTION}]" in line
+        ]
+        assert own == []
+        assert app.config.tr_file_option == "report_file"
+        assert app.config.tr_rootdir == str(tmp_path / "docs")
+        assert app.config.tr_case[0] == "test-case"
+
+
+class TestSphinxFree:
+    """A consumer without the documentation toolchain can read the section."""
+
+    def test_projectconfig_imports_without_sphinx(self):
+        # Importing the module runs the package __init__, so the package must
+        # not import Sphinx eagerly either -- or a build action that turns
+        # reports into a needs.json dies with ModuleNotFoundError wherever
+        # Sphinx is not installed. Checked in a subprocess: this process has
+        # Sphinx imported already.
+        code = (
+            "import sys\n"
+            "sys.modules['sphinx'] = None\n"  # any `import sphinx...` now fails
+            "import sphinxcontrib.test_reports.projectconfig\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -67,16 +67,16 @@ class TestLoader:
         assert config["property_link_types"] == {"request": "req"}
 
     def test_foreign_sub_table_is_kept_without_a_warning(self, tmp_path):
-        # [test_reports.convert] belongs to the report converter. This reader
-        # must neither complain about it nor apply it to a tr_* value -- the
-        # section describes the project, not just this extension.
+        # [test_reports.build] belongs to the command line. This reader must
+        # neither complain about it nor apply it to a tr_* value -- the section
+        # describes the project, not just this extension.
         _write(
             tmp_path,
             """
             [test_reports]
             file_option = "report_file"
 
-            [test_reports.convert]
+            [test_reports.build.needs]
             project = "demo"
             need_type = "check"
             """,
@@ -84,7 +84,7 @@ class TestLoader:
         reported = []
         section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME, reported.append)
         assert reported == []
-        assert section["convert"] == {"project": "demo", "need_type": "check"}
+        assert section["build"] == {"needs": {"project": "demo", "need_type": "check"}}
         assert not set(FOREIGN_TABLES) & set(BRIDGE_KEYS)
 
     def test_unknown_key_is_reported_but_not_fatal(self, tmp_path):


### PR DESCRIPTION
Stacked on #150 (sphinx-needs 6.0.1 / Sphinx 7.4 floor) and, through it, on the Python 3.11 floor of #147 — reading the section needs `tomllib`.

Describe the project once, in the `[test_reports]` section of `ubproject.toml` — the declarative file sphinx-needs, sphinx-codelinks, sphinx-mounts and ubCode already read — instead of restating it in `conf.py`.

**Rescoped.** This PR previously also carried the `test-reports convert` CLI integration and the conversion settings themselves. #144 has been reverted (#146) so the declarative configuration lands first; the converter returns as a follow-up PR stacked on this one, bringing its own settings under `[test_reports.build.needs]` and reading them from the start rather than shipping flags and growing `--config` afterwards. What is left here is exactly what the Sphinx extension consumes.

## What

- New Sphinx-free module `projectconfig.py` parses, validates and normalises the section. It imports no Sphinx, and neither does the package `__init__` it runs through: `setup` is resolved lazily (PEP 562), so a build action can read the section without the documentation toolchain installed. The section describes the *project*, not this extension.
- **Bridge**: a `config-inited` handler at `priority=100` applies the Sphinx-facing keys to their `tr_*` config values, ahead of the handlers that read them. Precedence is **`-D` > `ubproject.toml` > `conf.py` > built-in default** — the file is the source of truth for the project, the command line stays the per-invocation escape hatch. Both are announced in the log (`Applied … from …`, `Kept the -D value of …`).
- **New confval `tr_config_from_toml`** (default `ubproject.toml`; `None` disables, and `NoneType` is an accepted type so the documented opt-out does not trip Sphinx's own confval check). With the default name the file is searched for upwards from the `confdir` to the repository root — the directory holding `.git`, and nothing else bounds the search: a `pyproject.toml` on the way up marks a distribution, not the project, so `docs/pyproject.toml` beside `conf.py` and a uv-workspace member (`packages/<dist>/docs/conf.py` with one `ubproject.toml` at the monorepo root) both find the file. A fruitless search says where it ended (`sphinx-build -v`). An explicitly named file is used as-is and warns if missing (`test_reports.missing_config`).
- **Spellings**: `file`/`suite`/`case` accept both the positional `conf.py` list and a named table (`directive`/`type`/`name`/`prefix`/`color`/`style`). Relative `rootdir`/`report_template` anchor at the TOML file's directory; the loader joins without resolving, so the form of the path it is handed (Sphinx's already-resolved `confdir`, a converter's working directory) is kept as is.
- **Error policy**: a *known* key with the wrong type is an error — that is the typo class this validation exists for — and table *values* are checked, not just the outer table, including the values inside a `file`/`suite`/`case` table. An *unknown* key is warned about and ignored (suppressible via `test_reports.unknown_key`): the file is shared with tools on independent release cadences, so a key this version does not model must not take a build down. Same posture sphinx-mounts documents for `[[source.mounts]]`.
- **Foreign sub-table**: `[test_reports.build]` — and only that one — is recognised and passed through untouched. It holds the settings of the `test-reports build` command line, one sub-table per artifact it produces (`[test_reports.build.needs]` for turning test reports into a `needs.json` outside Sphinx), none of which this extension does, so it must draw neither an unknown-key warning nor a `tr_*` value. Any other sub-table is an unknown key like any other. The converter PR defines and validates the contents of `build.needs`.
- `tr_rootdir` declares `types=(str, os.PathLike)`: its default is Sphinx's `confdir`, a `_StrPath`, so a plain string — the only thing TOML or a string literal in `conf.py` can supply — used to fail Sphinx's confval type check and take a `-W` build down. Pre-existing, but the documented example newly advertised it.

## Notes

- The section is spelled `test_reports`, matching every other section of `ubproject.schema.json` (`build_tags`, `format_rst`, `needs_json`, …) and leaving the existing `[reports]` — report *templates* — unambiguous.

## Tests

54 tests in `tests/test_project_config.py`: loader validation, normalisation and path anchoring; upward discovery, its repository-root boundary and the layouts a `pyproject.toml` must not end (`docs/pyproject.toml`, workspace member); the foreign-sub-table passthrough; real Sphinx builds asserting the precedence chain (`-D` beats TOML, TOML beats `conf.py`), the warning paths, where a fruitless search ended, and that the documented example — read from `configuration.rst` verbatim — applies without a warning; and that `projectconfig` imports in a process where Sphinx is blocked.

## Review

Reviewed in https://github.com/useblocks/sphinx-test-reports/pull/145#issuecomment-5551256944, addressed in https://github.com/useblocks/sphinx-test-reports/pull/145#issuecomment-5551355689. The CLI-side fixes from that round move with the converter to its own PR.

Second round: https://github.com/useblocks/sphinx-test-reports/pull/145#pullrequestreview-5126626676 — the three fixes, the text corrections and both unconfirmed claims are addressed in 809bd9a; the discovery-rule question across packages stays open for the monorepo.

Two findings from the first review move with the conversion settings and are re-applied in the converter PR: the `need_type` / `case.type` agreement check (both name the need type of a test case, so they must not disagree), and the `link_properties` value-type validation.
