### PR TITLE
build: require Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.12"] # No "3.10", as nose seem to have problems with it
+        python-version: ["3.11", "3.12"]
         sphinx-version: ["5.0", "8.1.3"]
         sphinx_needs-version: ["2.1", "4.2", "5.1", "6.3.0", "8.0.0"]
     steps:
@@ -30,7 +30,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.12"
       - name: Install Nox Dependencies
         run: |
           python -m pip install poetry nox nox-poetry
@@ -61,7 +61,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.12"
       - name: Install Nox Dependencies
         run: |
           python -m pip install poetry nox nox-poetry

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,9 @@ Unreleased
 * Feature: New ``tr_deterministic_case_ids`` option derives test-case IDs from
   the source location instead of the need content, so an ID no longer changes
   when a test starts failing differently.
+* Support: Python 3.10 is no longer supported. It reached the end of upstream
+  support, and dropping it lets the package read TOML with ``tomllib`` from the
+  standard library instead of carrying a backport.
 
 .. _`release:1.4.0`:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 from nox import session
 
-PYTHON_VERSIONS = ["3.10", "3.12"]
+PYTHON_VERSIONS = ["3.11", "3.12"]
 SPHINX_VERSIONS = ["5.0", "7.2.5", "8.1.3"]
 SPHINX_NEEDS_VERSIONS = ["2.1", "4.2", "5.1", "6.0.0", "6.3.0", "8.0.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,12 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Topic :: Documentation",
 ]
 keywords = ["sphinx", "documentation", "test-reports"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["sphinx>4.0", "lxml", "sphinx-needs>=1.0.1", "packaging>=20.0"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Python 3.10 reached the end of upstream support.

The floor matters beyond housekeeping: `tomllib` landed in 3.11, so a 3.10 floor means carrying `tomli` as a dependency purely for older interpreters. Split out of #145, which needs a stdlib TOML parser, so the version bump can be reviewed and merged on its own.

## Changes

- `requires-python` `>=3.10` → `>=3.11`
- `noxfile.py` and the CI test matrix run 3.11/3.12
- the `3.9` and `3.10` classifiers go (3.9 was already stale — `requires-python` has excluded it for some time)
- the `pre-commit` and `linkcheck` jobs pinned Python 3.9 purely to drive nox; they move to 3.12, since 3.9 is two releases past end of life and the sessions they start pick their own interpreter anyway

No source change — nothing in the package uses a 3.11 feature yet. 110 tests pass.

For reference, the sibling repos are already ahead of this: sphinx-codelinks and sphinx-mounts both require `>=3.12`.