### PR TITLE
feat(cli): `test-reports build needs` — Sphinx-free test-XML to needs.json, configured from [test_reports.build.needs]

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,11 @@ Unreleased
   only imports the result. Its settings come from the ``[test_reports.build.needs]``
   table of ``ubproject.toml``, with flags for per-invocation overrides. See
   :ref:`cli`.
+* Feature: The produced ``needs.json`` declares every field it uses in a
+  ``needs_schema``, as Sphinx-Needs does for the files a build writes, so a
+  consumer can read the type of a field from the artifact instead of from a
+  Sphinx build with the extension loaded. The declarations and the fields the
+  extension registers come from one table, so the two cannot drift apart.
 * Support: Python 3.10 is no longer supported. It reached the end of upstream
   support, and dropping it lets the package read TOML with ``tomllib`` from the
   standard library instead of carrying a backport.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,7 +32,9 @@ Unreleased
 * Feature: New ``test-reports convert`` command line interface, converting
   test-result XML into a ``needs.json`` without running Sphinx, so the
   conversion can run as a cacheable build action and the documentation build
-  only imports the result. See :ref:`cli`.
+  only imports the result. Its settings come from the ``[test_reports.convert]``
+  table of ``ubproject.toml``, with flags for per-invocation overrides. See
+  :ref:`cli`.
 * Support: Python 3.10 is no longer supported. It reached the end of upstream
   support, and dropping it lets the package read TOML with ``tomllib`` from the
   standard library instead of carrying a backport.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,19 @@ Unreleased
   consumer can read the type of a field from the artifact instead of from a
   Sphinx build with the extension loaded. The declarations and the fields the
   extension registers come from one table, so the two cannot drift apart.
+* Bugfix: ``tr_file_option``, ``tr_source_file_option`` and
+  ``tr_source_line_option`` may no longer name a fixed field such as ``case``
+  or ``result``, in ``conf.py`` or in the declarative file. The build
+  previously stopped with a bare ``TypeError`` from inside a directive.
+* Support: ``result_text`` and ``remote_url`` are registered as need fields by
+  the extension, so a ``needs.json`` the ``build needs`` command produced
+  imports without dropping them. A project that registered ``remote_url``
+  itself keeps its own registration.
+* Known: Sphinx 9 renders a configuration error raised from the declarative
+  file -- a wrong type, a rename onto a fixed field, a disagreeing need type
+  -- as its crash report rather than as a one-line message; the message is in
+  the report. A typo in ``[test_reports.build.needs]`` is reported the same
+  way.
 * Support: Python 3.10 is no longer supported. It reached the end of upstream
   support, and dropping it lets the package read TOML with ``tomllib`` from the
   standard library instead of carrying a backport.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,7 +29,7 @@ Unreleased
   root;
   the new ``tr_config_from_toml`` names or disables it. Precedence is ``-D`` >
   ``ubproject.toml`` > ``conf.py`` > default. See :ref:`tr_config_from_toml`.
-* Feature: New ``test-reports convert`` command line interface, converting
+* Feature: New ``test-reports build needs`` command line interface, converting
   test-result XML into a ``needs.json`` without running Sphinx, so the
   conversion can run as a cacheable build action and the documentation build
   only imports the result. Its settings come from the ``[test_reports.convert]``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,7 +32,7 @@ Unreleased
 * Feature: New ``test-reports build needs`` command line interface, converting
   test-result XML into a ``needs.json`` without running Sphinx, so the
   conversion can run as a cacheable build action and the documentation build
-  only imports the result. Its settings come from the ``[test_reports.convert]``
+  only imports the result. Its settings come from the ``[test_reports.build.needs]``
   table of ``ubproject.toml``, with flags for per-invocation overrides. See
   :ref:`cli`.
 * Support: Python 3.10 is no longer supported. It reached the end of upstream

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,10 @@ Unreleased
   root;
   the new ``tr_config_from_toml`` names or disables it. Precedence is ``-D`` >
   ``ubproject.toml`` > ``conf.py`` > default. See :ref:`tr_config_from_toml`.
+* Feature: New ``test-reports convert`` command line interface, converting
+  test-result XML into a ``needs.json`` without running Sphinx, so the
+  conversion can run as a cacheable build action and the documentation build
+  only imports the result. See :ref:`cli`.
 * Support: Python 3.10 is no longer supported. It reached the end of upstream
   support, and dropping it lets the package read TOML with ``tomllib`` from the
   standard library instead of carrying a backport.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,124 @@
+.. _cli:
+
+Command line interface
+======================
+.. versionadded:: 1.5.0
+
+``Sphinx-Test-Reports`` ships a ``test-reports`` command that converts
+test-result XML into a ``needs.json`` **without running Sphinx**.
+
+Why this exists: parsing test results inside a documentation build couples the
+two, so results cannot be converted without building docs, the conversion cannot
+be cached by a build system, and the data is unavailable to anything else. The
+CLI splits the computation out; the documentation build only imports the result.
+
+The command imports no Sphinx code at all, so it can run as a build action in an
+environment that has no documentation toolchain installed.
+
+Converting a report
+-------------------
+
+.. code-block:: bash
+
+   test-reports convert bazel-testlogs/my_target/test.xml --output needs.json
+
+Several reports can be converted into one file -- a build system typically
+passes them as a file list:
+
+.. code-block:: bash
+
+   test-reports convert report_a.xml report_b.xml --output needs.json
+
+Each test case becomes one need, with the source location under the ``file`` and
+``line`` fields, the result under ``result``, a one-line ``result_text``, and the
+full failure evidence (every ``<failure>``/``<skipped>`` part plus captured
+output) in the need content.
+
+Consuming the result
+--------------------
+
+The output is a schema-conform ``needs.json``, so it can be imported as local
+needs:
+
+.. code-block:: rst
+
+   .. needimport:: needs.json
+
+or mounted as external needs via ``needs_external_needs`` in ``conf.py``.
+
+Every need carries the synthesized source URL twice: as ``external_url``, which
+Sphinx-Needs uses when rendering a link to an external need, and as a plain
+``remote_url`` field, so needs imported as *local* needs keep a clickable link
+through a ``needs_string_links`` entry.
+
+Linking test cases to requirements
+----------------------------------
+
+XML ``<properties>`` become need fields under their own names. To turn one into a
+link field instead, map it -- the value is split on commas:
+
+.. code-block:: bash
+
+   test-reports convert test.xml --output needs.json \
+       --link-property PartiallyVerifies=partially_verifies \
+       --link-property FullyVerifies=fully_verifies
+
+Mapped link fields are written even when a case has no such property, so a schema
+can require them.
+
+Source links
+------------
+
+Source URLs need both a repository and a commit; they are refused separately,
+because half the metadata cannot produce a URL:
+
+.. code-block:: bash
+
+   test-reports convert test.xml --output needs.json \
+       --remote-url git@github.com:org/repo.git \
+       --commit "$(git rev-parse HEAD)"
+
+Git remotes are accepted in ``scp`` form and normalised. Without this metadata --
+as in a hermetic sandbox -- the URL fields stay empty rather than carrying a
+placeholder that looks real and then 404s.
+
+Forges that lay out blob URLs differently are handled with ``--url-pattern``,
+which accepts the placeholders ``{base}``, ``{commit}``, ``{file}`` and
+``{line}``:
+
+.. code-block:: bash
+
+   test-reports convert test.xml --output needs.json \
+       --remote-url https://gitlab.com/org/repo --commit abc123 \
+       --url-pattern "{base}/-/blob/{commit}/{file}#L{line}"
+
+Reproducible output
+-------------------
+
+The written file is byte-stable: keys are sorted and no timestamp is recorded.
+Converting the same report twice produces identical bytes, so the output works as
+a cached build-action output and as diffable evidence.
+
+Missing source locations
+------------------------
+
+If no test case in a report carries a ``line`` attribute, the command says so on
+stderr. The usual cause is pytest's default ``junit_family = xunit2``, which
+filters ``file`` and ``line`` off ``<testcase>``; ``xunit1`` (or ``legacy``)
+emits them.
+
+All options
+-----------
+
+.. code-block:: text
+
+   test-reports convert FILE [FILE ...] --output PATH
+                        [--project NAME] [--version KEY]
+                        [--need-type TYPE] [--tags TAGS]
+                        [--link-property PROPERTY=LINK_FIELD]
+                        [--remote-url URL] [--commit COMMITISH]
+                        [--url-pattern PATTERN]
+
+``--project`` and ``--version`` fill the ``needs.json`` envelope;
+``--need-type`` (default ``testcase``) sets the need type and the ID prefix;
+``--tags`` is a comma-separated list applied to every created need.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -36,11 +36,14 @@ error naming the affected IDs rather than writing a valid-looking file that has
 lost evidence.
 
 Each test case becomes one need shaped exactly like the need the build's
-``test-case`` directive creates for it: ``suite``, ``case``, ``case_name``,
-``case_parameter``, ``classname``, ``result`` and ``time``; the report path
-under ``file``; the test's source location under ``case_file`` and
-``case_line``; a one-line ``result_text``; and the full failure evidence (every
-``<failure>``/``<skipped>`` part plus captured output) in the need content.
+``test-case`` directive creates for it: titled with the case name; ``suite``,
+``case``, ``case_name``, ``case_parameter``, ``classname``, ``result`` (spelled
+as the build spells it -- ``passed``, ``failure``, ``error``, ``skipped``,
+``disabled`` -- so one filter matches imported and local cases alike) and
+``time``; the report path under ``file``; the test's source location under
+``case_file`` and ``case_line``; a one-line ``result_text``; and the full
+failure evidence (every ``<failure>``/``<skipped>`` part plus captured output)
+in the need content.
 
 The three renameable fields carry the names the build's ``tr_file_option``,
 ``tr_source_file_option`` and ``tr_source_line_option`` select -- the converter
@@ -115,8 +118,11 @@ An XML ``<property>`` becomes a need field under its own name when it is listed
 in the ``extra_options`` of the ``[test_reports]`` section -- the same list that
 makes the build register the field and accept it, so an import never has to drop
 it as an unknown key -- or given with ``--extra-option NAME``. Properties named
-by neither are left out, and the command says which, once. To turn a property
-into a link field instead, map it -- the value is split on commas:
+by neither are left out, and the command says which, once. A listed property is
+written for every case -- ``null`` where a case has no such property, as the
+build leaves a field a directive did not set -- so a schema can require it. To
+turn a property into a link field instead, map it -- the value is split on
+commas:
 
 .. code-block:: bash
 
@@ -137,8 +143,8 @@ and lists ``TestType`` and ``DerivationTechnique`` in ``extra_options``.
 
 A property whose name is already taken by a built-in field (``result``,
 ``file``, ``time``, ...) or by a mapped link field is not exported: the built-in
-value wins, and the command says so on stderr. Rename the property, or map it to
-a link field, to get it into the need.
+value wins, and the command says so on stderr, once. Rename the property, or map
+it to a link field, to get it into the need.
 
 Source links
 ------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -145,9 +145,11 @@ because half the metadata cannot produce a URL:
        --remote-url git@github.com:org/repo.git \
        --commit "$(git rev-parse HEAD)"
 
-Git remotes are accepted in ``scp`` form and normalised. Without this metadata --
-as in a hermetic sandbox -- the URL fields stay empty rather than carrying a
-placeholder that looks real and then 404s.
+Git remotes are accepted in ``scp`` form and normalised, and credentials are
+stripped -- ``https://gitlab-ci-token:TOKEN@gitlab.example/org/repo.git`` is
+what GitLab's ``CI_REPOSITORY_URL`` looks like, and the base is written into
+every need. Without this metadata -- as in a hermetic sandbox -- the URL fields
+stay empty rather than carrying a placeholder that looks real and then 404s.
 
 Forges that lay out blob URLs differently are handled with ``--url-pattern``,
 which accepts the placeholders ``{base}``, ``{commit}``, ``{file}`` and
@@ -159,9 +161,10 @@ which accepts the placeholders ``{base}``, ``{commit}``, ``{file}`` and
        --remote-url https://gitlab.com/org/repo --commit abc123 \
        --url-pattern "{base}/-/blob/{commit}/{file}#L{line}"
 
-The template is checked before any report is read: an unknown placeholder or an
-unbalanced brace is a configuration error naming the problem, not a traceback on
-the first case that happens to carry a file.
+The template is checked before any report is read: an unknown placeholder, an
+attribute lookup such as ``{base.x}`` or an unbalanced brace is a configuration
+error naming the problem, not a traceback on the first case that happens to
+carry a file.
 
 .. _cli-declarative:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -48,6 +48,30 @@ reads them from the same ``[test_reports]`` section (:ref:`tr_config_from_toml`)
 so a project that spells its source location ``file``/``line`` gets a
 ``needs.json`` that says so too.
 
+Every field is declared in the file, under ``versions.<version>.needs_schema``,
+the way Sphinx-Needs declares the fields of the ``needs.json`` a build writes:
+its JSON type, a description, and whether it is a core field, a registered
+field or a link field. Configured ``extra_options`` and mapped link fields are
+declared whether or not a case populated them -- the block describes the
+format, not the one report at hand. So a consumer that never runs Sphinx (a
+schema check, a metamodel validator) can read the type of every field from the
+artifact:
+
+.. code-block:: json
+
+   "time": {
+     "type": ["string", "null"],
+     "description": "Test execution time, in seconds",
+     "field_type": "extra",
+     "default": null
+   }
+
+The declarations and the fields the extension registers with Sphinx-Needs come
+from one table, so a field cannot be typed one way in the file and another way
+in the build. ``time`` is declared a string because that is what the build's
+``test-case`` directive writes; turning it into a number is
+`#156 <https://github.com/useblocks/sphinx-test-reports/issues/156>`__.
+
 Consuming the result
 --------------------
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -60,7 +60,9 @@ needs:
 
 or mounted as external needs via ``needs_external_needs`` in ``conf.py``.
 
-Two things a build has to allow for. The IDs are lowercase
+Importing needs sphinx-needs 4 or newer: older versions read the need text
+from a ``description`` key, the converter writes ``content`` like every version
+since. Two things a build has to allow for. The IDs are lowercase
 (``testcase__MathTest__Addition_hcuyy``), the scheme S-CORE's tooling uses, and
 sphinx-needs' default ``needs_id_regex`` accepts capitals only -- widen it, e.g.
 ``needs_id_regex = "^[A-Za-z0-9_]{5,}"``, or every import is refused (see also

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -29,6 +29,12 @@ passes them as a file list:
 
    test-reports convert report_a.xml report_b.xml --output needs.json
 
+Every test case must be unique across the given reports. A case's ID is derived
+from where the test is, so the same case twice -- typically the same report
+given twice -- would collapse into one need; the command refuses that with an
+error naming the affected IDs rather than writing a valid-looking file that has
+lost evidence.
+
 Each test case becomes one need, with the source location under the ``file`` and
 ``line`` fields, the result under ``result``, a one-line ``result_text``, and the
 full failure evidence (every ``<failure>``/``<skipped>`` part plus captured
@@ -65,6 +71,11 @@ link field instead, map it -- the value is split on commas:
 
 Mapped link fields are written even when a case has no such property, so a schema
 can require them.
+
+A property whose name is already taken by a built-in field (``result``,
+``file``, ``time``, ...) or by a mapped link field is not exported: the built-in
+value wins, and the command says so on stderr. Rename the property, or map it to
+a link field, to get it into the need.
 
 Source links
 ------------
@@ -136,9 +147,11 @@ ignored. The whole ``[test_reports]`` section is validated, not only the
 refuse.
 
 ``need_type`` and the ``type`` of the build's ``case`` entry both name the need
-type of a test case, so a file that sets them to different values is rejected:
-a ``needs.json`` written with one type is neither registered nor cross-linked by
-a build configured with the other.
+type of a test case, so they must agree: a ``needs.json`` written with one type
+is neither registered nor cross-linked by a build configured with the other. The
+rule holds for the *merged* value -- a ``--need-type`` flag, or the built-in
+default, disagreeing with the file's ``case`` is refused just like a
+disagreeing ``need_type`` in the file.
 
 Reproducible output
 -------------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -92,6 +92,54 @@ which accepts the placeholders ``{base}``, ``{commit}``, ``{file}`` and
        --remote-url https://gitlab.com/org/repo --commit abc123 \
        --url-pattern "{base}/-/blob/{commit}/{file}#L{line}"
 
+.. _cli-declarative:
+
+Declarative configuration
+-------------------------
+
+None of the settings above has to be spelled as a flag. The command reads the
+``[test_reports.convert]`` table of ``ubproject.toml`` -- the same declarative
+file the documentation build reads (see :ref:`tr_config_from_toml`), so the two
+consumers of a project never work from different descriptions of it. By default
+the file is searched for in the working directory and its parents, stopping at
+the project root (a directory holding ``.git`` or ``pyproject.toml``); an absent
+default file is not an error.
+
+.. code-block:: toml
+
+   [test_reports.convert]
+   project = "My Project"
+   version = "2.0"
+   need_type = "testcase"
+   tags = ["ci", "unit"]
+   link_properties = { PartiallyVerifies = "partially_verifies" }
+   remote_url = "https://github.com/org/repo"
+   url_pattern = "{base}/blob/{commit}/{file}#L{line}"
+
+.. code-block:: bash
+
+   test-reports convert bazel-testlogs/my_target/test.xml --output needs.json \
+       --commit "$(git rev-parse HEAD)"
+
+**Precedence** is flag > table > built-in default. A flag given alongside the
+file overrides that key -- the natural home for per-invocation values such as
+the commit a CI job is converting for. ``--link-property``, given at all,
+replaces the whole ``link_properties`` table. ``--config PATH`` reads a
+different file (used as-is, not searched for, and it must exist);
+``--no-config`` ignores declarative configuration entirely, so the output
+depends only on the arguments given.
+
+**Validation** follows the file's own policy: a known key with the wrong type
+stops the conversion with an error, an unknown key is reported on stderr and
+ignored. The whole ``[test_reports]`` section is validated, not only the
+``convert`` table, so the converter refuses exactly the files the build would
+refuse.
+
+``need_type`` and the ``type`` of the build's ``case`` entry both name the need
+type of a test case, so a file that sets them to different values is rejected:
+a ``needs.json`` written with one type is neither registered nor cross-linked by
+a build configured with the other.
+
 Reproducible output
 -------------------
 
@@ -113,6 +161,7 @@ All options
 .. code-block:: text
 
    test-reports convert FILE [FILE ...] --output PATH
+                        [--config PATH | --no-config]
                         [--project NAME] [--version KEY]
                         [--need-type TYPE] [--tags TAGS]
                         [--link-property PROPERTY=LINK_FIELD]
@@ -121,4 +170,6 @@ All options
 
 ``--project`` and ``--version`` fill the ``needs.json`` envelope;
 ``--need-type`` (default ``testcase``) sets the need type and the ID prefix;
-``--tags`` is a comma-separated list applied to every created need.
+``--tags`` is a comma-separated list applied to every created need. Every one
+of these can also come from ``[test_reports.convert]`` in ``ubproject.toml``;
+a flag wins.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -94,7 +94,15 @@ into a link field instead, map it -- the value is split on commas:
        --link-property FullyVerifies=fully_verifies
 
 Mapped link fields are written even when a case has no such property, so a schema
-can require them.
+can require them. A test run that names its link properties
+``PartiallyVerifies`` and ``FullyVerifies`` is configured as
+
+.. code-block:: toml
+
+   [test_reports.convert]
+   link_properties = { PartiallyVerifies = "partially_verifies", FullyVerifies = "fully_verifies" }
+
+and lists ``TestType`` and ``DerivationTechnique`` in ``extra_options``.
 
 A property whose name is already taken by a built-in field (``result``,
 ``file``, ``time``, ...) or by a mapped link field is not exported: the built-in
@@ -194,7 +202,9 @@ Missing source locations
 If no test case in a report carries a ``line`` attribute, the command says so on
 stderr. The usual cause is pytest's default ``junit_family = xunit2``, which
 filters ``file`` and ``line`` off ``<testcase>``; ``xunit1`` (or ``legacy``)
-emits them.
+emits them -- and only through the ``record_xml_attribute`` fixture, which a
+stock run never calls. A test run therefore has to set ``junit_family`` and
+write the attributes itself for the source location to reach the needs.
 
 All options
 -----------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -120,9 +120,12 @@ makes the build register the field and accept it, so an import never has to drop
 it as an unknown key -- or given with ``--extra-option NAME``. Properties named
 by neither are left out, and the command says which, once. A listed property is
 written for every case -- ``null`` where a case has no such property, as the
-build leaves a field a directive did not set -- so a schema can require it. To
-turn a property into a link field instead, map it -- the value is split on
-commas:
+build leaves a field a directive did not set -- so a schema can require it.
+``--extra-option`` adds to the section's list rather than replacing it
+(``--no-config`` leaves the file out); a name that list does not contain is
+reported, because the build registers exactly the listed fields and
+``needimport`` drops every other one. To turn a property into a link field
+instead, map it -- the value is split on commas:
 
 .. code-block:: bash
 
@@ -189,8 +192,10 @@ None of the settings above has to be spelled as a flag. The command reads the
 file the documentation build reads (see :ref:`tr_config_from_toml`), so the two
 consumers of a project never work from different descriptions of it. By default
 the file is searched for in the working directory and its parents, stopping at
-the project root (a directory holding ``.git`` or ``pyproject.toml``); an absent
-default file is not an error.
+the repository root (the directory holding ``.git``) or, outside a repository,
+at the directory holding ``pyproject.toml``. An absent default file is not an
+error. A found one is named on stderr: it may sit directories above the
+invocation, and the output depends on it.
 
 .. code-block:: toml
 
@@ -215,15 +220,15 @@ replaces the whole ``link_properties`` table. ``--config PATH`` reads a
 different file (used as-is, not searched for, and it must exist);
 ``--no-config`` ignores declarative configuration entirely, so the output
 depends only on the arguments given. A run without a file is quiet by default
--- most projects have none -- but ``-v`` says which file was read, or where the
-search ended and why, so a misplaced file can be placed right; the Sphinx build
-says the same at ``sphinx-build -v``.
+-- most projects have none -- but ``-v`` says where the search ended and why,
+so a misplaced file can be placed right, and names a ``--config`` file; the
+Sphinx build says the same at ``sphinx-build -v``.
 
 **Validation** follows the file's own policy: a known key with the wrong type
 stops the conversion with an error, an unknown key is reported on stderr and
 ignored. The whole ``[test_reports]`` section is validated, not only the
-``convert`` table, so the converter refuses exactly the files the build would
-refuse.
+``build.needs`` table, so the converter refuses exactly the files the build
+would refuse.
 
 ``need_type`` and the ``type`` of the build's ``case`` entry both name the need
 type of a test case, so they must agree: a ``needs.json`` written with one type
@@ -238,6 +243,15 @@ Reproducible output
 The written file is byte-stable: keys are sorted and no timestamp is recorded.
 Converting the same report twice produces identical bytes, so the output works as
 a cached build-action output and as diffable evidence.
+
+Empty reports
+-------------
+
+A report without a single test case adds no needs, and the command says so on
+stderr. A file that is not a test report at all -- a ``pom.xml``, a
+``coverage.xml`` given by mistake -- parses as one empty suite, so a valid,
+empty ``needs.json`` with exit code 0 would otherwise be the silent outcome of
+exactly the mistake a cached build action needs to hear about.
 
 Missing source locations
 ------------------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -20,14 +20,14 @@ Converting a report
 
 .. code-block:: bash
 
-   test-reports convert bazel-testlogs/my_target/test.xml --output needs.json
+   test-reports build needs bazel-testlogs/my_target/test.xml --output needs.json
 
 Several reports can be converted into one file -- a build system typically
 passes them as a file list:
 
 .. code-block:: bash
 
-   test-reports convert report_a.xml report_b.xml --output needs.json
+   test-reports build needs report_a.xml report_b.xml --output needs.json
 
 Every test case must be unique across the given reports. A case's ID is derived
 from where the test is, so the same case twice -- typically the same report
@@ -89,7 +89,7 @@ into a link field instead, map it -- the value is split on commas:
 
 .. code-block:: bash
 
-   test-reports convert test.xml --output needs.json \
+   test-reports build needs test.xml --output needs.json \
        --link-property PartiallyVerifies=partially_verifies \
        --link-property FullyVerifies=fully_verifies
 
@@ -109,7 +109,7 @@ because half the metadata cannot produce a URL:
 
 .. code-block:: bash
 
-   test-reports convert test.xml --output needs.json \
+   test-reports build needs test.xml --output needs.json \
        --remote-url git@github.com:org/repo.git \
        --commit "$(git rev-parse HEAD)"
 
@@ -123,7 +123,7 @@ which accepts the placeholders ``{base}``, ``{commit}``, ``{file}`` and
 
 .. code-block:: bash
 
-   test-reports convert test.xml --output needs.json \
+   test-reports build needs test.xml --output needs.json \
        --remote-url https://gitlab.com/org/repo --commit abc123 \
        --url-pattern "{base}/-/blob/{commit}/{file}#L{line}"
 
@@ -157,7 +157,7 @@ default file is not an error.
 
 .. code-block:: bash
 
-   test-reports convert bazel-testlogs/my_target/test.xml --output needs.json \
+   test-reports build needs bazel-testlogs/my_target/test.xml --output needs.json \
        --commit "$(git rev-parse HEAD)"
 
 **Precedence** is flag > table > built-in default. A flag given alongside the
@@ -201,8 +201,8 @@ All options
 
 .. code-block:: text
 
-   test-reports convert FILE [FILE ...] --output PATH
-                        [--config PATH | --no-config]
+   test-reports build needs FILE [FILE ...] --output PATH
+                            [--config PATH | --no-config]
                         [--project NAME] [--version KEY]
                         [--need-type TYPE] [--tags TAGS]
                         [--extra-option NAME] [--link-property PROPERTY=LINK_FIELD]

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -174,7 +174,10 @@ the commit a CI job is converting for. ``--link-property``, given at all,
 replaces the whole ``link_properties`` table. ``--config PATH`` reads a
 different file (used as-is, not searched for, and it must exist);
 ``--no-config`` ignores declarative configuration entirely, so the output
-depends only on the arguments given.
+depends only on the arguments given. A run without a file is quiet by default
+-- most projects have none -- but ``-v`` says which file was read, or where the
+search ended and why, so a misplaced file can be placed right; the Sphinx build
+says the same at ``sphinx-build -v``.
 
 **Validation** follows the file's own policy: a known key with the wrong type
 stops the conversion with an error, an unknown key is reported on stderr and
@@ -212,7 +215,7 @@ All options
 .. code-block:: text
 
    test-reports build needs FILE [FILE ...] --output PATH
-                            [--config PATH | --no-config]
+                            [--config PATH | --no-config] [-v]
                         [--project NAME] [--version KEY]
                         [--need-type TYPE] [--tags TAGS]
                         [--extra-option NAME] [--link-property PROPERTY=LINK_FIELD]

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -99,7 +99,7 @@ can require them. A test run that names its link properties
 
 .. code-block:: toml
 
-   [test_reports.convert]
+   [test_reports.build.needs]
    link_properties = { PartiallyVerifies = "partially_verifies", FullyVerifies = "fully_verifies" }
 
 and lists ``TestType`` and ``DerivationTechnique`` in ``extra_options``.
@@ -145,7 +145,7 @@ Declarative configuration
 -------------------------
 
 None of the settings above has to be spelled as a flag. The command reads the
-``[test_reports.convert]`` table of ``ubproject.toml`` -- the same declarative
+``[test_reports.build.needs]`` table of ``ubproject.toml`` -- the same declarative
 file the documentation build reads (see :ref:`tr_config_from_toml`), so the two
 consumers of a project never work from different descriptions of it. By default
 the file is searched for in the working directory and its parents, stopping at
@@ -154,7 +154,7 @@ default file is not an error.
 
 .. code-block:: toml
 
-   [test_reports.convert]
+   [test_reports.build.needs]
    project = "My Project"
    version = "2.0"
    need_type = "testcase"
@@ -225,5 +225,5 @@ All options
 ``--project`` and ``--version`` fill the ``needs.json`` envelope;
 ``--need-type`` (default ``testcase``) sets the need type and the ID prefix;
 ``--tags`` is a comma-separated list applied to every created need. Every one
-of these can also come from ``[test_reports.convert]`` in ``ubproject.toml``;
+of these can also come from ``[test_reports.build.needs]`` in ``ubproject.toml``;
 a flag wins.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -46,7 +46,14 @@ The three renameable fields carry the names the build's ``tr_file_option``,
 ``tr_source_file_option`` and ``tr_source_line_option`` select -- the converter
 reads them from the same ``[test_reports]`` section (:ref:`tr_config_from_toml`),
 so a project that spells its source location ``file``/``line`` gets a
-``needs.json`` that says so too.
+``needs.json`` that says so too. That section is the only place it can read
+them from: a rename made in ``conf.py`` alone is invisible to the converter,
+which then writes the default names -- ``needimport`` drops ``case_file`` and
+``case_line`` as unknown keys, and the report path lands in ``file``, the field
+such a project defines as the *source* file. Renames belong in
+``ubproject.toml``. None of the three may take the name of a fixed field
+(``case``, ``result``, ...); both consumers refuse such a configuration, since
+the field would be written twice.
 
 Every field is declared in the file, under ``versions.<version>.needs_schema``,
 the way Sphinx-Needs declares the fields of the ``needs.json`` a build writes:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -101,8 +101,9 @@ since. Two things a build has to allow for. The IDs are lowercase
 sphinx-needs' default ``needs_id_regex`` accepts capitals only -- widen it, e.g.
 ``needs_id_regex = "^[A-Za-z0-9_]{5,}"``, or every import is refused (see also
 ``tr_deterministic_case_ids`` in :ref:`configuration`). And a link field
-created with ``--link-property`` has to exist as a link type
-(``needs_extra_links``), as for any need. The plain fields the converter adds
+created with ``--link-property`` has to exist as a link type (``needs_links``;
+``needs_extra_links`` before sphinx-needs 6.3), as for any need. The plain
+fields the converter adds
 beyond the directive's (``result_text``, ``remote_url``) are registered by the
 extension, so ``needimport`` keeps them.
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -35,10 +35,18 @@ given twice -- would collapse into one need; the command refuses that with an
 error naming the affected IDs rather than writing a valid-looking file that has
 lost evidence.
 
-Each test case becomes one need, with the source location under the ``file`` and
-``line`` fields, the result under ``result``, a one-line ``result_text``, and the
-full failure evidence (every ``<failure>``/``<skipped>`` part plus captured
-output) in the need content.
+Each test case becomes one need shaped exactly like the need the build's
+``test-case`` directive creates for it: ``suite``, ``case``, ``case_name``,
+``case_parameter``, ``classname``, ``result`` and ``time``; the report path
+under ``file``; the test's source location under ``case_file`` and
+``case_line``; a one-line ``result_text``; and the full failure evidence (every
+``<failure>``/``<skipped>`` part plus captured output) in the need content.
+
+The three renameable fields carry the names the build's ``tr_file_option``,
+``tr_source_file_option`` and ``tr_source_line_option`` select -- the converter
+reads them from the same ``[test_reports]`` section (:ref:`tr_config_from_toml`),
+so a project that spells its source location ``file``/``line`` gets a
+``needs.json`` that says so too.
 
 Consuming the result
 --------------------
@@ -52,6 +60,16 @@ needs:
 
 or mounted as external needs via ``needs_external_needs`` in ``conf.py``.
 
+Two things a build has to allow for. The IDs are lowercase
+(``testcase__MathTest__Addition_hcuyy``), the scheme S-CORE's tooling uses, and
+sphinx-needs' default ``needs_id_regex`` accepts capitals only -- widen it, e.g.
+``needs_id_regex = "^[A-Za-z0-9_]{5,}"``, or every import is refused (see also
+``tr_deterministic_case_ids`` in :ref:`configuration`). And a link field
+created with ``--link-property`` has to exist as a link type
+(``needs_extra_links``), as for any need. The plain fields the converter adds
+beyond the directive's (``result_text``, ``remote_url``) are registered by the
+extension, so ``needimport`` keeps them.
+
 Every need carries the synthesized source URL twice: as ``external_url``, which
 Sphinx-Needs uses when rendering a link to an external need, and as a plain
 ``remote_url`` field, so needs imported as *local* needs keep a clickable link
@@ -60,8 +78,12 @@ through a ``needs_string_links`` entry.
 Linking test cases to requirements
 ----------------------------------
 
-XML ``<properties>`` become need fields under their own names. To turn one into a
-link field instead, map it -- the value is split on commas:
+An XML ``<property>`` becomes a need field under its own name when it is listed
+in the ``extra_options`` of the ``[test_reports]`` section -- the same list that
+makes the build register the field and accept it, so an import never has to drop
+it as an unknown key -- or given with ``--extra-option NAME``. Properties named
+by neither are left out, and the command says which, once. To turn a property
+into a link field instead, map it -- the value is split on commas:
 
 .. code-block:: bash
 
@@ -102,6 +124,10 @@ which accepts the placeholders ``{base}``, ``{commit}``, ``{file}`` and
    test-reports convert test.xml --output needs.json \
        --remote-url https://gitlab.com/org/repo --commit abc123 \
        --url-pattern "{base}/-/blob/{commit}/{file}#L{line}"
+
+The template is checked before any report is read: an unknown placeholder or an
+unbalanced brace is a configuration error naming the problem, not a traceback on
+the first case that happens to carry a file.
 
 .. _cli-declarative:
 
@@ -177,7 +203,7 @@ All options
                         [--config PATH | --no-config]
                         [--project NAME] [--version KEY]
                         [--need-type TYPE] [--tags TAGS]
-                        [--link-property PROPERTY=LINK_FIELD]
+                        [--extra-option NAME] [--link-property PROPERTY=LINK_FIELD]
                         [--remote-url URL] [--commit COMMITISH]
                         [--url-pattern PATTERN]
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -456,7 +456,7 @@ catch. An *unknown* key is reported as a warning and ignored: the file is
 shared with tools on independent release cadences, so a key this version does
 not model must not take your build down.
 
-The ``[test_reports.convert]`` sub-table holds the settings of the
+The ``[test_reports.build.needs]`` sub-table holds the settings of the
 :ref:`build needs command <cli-declarative>`. The build validates it along with
 the rest of the section -- so a typo is caught whichever consumer reads the file
 first -- but never applies it to a ``tr_*`` value. One rule spans both:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -444,7 +444,13 @@ acting on it works from the same settings instead of each restating them.
    # case = ["test-case", "testcase", "Test-Case", "TC_", "#999999", "rectangle"]
 
 **Keys.** Every key is named like its ``tr_*`` config value without the prefix
-(``file_option`` configures ``tr_file_option``, and so on). A key carrying the
+(``file_option`` configures ``tr_file_option``, and so on). The build applies
+them all; the :ref:`convert command <cli>` reads the three field-name keys
+(``file_option``, ``source_file_option``, ``source_line_option``) and
+``extra_options`` as well, so the needs it writes have the shape of the needs
+the build creates and carry exactly the fields the build accepts -- and it
+refuses a file whose two path fields share a name, as the build does. A key
+carrying the
 wrong type is an error -- that is the typo class this validation exists to
 catch. An *unknown* key is reported as a warning and ignored: the file is
 shared with tools on independent release cadences, so a key this version does

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -450,11 +450,13 @@ catch. An *unknown* key is reported as a warning and ignored: the file is
 shared with tools on independent release cadences, so a key this version does
 not model must not take your build down.
 
-One sub-table belongs to another tool and is left alone: ``[test_reports.build]``
-holds the settings of the ``test-reports build`` command line, one sub-table per
-artifact it produces -- ``[test_reports.build.needs]`` for turning test reports
-into a ``needs.json`` outside Sphinx -- none of which this extension does. Any
-other sub-table is treated like any other unknown key -- reported and ignored.
+The ``[test_reports.convert]`` sub-table holds the settings of the
+:ref:`convert command <cli-declarative>`. The build validates it along with
+the rest of the section -- so a typo is caught whichever consumer reads the file
+first -- but never applies it to a ``tr_*`` value. One rule spans both:
+``need_type`` in that table and the ``type`` of ``case`` name the same need
+type, and a file setting them to different values is rejected. Any other sub-table is an unknown key like any other --
+reported and ignored.
 
 **Warnings.** The two warnings this feature emits carry a type, so either can
 be silenced through Sphinx's ``suppress_warnings`` in a project that builds

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -445,7 +445,7 @@ acting on it works from the same settings instead of each restating them.
 
 **Keys.** Every key is named like its ``tr_*`` config value without the prefix
 (``file_option`` configures ``tr_file_option``, and so on). The build applies
-them all; the :ref:`convert command <cli>` reads the three field-name keys
+them all; the :ref:`build needs command <cli>` reads the three field-name keys
 (``file_option``, ``source_file_option``, ``source_line_option``) and
 ``extra_options`` as well, so the needs it writes have the shape of the needs
 the build creates and carry exactly the fields the build accepts -- and it
@@ -457,7 +457,7 @@ shared with tools on independent release cadences, so a key this version does
 not model must not take your build down.
 
 The ``[test_reports.convert]`` sub-table holds the settings of the
-:ref:`convert command <cli-declarative>`. The build validates it along with
+:ref:`build needs command <cli-declarative>`. The build validates it along with
 the rest of the section -- so a typo is caught whichever consumer reads the file
 first -- but never applies it to a ``tr_*`` value. One rule spans both:
 ``need_type`` in that table and the ``type`` of ``case`` name the same need

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -146,8 +146,11 @@ rename the report field instead:
    tr_source_file_option = "file"
    tr_source_line_option = "line"
 
-Each of the three options must name a different field; otherwise the build stops
-with a configuration error.
+Each of the three options must name a field of its own -- not one of the other
+two, and not a fixed field such as ``case`` or ``result`` -- or the build stops
+with a configuration error. For the :ref:`build needs command <cli>` to write
+the renamed fields as well, put the renames in ``ubproject.toml``
+(:ref:`tr_config_from_toml`): it cannot see ``conf.py``.
 
 The field is empty when the XML carries no ``file`` attribute. With pytest this
 is the norm: it emits ``file``/``line`` only with ``junit_family = xunit1`` (or
@@ -449,8 +452,8 @@ them all; the :ref:`build needs command <cli>` reads the three field-name keys
 (``file_option``, ``source_file_option``, ``source_line_option``) and
 ``extra_options`` as well, so the needs it writes have the shape of the needs
 the build creates and carry exactly the fields the build accepts -- and it
-refuses a file whose two path fields share a name, as the build does. A key
-carrying the
+refuses a file whose path fields share a name or take a fixed field's, as the
+build does. A key carrying the
 wrong type is an error -- that is the typo class this validation exists to
 catch. An *unknown* key is reported as a warning and ignored: the file is
 shared with tools on independent release cadences, so a key this version does

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,6 +75,7 @@ Content
    install
    directives/index
    configuration
+   cli
    parsers
    filter
    functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ docs = [
 [dependency-groups]
 dev = ["pre-commit~=3.0", "nox>=2025.2.9", "mypy>=1.16.0"]
 
+[project.scripts]
+test-reports = "sphinxcontrib.test_reports.cli:main"
+
 [tool.flit.module]
 name = "sphinxcontrib.test_reports"
 
@@ -88,6 +91,9 @@ show_error_codes = true
 exclude = [
   "^sphinxcontrib/test_reports/__init__\\.py$",
   "^sphinxcontrib/test_reports/config\\.py$",
+  # argparse.Namespace attributes are Any by construction, which
+  # disallow_any_expr rejects; needs a typed settings object first.
+  "^sphinxcontrib/test_reports/cli\\.py$",
   "^sphinxcontrib/test_reports/directives/__init__\\.py$",
   "^sphinxcontrib/test_reports/directives/test_case\\.py$",
   "^sphinxcontrib/test_reports/directives/test_common\\.py$",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,6 @@ show_error_codes = true
 exclude = [
   "^sphinxcontrib/test_reports/__init__\\.py$",
   "^sphinxcontrib/test_reports/config\\.py$",
-  # argparse.Namespace attributes are Any by construction, which
-  # disallow_any_expr rejects; needs a typed settings object first.
-  "^sphinxcontrib/test_reports/cli\\.py$",
   "^sphinxcontrib/test_reports/directives/__init__\\.py$",
   "^sphinxcontrib/test_reports/directives/test_case\\.py$",
   "^sphinxcontrib/test_reports/directives/test_common\\.py$",
@@ -145,13 +142,18 @@ disallow_untyped_defs = true
 # # Config file
 # warn_unused_configs = true
 
-# `test_reports.py` is the Sphinx-facing module: it talks to the sphinx-needs
-# API (which ships no py.typed) and reads `tr_*` config values off the Sphinx
-# config object with `getattr`, so nearly every expression in it is typed
-# `Any`. `disallow_any_expr` cannot be satisfied there without stubs upstream,
-# and it has no counterpart in `ty`, which the sphinx-needs workspace uses.
-# Every other strict check applies, so annotations and real type errors are
-# still caught -- unlike under the `exclude` entry this replaces.
+# The two modules that talk to something untyped by construction:
+# `test_reports.py` to the sphinx-needs API (which ships no py.typed) and to
+# `tr_*` config values read off the Sphinx config with `getattr`; `cli.py` to
+# `argparse.Namespace`, whose attributes are `Any`. Nearly every expression in
+# them is therefore `Any`, which `disallow_any_expr` cannot accept and no
+# amount of local annotation fixes. The flag also has no counterpart in `ty`,
+# which the sphinx-needs workspace uses, so relaxing it here costs nothing
+# there. Every other strict check still applies -- annotations and real type
+# errors are caught, which the `exclude` entries this replaces prevented.
 [[tool.mypy.overrides]]
-module = "sphinxcontrib.test_reports.test_reports"
+module = [
+  "sphinxcontrib.test_reports.test_reports",
+  "sphinxcontrib.test_reports.cli",
+]
 disallow_any_expr = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,14 @@ docs = [
 ]
 
 [dependency-groups]
-dev = ["pre-commit~=3.0", "nox>=2025.2.9", "mypy>=1.16.0"]
+dev = [
+  "pre-commit~=3.0",
+  "nox>=2025.2.9",
+  "mypy>=1.16.0",
+  # Stubs for docutils, which ships none: without them every directive
+  # option spec is untyped and `test_reports.py` cannot be checked.
+  "types-docutils>=0.21",
+]
 
 [project.scripts]
 test-reports = "sphinxcontrib.test_reports.cli:main"
@@ -87,7 +94,7 @@ extend-select = [
 packages = ["sphinxcontrib.test_reports"]
 strict = true
 show_error_codes = true
-# TODO: reactivate below files and fix issues in future PRs
+# TODO: reactivate below files and fix issues in future PRs (#114)
 exclude = [
   "^sphinxcontrib/test_reports/__init__\\.py$",
   "^sphinxcontrib/test_reports/config\\.py$",
@@ -107,7 +114,6 @@ exclude = [
   "^sphinxcontrib/test_reports/functions",
   "^sphinxcontrib/test_reports/jsonparser\\.py$",
   "^sphinxcontrib/test_reports/junitparser\\.py$",
-  "^sphinxcontrib/test_reports/test_reports\\.py$",
 ]
 # Disallow dynamic typing
 disallow_any_unimported = true
@@ -138,3 +144,14 @@ disallow_untyped_defs = true
 
 # # Config file
 # warn_unused_configs = true
+
+# `test_reports.py` is the Sphinx-facing module: it talks to the sphinx-needs
+# API (which ships no py.typed) and reads `tr_*` config values off the Sphinx
+# config object with `getattr`, so nearly every expression in it is typed
+# `Any`. `disallow_any_expr` cannot be satisfied there without stubs upstream,
+# and it has no counterpart in `ty`, which the sphinx-needs workspace uses.
+# Every other strict check applies, so annotations and real type errors are
+# still caught -- unlike under the `exclude` entry this replaces.
+[[tool.mypy.overrides]]
+module = "sphinxcontrib.test_reports.test_reports"
+disallow_any_expr = false

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -1,0 +1,184 @@
+"""``test-reports`` command line interface.
+
+Converts test-result XML into needs.json *outside* Sphinx, so a build system can
+schedule and cache the conversion and the documentation build only imports the
+result. Nothing in the import chain of this module may import Sphinx; the test
+suite asserts that.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from sphinxcontrib.test_reports.junitparser import JUnitParser
+from sphinxcontrib.test_reports.needs_export import DEFAULT_VERSION, build_needs_file
+from sphinxcontrib.test_reports.remote import DEFAULT_URL_PATTERN, normalise_remote_url
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="test-reports",
+        description="Convert test-result XML into sphinx-needs data.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    convert = subcommands.add_parser(
+        "convert",
+        help="Convert one or more test-result XML files into needs.json.",
+        description=(
+            "Convert one or more test-result XML files into a needs.json that "
+            "can be consumed with needimport or needs_external_needs."
+        ),
+    )
+    convert.add_argument(
+        "files",
+        nargs="+",
+        metavar="FILE",
+        help="Test-result XML files (a build system passes these as a file list).",
+    )
+    convert.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        metavar="PATH",
+        help="Where to write the needs.json.",
+    )
+    convert.add_argument(
+        "--project",
+        default="",
+        help="Project name recorded in the needs.json envelope.",
+    )
+    convert.add_argument(
+        "--version",
+        default=DEFAULT_VERSION,
+        help=f"Version key in the envelope (default: {DEFAULT_VERSION}).",
+    )
+    convert.add_argument(
+        "--need-type",
+        default="testcase",
+        help="Need type for each test case (default: testcase).",
+    )
+    convert.add_argument(
+        "--tags",
+        default="",
+        help="Comma-separated tags applied to every created need.",
+    )
+    convert.add_argument(
+        "--link-property",
+        action="append",
+        default=[],
+        metavar="PROPERTY=LINK_FIELD",
+        help=(
+            "Promote an XML property to a link field, comma-splitting its value "
+            "(repeatable), e.g. PartiallyVerifies=partially_verifies."
+        ),
+    )
+    convert.add_argument(
+        "--remote-url",
+        default="",
+        help="Repository URL used to synthesize source links; git remotes are accepted.",
+    )
+    convert.add_argument(
+        "--commit",
+        default="",
+        help="Commit-ish the reports were produced from.",
+    )
+    convert.add_argument(
+        "--url-pattern",
+        default=DEFAULT_URL_PATTERN,
+        help=f"Source-URL template (default: {DEFAULT_URL_PATTERN}).",
+    )
+    return parser
+
+
+def _parse_link_properties(values: list[str]) -> dict[str, str]:
+    mapping = {}
+    for value in values:
+        property_name, separator, link_field = value.partition("=")
+        if not separator or not property_name.strip() or not link_field.strip():
+            raise ValueError(
+                f"--link-property expects PROPERTY=LINK_FIELD, got {value!r}"
+            )
+        mapping[property_name.strip()] = link_field.strip()
+    return mapping
+
+
+def _warn_about_absent_source_lines(path: Path, suites: list) -> None:
+    """Report the most common cause of a missing source location.
+
+    pytest emits ``file``/``line`` as ``<testcase>`` attributes only under
+    ``junit_family = xunit1`` (or ``legacy``); its default ``xunit2`` filters
+    them out, which silently costs the source location of every case.
+    """
+    cases = [case for suite in suites for case in suite.get("testcases", [])]
+    if cases and all(case.get("line", -1) == -1 for case in cases):
+        print(
+            f"warning: {path}: no <testcase> carries a 'line' attribute, so no "
+            "source location could be recorded. pytest emits file/line only "
+            "with junit_family = xunit1 (or legacy); its default xunit2 drops "
+            "them.",
+            file=sys.stderr,
+        )
+
+
+def _convert(arguments: argparse.Namespace) -> int:
+    try:
+        link_properties = _parse_link_properties(list(arguments.link_property))
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    if bool(arguments.remote_url) != bool(arguments.commit):
+        print(
+            "error: --remote-url and --commit must be given together; without "
+            "both, no source URL can be synthesized.",
+            file=sys.stderr,
+        )
+        return 2
+
+    suites: list = []
+    for name in arguments.files:
+        path = Path(name)
+        if not path.is_file():
+            print(f"error: no such file: {path}", file=sys.stderr)
+            return 1
+        try:
+            parsed = JUnitParser(str(path)).parse()
+        except Exception as error:  # noqa: BLE001 - report, never traceback
+            print(f"error: {path}: {error}", file=sys.stderr)
+            return 1
+        _warn_about_absent_source_lines(path, parsed)
+        suites.extend(parsed)
+
+    payload = build_needs_file(
+        suites,
+        project=arguments.project,
+        version=arguments.version,
+        need_type=arguments.need_type,
+        tags=[tag.strip() for tag in arguments.tags.split(",") if tag.strip()],
+        link_properties=link_properties,
+        base_url=normalise_remote_url(arguments.remote_url),
+        commit=arguments.commit,
+        url_pattern=arguments.url_pattern,
+    )
+
+    output = Path(arguments.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    # Sorted keys and a fixed indent keep the output byte-stable across runs.
+    output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    """Entry point. Returns a process exit code instead of raising."""
+    arguments = _build_parser().parse_args(argv)
+    if arguments.command == "convert":
+        return _convert(arguments)
+    return 2  # pragma: no cover - argparse rejects unknown commands
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -26,6 +26,7 @@ from sphinxcontrib.test_reports.projectconfig import (
     DEFAULT_TOML_FILENAME,
     SECTION,
     TomlConfigError,
+    case_need_type,
     find_project_config,
     load_project_config,
 )
@@ -33,6 +34,10 @@ from sphinxcontrib.test_reports.remote import DEFAULT_URL_PATTERN, normalise_rem
 
 #: How the table is spelled in help texts and diagnostics.
 TABLE = f"[{SECTION}.{CONVERT_TABLE}]"
+
+
+def _warn(message: str) -> None:
+    print(f"warning: {message}", file=sys.stderr)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -191,14 +196,18 @@ def _warn_about_absent_source_lines(path: Path, suites: list) -> None:
         )
 
 
-def _load_convert_table(
+def _load_section(
     arguments: argparse.Namespace,
 ) -> "tuple[dict, Path | None, str | None]":
-    """Load ``[test_reports.convert]``, honouring ``--config``/``--no-config``.
+    """Load the ``[test_reports]`` section, honouring ``--config``/``--no-config``.
 
-    Returns ``(table, path, error_message)``. ``table`` is ``{}`` and ``path``
-    ``None`` when no file applies: an absent *default* file is not an error, an
-    explicitly given path that cannot be read is.
+    Returns ``(section, path, error_message)``. ``section`` is ``{}`` and
+    ``path`` ``None`` when no file applies: an absent *default* file is not an
+    error, an explicitly given path that cannot be read is.
+
+    The whole section is loaded, not only the converter's table: validation
+    covers the file as the build sees it, and the build's ``case`` entry is
+    needed to check the need type against.
 
     The default file is searched for upwards from the working directory, since
     it conventionally sits at the project root while the converter runs from
@@ -218,15 +227,11 @@ def _load_convert_table(
             return {}, None, None
         path = found
 
-    def warn(message: str) -> None:
-        print(f"warning: {message}", file=sys.stderr)
-
     try:
-        section = load_project_config(path, warn) or {}
+        section = load_project_config(path, _warn) or {}
     except TomlConfigError as error:
         return {}, path, f"error: {error}"
-    table = section.get(CONVERT_TABLE, {})
-    return table if isinstance(table, dict) else {}, path, None
+    return section, path, None
 
 
 #: Built-in value of every conversion setting, used when neither a flag nor
@@ -243,7 +248,8 @@ _DEFAULTS: "dict[str, object]" = {
     "commit": "",
     "url_pattern": DEFAULT_URL_PATTERN,
 }
-assert set(_DEFAULTS) == set(CONVERSION_KEYS), "every conversion key needs a default"
+if set(_DEFAULTS) != set(CONVERSION_KEYS):  # pragma: no cover - import-time guard
+    raise RuntimeError("every [test_reports.convert] key needs a built-in default")
 
 #: argparse destination per conversion key, where it differs from the key.
 #: Only the repeatable ``--link-property`` flag does.
@@ -285,8 +291,13 @@ def _resolve_settings(
 
 
 def _spell(key: str, sources: "dict[str, str]") -> str:
-    """The key as the user wrote it: the flag, or the TOML key."""
-    return key if sources.get(key) == "toml" else _FLAGS[key]
+    """The key as the user wrote it: the flag, the TOML key, or the default."""
+    source = sources.get(key)
+    if source == "toml":
+        return key
+    if source == "default":
+        return f"the default {key}"
+    return _FLAGS[key]
 
 
 def _pair_requirement(sources: "dict[str, str]", path: "Path | None") -> str:
@@ -295,19 +306,44 @@ def _pair_requirement(sources: "dict[str, str]", path: "Path | None") -> str:
     Either half can come from the TOML file, so naming only the flags would
     point at options that appear nowhere in the invocation.
     """
-    requirement = f"{_spell('remote_url', sources)} and {_spell('commit', sources)}"
+    # The half that is missing is named by the flag that would supply it --
+    # that is the actionable spelling -- and the half that was given by however
+    # the user gave it.
+    names = [
+        key if sources.get(key) == "toml" else _FLAGS[key]
+        for key in ("remote_url", "commit")
+    ]
+    requirement = f"{names[0]} and {names[1]}"
     if "toml" in (sources.get("remote_url"), sources.get("commit")):
         requirement += f" (the bare names are {TABLE} keys in {path})"
     return requirement
 
 
 def _convert(arguments: argparse.Namespace) -> int:
-    table, config_path, error = _load_convert_table(arguments)
+    section, config_path, error = _load_section(arguments)
     if error:
         print(error, file=sys.stderr)
         return 2
 
-    settings, sources = _resolve_settings(arguments, table)
+    table = section.get(CONVERT_TABLE, {})
+    settings, sources = _resolve_settings(
+        arguments, table if isinstance(table, dict) else {}
+    )
+
+    # The loader already rejects a file whose convert.need_type disagrees with
+    # case's type. A --need-type flag (or the default) is not in the file, so
+    # the merged value has to be checked here as well, or the converter writes
+    # needs of a type the build does not register.
+    case_type = case_need_type(section)
+    if case_type is not None and settings["need_type"] != case_type:
+        print(
+            f"error: {_spell('need_type', sources)} is {settings['need_type']!r} "
+            f"but [{SECTION}] case's type is {case_type!r} in {config_path}. Both "
+            f"name the need type of a test case -- need_type for this converter, "
+            f"case for the Sphinx build -- so they must agree.",
+            file=sys.stderr,
+        )
+        return 2
 
     try:
         link_properties = _parse_link_properties(settings["link_properties"])
@@ -337,17 +373,22 @@ def _convert(arguments: argparse.Namespace) -> int:
         _warn_about_absent_source_lines(path, parsed)
         suites.extend(parsed)
 
-    payload = build_needs_file(
-        suites,
-        project=settings["project"],
-        version=settings["version"],
-        need_type=settings["need_type"],
-        tags=settings["tags"],
-        link_properties=link_properties,
-        base_url=normalise_remote_url(settings["remote_url"]),
-        commit=settings["commit"],
-        url_pattern=settings["url_pattern"],
-    )
+    try:
+        payload = build_needs_file(
+            suites,
+            project=settings["project"],
+            version=settings["version"],
+            need_type=settings["need_type"],
+            tags=settings["tags"],
+            link_properties=link_properties,
+            base_url=normalise_remote_url(settings["remote_url"]),
+            commit=settings["commit"],
+            url_pattern=settings["url_pattern"],
+            warn=_warn,
+        )
+    except ValueError as error:  # duplicate test cases across the inputs
+        print(f"error: {error}", file=sys.stderr)
+        return 2
 
     output = Path(arguments.output)
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -19,7 +19,12 @@ import sys
 from pathlib import Path
 
 from sphinxcontrib.test_reports.junitparser import JUnitParser
-from sphinxcontrib.test_reports.needs_export import DEFAULT_VERSION, build_needs_file
+from sphinxcontrib.test_reports.needs_export import (
+    DEFAULT_VERSION,
+    build_needs_file,
+    iter_cases,
+    optional,
+)
 from sphinxcontrib.test_reports.projectconfig import (
     CONVERSION_KEYS,
     CONVERT_TABLE,
@@ -27,10 +32,15 @@ from sphinxcontrib.test_reports.projectconfig import (
     SECTION,
     TomlConfigError,
     case_need_type,
+    field_names,
     find_project_config,
     load_project_config,
 )
-from sphinxcontrib.test_reports.remote import DEFAULT_URL_PATTERN, normalise_remote_url
+from sphinxcontrib.test_reports.remote import (
+    DEFAULT_URL_PATTERN,
+    check_url_pattern,
+    normalise_remote_url,
+)
 
 #: How the table is spelled in help texts and diagnostics.
 TABLE = f"[{SECTION}.{CONVERT_TABLE}]"
@@ -103,6 +113,18 @@ def _build_parser() -> argparse.ArgumentParser:
             "Promote an XML property to a link field, comma-splitting its value "
             "(repeatable), e.g. PartiallyVerifies=partially_verifies. Given at "
             "all, it replaces the file's link_properties table."
+        ),
+    )
+    convert.add_argument(
+        "--extra-option",
+        action="append",
+        default=None,
+        metavar="NAME",
+        help=(
+            "Export the XML property NAME as a need field (repeatable). Default: "
+            f"the extra_options of [{SECTION}] -- the same list that makes the "
+            "build accept the field. Properties named by neither are reported "
+            "and left out."
         ),
     )
     convert.add_argument(
@@ -185,8 +207,11 @@ def _warn_about_absent_source_lines(path: Path, suites: list) -> None:
     ``junit_family = xunit1`` (or ``legacy``); its default ``xunit2`` filters
     them out, which silently costs the source location of every case.
     """
-    cases = [case for suite in suites for case in suite.get("testcases", [])]
-    if cases and all(case.get("line", -1) == -1 for case in cases):
+    # Walk the report the way the export does: the parser files the cases of
+    # a suite with nested <testsuite> elements under testsuite_nested only, so
+    # looking at the top-level testcases alone goes quiet on nested reports.
+    cases = [case for _suite_name, case in iter_cases(suites)]
+    if cases and all(optional(case.get("line"), -1) == "" for case in cases):
         print(
             f"warning: {path}: no <testcase> carries a 'line' attribute, so no "
             "source location could be recorded. pytest emits file/line only "
@@ -319,6 +344,14 @@ def _pair_requirement(sources: "dict[str, str]", path: "Path | None") -> str:
     return requirement
 
 
+def _extra_options(arguments: argparse.Namespace, section: dict) -> list:
+    """Properties exported as fields: the flag if given, else the section's."""
+    if arguments.extra_option is not None:
+        return list(arguments.extra_option)
+    names = section.get("extra_options", [])
+    return list(names) if isinstance(names, list) else []
+
+
 def _convert(arguments: argparse.Namespace) -> int:
     section, config_path, error = _load_section(arguments)
     if error:
@@ -351,6 +384,17 @@ def _convert(arguments: argparse.Namespace) -> int:
         print(f"error: {error}", file=sys.stderr)
         return 2
 
+    problem = check_url_pattern(str(settings["url_pattern"]))
+    if problem is not None:
+        # Checked before any report is read: str.format would otherwise fail
+        # on the first case that carries a file, as a traceback.
+        print(
+            f"error: {_spell('url_pattern', sources)} {settings['url_pattern']!r}: "
+            f"{problem}",
+            file=sys.stderr,
+        )
+        return 2
+
     if bool(settings["remote_url"]) != bool(settings["commit"]):
         print(
             f"error: {_pair_requirement(sources, config_path)} must be given "
@@ -359,7 +403,7 @@ def _convert(arguments: argparse.Namespace) -> int:
         )
         return 2
 
-    suites: list = []
+    reports: list = []
     for name in arguments.files:
         path = Path(name)
         if not path.is_file():
@@ -371,11 +415,13 @@ def _convert(arguments: argparse.Namespace) -> int:
             print(f"error: {path}: {error}", file=sys.stderr)
             return 1
         _warn_about_absent_source_lines(path, parsed)
-        suites.extend(parsed)
+        # The path as given, like the build records the path given to its
+        # directives; it is a label for the report, not something resolved.
+        reports.append((str(path), parsed))
 
     try:
         payload = build_needs_file(
-            suites,
+            reports,
             project=settings["project"],
             version=settings["version"],
             need_type=settings["need_type"],
@@ -384,6 +430,11 @@ def _convert(arguments: argparse.Namespace) -> int:
             base_url=normalise_remote_url(settings["remote_url"]),
             commit=settings["commit"],
             url_pattern=settings["url_pattern"],
+            # The renameable field names and the accepted extra fields come
+            # from the same section the build reads, so an imported need has
+            # the shape of a local one.
+            fields=field_names(section),
+            extra_options=_extra_options(arguments, section),
             warn=_warn,
         )
     except ValueError as error:  # duplicate test cases across the inputs

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -1,6 +1,6 @@
 """``test-reports`` command line interface.
 
-Converts test-result XML into needs.json *outside* Sphinx, so a build system can
+``test-reports build needs`` turns test-result XML into needs.json *outside* Sphinx, so a build system can
 schedule and cache the conversion and the documentation build only imports the
 result. Nothing in the import chain of this module may import Sphinx; the test
 suite asserts that.
@@ -57,12 +57,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     subcommands = parser.add_subparsers(dest="command", required=True)
 
-    convert = subcommands.add_parser(
-        "convert",
-        help="Convert one or more test-result XML files into needs.json.",
+    # `build <artifact>`, as ubCode spells it (`ubc build needs`): the command
+    # names what gets produced, and leaves room for further artifacts.
+    build = subcommands.add_parser(
+        "build",
+        help="Build an artifact from test-result XML.",
+        description="Build an artifact from one or more test-result XML files.",
+    )
+    artifacts = build.add_subparsers(dest="artifact", required=True)
+    convert = artifacts.add_parser(
+        "needs",
+        help="Build a needs.json from one or more test-result XML files.",
         description=(
-            "Convert one or more test-result XML files into a needs.json that "
-            "can be consumed with needimport or needs_external_needs. Settings "
+            "Build a needs.json from one or more test-result XML files, ready "
+            "to be consumed with needimport or needs_external_needs. Settings "
             f"default to the {TABLE} table of {DEFAULT_TOML_FILENAME}; a flag "
             "overrides the file's value for that key."
         ),
@@ -352,7 +360,7 @@ def _extra_options(arguments: argparse.Namespace, section: dict) -> list:
     return list(names) if isinstance(names, list) else []
 
 
-def _convert(arguments: argparse.Namespace) -> int:
+def _build_needs(arguments: argparse.Namespace) -> int:
     section, config_path, error = _load_section(arguments)
     if error:
         print(error, file=sys.stderr)
@@ -453,8 +461,8 @@ def _convert(arguments: argparse.Namespace) -> int:
 def main(argv: "list[str] | None" = None) -> int:
     """Entry point. Returns a process exit code instead of raising."""
     arguments = _build_parser().parse_args(argv)
-    if arguments.command == "convert":
-        return _convert(arguments)
+    if arguments.command == "build" and arguments.artifact == "needs":
+        return _build_needs(arguments)
     return 2  # pragma: no cover - argparse rejects unknown commands
 
 

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -17,10 +17,12 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Mapping, Sequence
 
 from sphinxcontrib.test_reports.junitparser import JUnitParser
 from sphinxcontrib.test_reports.needs_export import (
     DEFAULT_VERSION,
+    Report,
     build_needs_file,
     iter_cases,
     optional,
@@ -49,6 +51,20 @@ TABLE = f"[{NEEDS_TABLE_PATH}]"
 
 def _warn(message: str) -> None:
     print(f"warning: {message}", file=sys.stderr)
+
+
+# The conversion settings are resolved key by key in a loop (see
+# `_resolve_settings`), which a TypedDict cannot express, so the mapping stays
+# `dict[str, object]`. These two state at the point of use the type
+# `_NEEDS_KEY_TYPES` already enforces when the file is read.
+def _text(value: object) -> str:
+    """A setting the validation pins to a string."""
+    return value if isinstance(value, str) else ""
+
+
+def _texts(value: object) -> "list[str]":
+    """A setting the validation pins to a list of strings."""
+    return [str(item) for item in value] if isinstance(value, list) else []
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -187,9 +203,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _parse_link_properties(
-    values: "list[str] | dict[str, str] | None",
-) -> dict[str, str]:
+def _parse_link_properties(values: object) -> dict[str, str]:
     """Normalise the link-property mapping from any input spelling.
 
     Flags provide ``PROPERTY=LINK_FIELD`` strings; the TOML file provides a
@@ -197,6 +211,9 @@ def _parse_link_properties(
     must yield non-empty keys and values -- a silently dropped mapping would
     send link fields into needs.json as plain fields instead. This is the only
     place the mapping is normalised, so the two spellings cannot drift.
+
+    The parameter is ``object`` because the value arrives from a flag or from
+    the TOML file; this function is where its shape is established.
     """
     if values is None:
         return {}
@@ -211,9 +228,14 @@ def _parse_link_properties(
             mapping[str(property_name).strip()] = str(link_field).strip()
         return mapping
 
+    if not isinstance(values, list):
+        raise ValueError(
+            f'link_properties expects a PROPERTY = "LINK_FIELD" table, got {values!r}'
+        )
+
     mapping = {}
     for value in values:
-        property_name, separator, link_field = value.partition("=")
+        property_name, separator, link_field = str(value).partition("=")
         if not separator or not property_name.strip() or not link_field.strip():
             raise ValueError(
                 f"--link-property expects PROPERTY=LINK_FIELD, got {value!r}"
@@ -222,7 +244,9 @@ def _parse_link_properties(
     return mapping
 
 
-def _warn_about_absent_source_lines(path: Path, suites: list) -> None:
+def _warn_about_absent_source_lines(
+    path: Path, suites: Sequence[Mapping[str, object]]
+) -> None:
     """Report the most common cause of a missing source location.
 
     pytest emits ``file``/``line`` as ``<testcase>`` attributes only under
@@ -245,7 +269,7 @@ def _warn_about_absent_source_lines(path: Path, suites: list) -> None:
 
 def _load_section(
     arguments: argparse.Namespace,
-) -> "tuple[dict, Path | None, str | None]":
+) -> "tuple[dict[str, object], Path | None, str | None]":
     """Load the ``[test_reports]`` section, honouring ``--config``/``--no-config``.
 
     Returns ``(section, path, error_message)``. ``section`` is ``{}`` and
@@ -315,8 +339,8 @@ _FLAGS["link_properties"] = "--link-property"
 
 
 def _resolve_settings(
-    arguments: argparse.Namespace, table: dict
-) -> "tuple[dict, dict[str, str]]":
+    arguments: argparse.Namespace, table: "dict[str, object]"
+) -> "tuple[dict[str, object], dict[str, str]]":
     """Merge the conversion settings: flag > TOML table > built-in default.
 
     Flags default to ``None``, so ``None`` means "not given"; every key resolves
@@ -338,8 +362,8 @@ def _resolve_settings(
     tags = resolved["tags"]
     if isinstance(tags, str):  # comma-separated, from the flag
         resolved["tags"] = [tag.strip() for tag in tags.split(",") if tag.strip()]
-    else:  # array from the TOML file
-        resolved["tags"] = [str(tag) for tag in tags or []]
+    else:  # array from the TOML file, or the key is absent
+        resolved["tags"] = _texts(tags)
 
     return resolved, sources
 
@@ -373,7 +397,9 @@ def _pair_requirement(sources: "dict[str, str]", path: "Path | None") -> str:
     return requirement
 
 
-def _extra_options(arguments: argparse.Namespace, section: dict) -> list:
+def _extra_options(
+    arguments: argparse.Namespace, section: "dict[str, object]"
+) -> "list[str]":
     """Properties exported as fields: the flag if given, else the section's."""
     if arguments.extra_option is not None:
         return list(arguments.extra_option)
@@ -431,14 +457,16 @@ def _build_needs(arguments: argparse.Namespace) -> int:
         )
         return 2
 
-    reports: list = []
+    reports: "list[Report]" = []
     for name in arguments.files:
         path = Path(name)
         if not path.is_file():
             print(f"error: no such file: {path}", file=sys.stderr)
             return 1
         try:
-            parsed = JUnitParser(str(path)).parse()
+            # The parser is not typed yet (#114), so both calls are
+            # untyped to mypy; nothing to fix from this side.
+            parsed = JUnitParser(str(path)).parse()  # type: ignore[no-untyped-call]
         except Exception as error:  # noqa: BLE001 - report, never traceback
             print(f"error: {path}: {error}", file=sys.stderr)
             return 1
@@ -450,14 +478,14 @@ def _build_needs(arguments: argparse.Namespace) -> int:
     try:
         payload = build_needs_file(
             reports,
-            project=settings["project"],
-            version=settings["version"],
-            need_type=settings["need_type"],
-            tags=settings["tags"],
+            project=_text(settings["project"]),
+            version=_text(settings["version"]),
+            need_type=_text(settings["need_type"]),
+            tags=_texts(settings["tags"]),
             link_properties=link_properties,
-            base_url=normalise_remote_url(settings["remote_url"]),
-            commit=settings["commit"],
-            url_pattern=settings["url_pattern"],
+            base_url=normalise_remote_url(_text(settings["remote_url"])),
+            commit=_text(settings["commit"]),
+            url_pattern=_text(settings["url_pattern"]),
             # The renameable field names and the accepted extra fields come
             # from the same section the build reads, so an imported need has
             # the shape of a local one.

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -4,6 +4,13 @@ Converts test-result XML into needs.json *outside* Sphinx, so a build system can
 schedule and cache the conversion and the documentation build only imports the
 result. Nothing in the import chain of this module may import Sphinx; the test
 suite asserts that.
+
+The conversion settings come from three places, highest precedence first: a
+command-line flag, the ``[test_reports.convert]`` table of the project's
+``ubproject.toml``, the built-in default. The file is the declarative
+description of the project that the Sphinx build reads too, so the two
+consumers cannot drift apart; the flags stay for per-invocation values such as
+the commit a CI job is converting for.
 """
 
 import argparse
@@ -13,7 +20,19 @@ from pathlib import Path
 
 from sphinxcontrib.test_reports.junitparser import JUnitParser
 from sphinxcontrib.test_reports.needs_export import DEFAULT_VERSION, build_needs_file
+from sphinxcontrib.test_reports.projectconfig import (
+    CONVERSION_KEYS,
+    CONVERT_TABLE,
+    DEFAULT_TOML_FILENAME,
+    SECTION,
+    TomlConfigError,
+    find_project_config,
+    load_project_config,
+)
 from sphinxcontrib.test_reports.remote import DEFAULT_URL_PATTERN, normalise_remote_url
+
+#: How the table is spelled in help texts and diagnostics.
+TABLE = f"[{SECTION}.{CONVERT_TABLE}]"
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -28,7 +47,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Convert one or more test-result XML files into needs.json.",
         description=(
             "Convert one or more test-result XML files into a needs.json that "
-            "can be consumed with needimport or needs_external_needs."
+            "can be consumed with needimport or needs_external_needs. Settings "
+            f"default to the {TABLE} table of {DEFAULT_TOML_FILENAME}; a flag "
+            "overrides the file's value for that key."
         ),
     )
     convert.add_argument(
@@ -44,55 +65,103 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="Where to write the needs.json.",
     )
+    # Every setting the TOML file can supply defaults to None here and is
+    # resolved in _resolve_settings: a given flag beats the file, which beats
+    # the built-in default. None is safe because each key resolves to a
+    # concrete value there.
     convert.add_argument(
         "--project",
-        default="",
-        help="Project name recorded in the needs.json envelope.",
+        default=None,
+        help="Project name recorded in the needs.json envelope (default: empty).",
     )
     convert.add_argument(
         "--version",
-        default=DEFAULT_VERSION,
+        default=None,
         help=f"Version key in the envelope (default: {DEFAULT_VERSION}).",
     )
     convert.add_argument(
         "--need-type",
-        default="testcase",
+        default=None,
         help="Need type for each test case (default: testcase).",
     )
     convert.add_argument(
         "--tags",
-        default="",
+        default=None,
         help="Comma-separated tags applied to every created need.",
     )
     convert.add_argument(
         "--link-property",
         action="append",
-        default=[],
+        default=None,
         metavar="PROPERTY=LINK_FIELD",
         help=(
             "Promote an XML property to a link field, comma-splitting its value "
-            "(repeatable), e.g. PartiallyVerifies=partially_verifies."
+            "(repeatable), e.g. PartiallyVerifies=partially_verifies. Given at "
+            "all, it replaces the file's link_properties table."
         ),
     )
     convert.add_argument(
         "--remote-url",
-        default="",
+        default=None,
         help="Repository URL used to synthesize source links; git remotes are accepted.",
     )
     convert.add_argument(
         "--commit",
-        default="",
+        default=None,
         help="Commit-ish the reports were produced from.",
     )
     convert.add_argument(
         "--url-pattern",
-        default=DEFAULT_URL_PATTERN,
+        default=None,
         help=f"Source-URL template (default: {DEFAULT_URL_PATTERN}).",
+    )
+    config_source = convert.add_mutually_exclusive_group()
+    config_source.add_argument(
+        "--config",
+        default=None,
+        metavar="PATH",
+        help=(
+            f"Declarative config file to read the {TABLE} table from. By "
+            f"default {DEFAULT_TOML_FILENAME} is searched for in the working "
+            "directory and its parents, up to the project root; an explicitly "
+            "given path is used as-is and must exist."
+        ),
+    )
+    config_source.add_argument(
+        "--no-config",
+        action="store_true",
+        help=(
+            "Ignore the declarative config file entirely, so the output "
+            "depends only on the arguments given here."
+        ),
     )
     return parser
 
 
-def _parse_link_properties(values: list[str]) -> dict[str, str]:
+def _parse_link_properties(
+    values: "list[str] | dict[str, str] | None",
+) -> dict[str, str]:
+    """Normalise the link-property mapping from any input spelling.
+
+    Flags provide ``PROPERTY=LINK_FIELD`` strings; the TOML file provides a
+    ``PROPERTY = "LINK_FIELD"`` table; neither given is ``None``. Both spellings
+    must yield non-empty keys and values -- a silently dropped mapping would
+    send link fields into needs.json as plain fields instead. This is the only
+    place the mapping is normalised, so the two spellings cannot drift.
+    """
+    if values is None:
+        return {}
+    if isinstance(values, dict):
+        mapping = {}
+        for property_name, link_field in values.items():
+            if not str(property_name).strip() or not str(link_field).strip():
+                raise ValueError(
+                    f'link_properties expects PROPERTY = "LINK_FIELD", got '
+                    f"{property_name!r} = {link_field!r}"
+                )
+            mapping[str(property_name).strip()] = str(link_field).strip()
+        return mapping
+
     mapping = {}
     for value in values:
         property_name, separator, link_field = value.partition("=")
@@ -122,17 +191,134 @@ def _warn_about_absent_source_lines(path: Path, suites: list) -> None:
         )
 
 
-def _convert(arguments: argparse.Namespace) -> int:
+def _load_convert_table(
+    arguments: argparse.Namespace,
+) -> "tuple[dict, Path | None, str | None]":
+    """Load ``[test_reports.convert]``, honouring ``--config``/``--no-config``.
+
+    Returns ``(table, path, error_message)``. ``table`` is ``{}`` and ``path``
+    ``None`` when no file applies: an absent *default* file is not an error, an
+    explicitly given path that cannot be read is.
+
+    The default file is searched for upwards from the working directory, since
+    it conventionally sits at the project root while the converter runs from
+    wherever CI invoked it. That is also where the Sphinx side looks, so both
+    consumers read the same file.
+    """
+    if arguments.no_config:
+        return {}, None, None
+
+    if arguments.config is not None:
+        path = Path(arguments.config)
+        if not path.is_file():
+            return {}, None, f"error: no such config file: {path}"
+    else:
+        found = find_project_config(Path.cwd())
+        if found is None:
+            return {}, None, None
+        path = found
+
+    def warn(message: str) -> None:
+        print(f"warning: {message}", file=sys.stderr)
+
     try:
-        link_properties = _parse_link_properties(list(arguments.link_property))
+        section = load_project_config(path, warn) or {}
+    except TomlConfigError as error:
+        return {}, path, f"error: {error}"
+    table = section.get(CONVERT_TABLE, {})
+    return table if isinstance(table, dict) else {}, path, None
+
+
+#: Built-in value of every conversion setting, used when neither a flag nor
+#: the TOML file supplies one. Keyed by :data:`CONVERSION_KEYS`, and checked
+#: against it at import time, so a key cannot be added to the table without
+#: also being given a default here.
+_DEFAULTS: "dict[str, object]" = {
+    "project": "",
+    "version": DEFAULT_VERSION,
+    "need_type": "testcase",
+    "tags": "",
+    "link_properties": None,
+    "remote_url": "",
+    "commit": "",
+    "url_pattern": DEFAULT_URL_PATTERN,
+}
+assert set(_DEFAULTS) == set(CONVERSION_KEYS), "every conversion key needs a default"
+
+#: argparse destination per conversion key, where it differs from the key.
+#: Only the repeatable ``--link-property`` flag does.
+_DESTS = {"link_properties": "link_property"}
+
+#: Command-line spelling of a conversion key, for diagnostics.
+_FLAGS = {key: "--" + key.replace("_", "-") for key in CONVERSION_KEYS}
+_FLAGS["link_properties"] = "--link-property"
+
+
+def _resolve_settings(
+    arguments: argparse.Namespace, table: dict
+) -> "tuple[dict, dict[str, str]]":
+    """Merge the conversion settings: flag > TOML table > built-in default.
+
+    Flags default to ``None``, so ``None`` means "not given"; every key resolves
+    to a concrete value here. Also returns, per key, where the value came from,
+    because a diagnostic has to name the flag or the TOML key the user actually
+    wrote.
+    """
+    resolved: "dict[str, object]" = {}
+    sources: "dict[str, str]" = {}
+    for key in CONVERSION_KEYS:
+        flag = getattr(arguments, _DESTS.get(key, key))
+        if flag is not None:
+            resolved[key], sources[key] = flag, "flag"
+        elif key in table:
+            resolved[key], sources[key] = table[key], "toml"
+        else:
+            resolved[key], sources[key] = _DEFAULTS[key], "default"
+
+    tags = resolved["tags"]
+    if isinstance(tags, str):  # comma-separated, from the flag
+        resolved["tags"] = [tag.strip() for tag in tags.split(",") if tag.strip()]
+    else:  # array from the TOML file
+        resolved["tags"] = [str(tag) for tag in tags or []]
+
+    return resolved, sources
+
+
+def _spell(key: str, sources: "dict[str, str]") -> str:
+    """The key as the user wrote it: the flag, or the TOML key."""
+    return key if sources.get(key) == "toml" else _FLAGS[key]
+
+
+def _pair_requirement(sources: "dict[str, str]", path: "Path | None") -> str:
+    """Name the remote-url/commit pair the way the user actually spelled it.
+
+    Either half can come from the TOML file, so naming only the flags would
+    point at options that appear nowhere in the invocation.
+    """
+    requirement = f"{_spell('remote_url', sources)} and {_spell('commit', sources)}"
+    if "toml" in (sources.get("remote_url"), sources.get("commit")):
+        requirement += f" (the bare names are {TABLE} keys in {path})"
+    return requirement
+
+
+def _convert(arguments: argparse.Namespace) -> int:
+    table, config_path, error = _load_convert_table(arguments)
+    if error:
+        print(error, file=sys.stderr)
+        return 2
+
+    settings, sources = _resolve_settings(arguments, table)
+
+    try:
+        link_properties = _parse_link_properties(settings["link_properties"])
     except ValueError as error:
         print(f"error: {error}", file=sys.stderr)
         return 2
 
-    if bool(arguments.remote_url) != bool(arguments.commit):
+    if bool(settings["remote_url"]) != bool(settings["commit"]):
         print(
-            "error: --remote-url and --commit must be given together; without "
-            "both, no source URL can be synthesized.",
+            f"error: {_pair_requirement(sources, config_path)} must be given "
+            f"together; without both, no source URL can be synthesized.",
             file=sys.stderr,
         )
         return 2
@@ -153,14 +339,14 @@ def _convert(arguments: argparse.Namespace) -> int:
 
     payload = build_needs_file(
         suites,
-        project=arguments.project,
-        version=arguments.version,
-        need_type=arguments.need_type,
-        tags=[tag.strip() for tag in arguments.tags.split(",") if tag.strip()],
+        project=settings["project"],
+        version=settings["version"],
+        need_type=settings["need_type"],
+        tags=settings["tags"],
         link_properties=link_properties,
-        base_url=normalise_remote_url(arguments.remote_url),
-        commit=arguments.commit,
-        url_pattern=arguments.url_pattern,
+        base_url=normalise_remote_url(settings["remote_url"]),
+        commit=settings["commit"],
+        url_pattern=settings["url_pattern"],
     )
 
     output = Path(arguments.output)

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -150,6 +150,16 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help=f"Source-URL template (default: {DEFAULT_URL_PATTERN}).",
     )
+    convert.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help=(
+            "Say on stderr which declarative config file was used, or where "
+            "the search for one ended. Off by default: most runs have no file "
+            "and should stay quiet, but a misplaced one must be diagnosable."
+        ),
+    )
     config_source = convert.add_mutually_exclusive_group()
     config_source.add_argument(
         "--config",
@@ -245,20 +255,27 @@ def _load_section(
     The default file is searched for upwards from the working directory, since
     it conventionally sits at the project root while the converter runs from
     wherever CI invoked it. That is also where the Sphinx side looks, so both
-    consumers read the same file.
+    consumers read the same file. With ``--verbose`` the search reports where
+    it ended and which file was used -- the same posture as the Sphinx bridge,
+    which says the same at ``sphinx-build -v``.
     """
     if arguments.no_config:
         return {}, None, None
+
+    def verbose(message: str) -> None:
+        if arguments.verbose:
+            print(message, file=sys.stderr)
 
     if arguments.config is not None:
         path = Path(arguments.config)
         if not path.is_file():
             return {}, None, f"error: no such config file: {path}"
     else:
-        found = find_project_config(Path.cwd())
+        found = find_project_config(Path.cwd(), report=verbose)
         if found is None:
             return {}, None, None
         path = found
+    verbose(f"reading [{SECTION}] from {path}")
 
     try:
         section = load_project_config(path, _warn) or {}

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -125,6 +125,9 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     needs.add_argument(
+        # Named after `tr_extra_options`, which the flag defaults from.
+        # sphinx-needs has since renamed `needs_extra_options` to
+        # `needs_fields`; realigning this extension's vocabulary is issue #157.
         "--extra-option",
         action="append",
         default=None,

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -29,6 +29,7 @@ from sphinxcontrib.test_reports.needs_export import (
 )
 from sphinxcontrib.test_reports.projectconfig import (
     CONVERSION_KEYS,
+    DEFAULT_NEED_TYPE,
     DEFAULT_TOML_FILENAME,
     NEEDS_TABLE_PATH,
     SECTION,
@@ -122,7 +123,11 @@ def _build_parser() -> argparse.ArgumentParser:
     needs.add_argument(
         "--need-type",
         default=None,
-        help="Need type for each test case (default: testcase).",
+        help=(
+            f"Need type for each test case (default: {DEFAULT_NEED_TYPE}). Must "
+            f"agree with the type of case in [{SECTION}] when a config file "
+            "applies."
+        ),
     )
     needs.add_argument(
         "--tags",
@@ -149,10 +154,10 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="NAME",
         help=(
-            "Export the XML property NAME as a need field (repeatable). Default: "
-            f"the extra_options of [{SECTION}] -- the same list that makes the "
-            "build accept the field. Properties named by neither are reported "
-            "and left out."
+            "Export the XML property NAME as a need field (repeatable), in "
+            f"addition to the extra_options of [{SECTION}] -- the same list that "
+            "makes the build accept the field. A NAME that list lacks is "
+            "reported. Properties named by neither are reported and left out."
         ),
     )
     needs.add_argument(
@@ -175,9 +180,12 @@ def _build_parser() -> argparse.ArgumentParser:
         "--verbose",
         action="store_true",
         help=(
-            "Say on stderr which declarative config file was used, or where "
-            "the search for one ended. Off by default: most runs have no file "
-            "and should stay quiet, but a misplaced one must be diagnosable."
+            "Say on stderr where the search for the declarative config file "
+            "ended when it found none, and name a --config file. Off by "
+            "default: most runs have no file and should stay quiet, but a "
+            "misplaced one must be diagnosable. A file the search did find is "
+            "always named -- it may sit directories above, and the output "
+            "depends on it."
         ),
     )
     config_source = needs.add_mutually_exclusive_group()
@@ -267,6 +275,24 @@ def _warn_about_absent_source_lines(
         )
 
 
+def _warn_about_empty_report(
+    path: Path, suites: Sequence[Mapping[str, object]]
+) -> None:
+    """A report without a single test case contributes nothing -- say so.
+
+    A file that is not a test report at all (a ``pom.xml``, a ``coverage.xml``)
+    parses as one empty suite, and a genuine report may have had every case
+    filtered out. Either way the artifact ends up with fewer needs than the
+    caller expects, and for a cached build output "0 needs" is the one outcome
+    that must never be silent.
+    """
+    if not any(True for _ in iter_cases(suites)):
+        _warn(
+            f"{path}: no test cases found, so it adds no needs. A file that is "
+            f"not a test report parses as an empty one."
+        )
+
+
 def _load_section(
     arguments: argparse.Namespace,
 ) -> "tuple[dict[str, object], Path | None, str | None]":
@@ -283,9 +309,12 @@ def _load_section(
     The default file is searched for upwards from the working directory, since
     it conventionally sits at the project root while the converter runs from
     wherever CI invoked it. That is also where the Sphinx side looks, so both
-    consumers read the same file. With ``--verbose`` the search reports where
-    it ended and which file was used -- the same posture as the Sphinx bridge,
-    which says the same at ``sphinx-build -v``.
+    consumers read the same file. A file the search finds is always named on
+    stderr: it may sit directories above the invocation, and the bytes written
+    depend on it, so a cached artifact has to be traceable to the file that
+    shaped it -- the Sphinx bridge logs the same at INFO on every build. With
+    ``--verbose`` a fruitless search also reports where it ended, and an
+    explicitly given file is named too.
     """
     if arguments.no_config:
         return {}, None, None
@@ -298,12 +327,13 @@ def _load_section(
         path = Path(arguments.config)
         if not path.is_file():
             return {}, None, f"error: no such config file: {path}"
+        verbose(f"reading [{SECTION}] from {path}")
     else:
         found = find_project_config(Path.cwd(), report=verbose)
         if found is None:
             return {}, None, None
         path = found
-    verbose(f"reading [{SECTION}] from {path}")
+        print(f"reading [{SECTION}] from {path}", file=sys.stderr)
 
     try:
         section = load_project_config(path, _warn) or {}
@@ -319,7 +349,7 @@ def _load_section(
 _DEFAULTS: "dict[str, object]" = {
     "project": "",
     "version": DEFAULT_VERSION,
-    "need_type": "testcase",
+    "need_type": DEFAULT_NEED_TYPE,
     "tags": "",
     "link_properties": None,
     "remote_url": "",
@@ -398,13 +428,33 @@ def _pair_requirement(sources: "dict[str, str]", path: "Path | None") -> str:
 
 
 def _extra_options(
-    arguments: argparse.Namespace, section: "dict[str, object]"
+    arguments: argparse.Namespace,
+    section: "dict[str, object]",
+    config_path: "Path | None",
 ) -> "list[str]":
-    """Properties exported as fields: the flag if given, else the section's."""
-    if arguments.extra_option is not None:
-        return list(arguments.extra_option)
-    names = section.get("extra_options", [])
-    return list(names) if isinstance(names, list) else []
+    """Properties exported as fields: the section's ``extra_options`` plus the flag's.
+
+    The flag adds to the file's list rather than replacing it: a repeatable
+    flag reads as additive, and ``--no-config`` is the way to leave the file
+    out. A flag name the section's list does not contain is exported all the
+    same -- the flag may stand in for a build configured elsewhere -- but
+    reported: the build registers exactly the section's list, so an import of
+    the produced file drops every other field as an unknown key.
+    """
+    configured = _texts(section.get("extra_options", []))
+    if arguments.extra_option is None:
+        return configured
+    added = [str(name) for name in arguments.extra_option]
+    names = list(dict.fromkeys([*configured, *added], True))
+    unlisted = [name for name in names if name not in configured]
+    if unlisted and config_path is not None:
+        _warn(
+            f"--extra-option {', '.join(unlisted)}: not in the extra_options of "
+            f"[{SECTION}] in {config_path}. The build registers only the fields "
+            f"listed there, so a needimport of the produced file drops these; "
+            f"list them in the file."
+        )
+    return names
 
 
 def _build_needs(arguments: argparse.Namespace) -> int:
@@ -417,20 +467,31 @@ def _build_needs(arguments: argparse.Namespace) -> int:
         arguments, dict(needs_settings(section) or {})
     )
 
-    # The loader already rejects a file whose build.needs.need_type disagrees with
-    # case's type. A --need-type flag (or the default) is not in the file, so
-    # the merged value has to be checked here as well, or the converter writes
-    # needs of a type the build does not register.
-    case_type = case_need_type(section)
-    if case_type is not None and settings["need_type"] != case_type:
-        print(
-            f"error: {_spell('need_type', sources)} is {settings['need_type']!r} "
-            f"but [{SECTION}] case's type is {case_type!r} in {config_path}. Both "
-            f"name the need type of a test case -- need_type for this converter, "
-            f"case for the Sphinx build -- so they must agree.",
-            file=sys.stderr,
-        )
-        return 2
+    # The loader already rejects a file whose build.needs.need_type disagrees
+    # with case's type. A --need-type flag (or the built-in default) is not in
+    # the file, so the merged value has to be checked here as well, or the
+    # converter writes needs of a type the build does not register. As in the
+    # loader, a side that is not set is compared at its default: a file that
+    # leaves case alone configures the build with the default type. Without a
+    # file the rule has nothing to hold against, and the output depends on
+    # the arguments alone.
+    if config_path is not None:
+        case_type = case_need_type(section)
+        if settings["need_type"] != (case_type or DEFAULT_NEED_TYPE):
+            build_side = (
+                f"[{SECTION}] case's type is {case_type!r}"
+                if case_type is not None
+                else f"[{SECTION}] does not set case, so the build's test-case "
+                f"type is the default {DEFAULT_NEED_TYPE!r},"
+            )
+            print(
+                f"error: {_spell('need_type', sources)} is "
+                f"{settings['need_type']!r} but {build_side} in {config_path}. "
+                f"Both name the need type of a test case -- need_type for this "
+                f"converter, case for the Sphinx build -- so they must agree.",
+                file=sys.stderr,
+            )
+            return 2
 
     try:
         link_properties = _parse_link_properties(settings["link_properties"])
@@ -470,6 +531,7 @@ def _build_needs(arguments: argparse.Namespace) -> int:
         except Exception as error:  # noqa: BLE001 - report, never traceback
             print(f"error: {path}: {error}", file=sys.stderr)
             return 1
+        _warn_about_empty_report(path, parsed)
         _warn_about_absent_source_lines(path, parsed)
         # The path as given, like the build records the path given to its
         # directives; it is a label for the report, not something resolved.
@@ -490,7 +552,7 @@ def _build_needs(arguments: argparse.Namespace) -> int:
             # from the same section the build reads, so an imported need has
             # the shape of a local one.
             fields=field_names(section),
-            extra_options=_extra_options(arguments, section),
+            extra_options=_extra_options(arguments, section, config_path),
             warn=_warn,
         )
     except ValueError as error:  # duplicate test cases across the inputs

--- a/sphinxcontrib/test_reports/cli.py
+++ b/sphinxcontrib/test_reports/cli.py
@@ -6,7 +6,7 @@ result. Nothing in the import chain of this module may import Sphinx; the test
 suite asserts that.
 
 The conversion settings come from three places, highest precedence first: a
-command-line flag, the ``[test_reports.convert]`` table of the project's
+command-line flag, the ``[test_reports.build.needs]`` table of the project's
 ``ubproject.toml``, the built-in default. The file is the declarative
 description of the project that the Sphinx build reads too, so the two
 consumers cannot drift apart; the flags stay for per-invocation values such as
@@ -27,14 +27,15 @@ from sphinxcontrib.test_reports.needs_export import (
 )
 from sphinxcontrib.test_reports.projectconfig import (
     CONVERSION_KEYS,
-    CONVERT_TABLE,
     DEFAULT_TOML_FILENAME,
+    NEEDS_TABLE_PATH,
     SECTION,
     TomlConfigError,
     case_need_type,
     field_names,
     find_project_config,
     load_project_config,
+    needs_settings,
 )
 from sphinxcontrib.test_reports.remote import (
     DEFAULT_URL_PATTERN,
@@ -43,7 +44,7 @@ from sphinxcontrib.test_reports.remote import (
 )
 
 #: How the table is spelled in help texts and diagnostics.
-TABLE = f"[{SECTION}.{CONVERT_TABLE}]"
+TABLE = f"[{NEEDS_TABLE_PATH}]"
 
 
 def _warn(message: str) -> None:
@@ -65,7 +66,7 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Build an artifact from one or more test-result XML files.",
     )
     artifacts = build.add_subparsers(dest="artifact", required=True)
-    convert = artifacts.add_parser(
+    needs = artifacts.add_parser(
         "needs",
         help="Build a needs.json from one or more test-result XML files.",
         description=(
@@ -75,13 +76,13 @@ def _build_parser() -> argparse.ArgumentParser:
             "overrides the file's value for that key."
         ),
     )
-    convert.add_argument(
+    needs.add_argument(
         "files",
         nargs="+",
         metavar="FILE",
         help="Test-result XML files (a build system passes these as a file list).",
     )
-    convert.add_argument(
+    needs.add_argument(
         "--output",
         "-o",
         required=True,
@@ -92,27 +93,27 @@ def _build_parser() -> argparse.ArgumentParser:
     # resolved in _resolve_settings: a given flag beats the file, which beats
     # the built-in default. None is safe because each key resolves to a
     # concrete value there.
-    convert.add_argument(
+    needs.add_argument(
         "--project",
         default=None,
         help="Project name recorded in the needs.json envelope (default: empty).",
     )
-    convert.add_argument(
+    needs.add_argument(
         "--version",
         default=None,
         help=f"Version key in the envelope (default: {DEFAULT_VERSION}).",
     )
-    convert.add_argument(
+    needs.add_argument(
         "--need-type",
         default=None,
         help="Need type for each test case (default: testcase).",
     )
-    convert.add_argument(
+    needs.add_argument(
         "--tags",
         default=None,
         help="Comma-separated tags applied to every created need.",
     )
-    convert.add_argument(
+    needs.add_argument(
         "--link-property",
         action="append",
         default=None,
@@ -123,7 +124,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "all, it replaces the file's link_properties table."
         ),
     )
-    convert.add_argument(
+    needs.add_argument(
         "--extra-option",
         action="append",
         default=None,
@@ -135,22 +136,22 @@ def _build_parser() -> argparse.ArgumentParser:
             "and left out."
         ),
     )
-    convert.add_argument(
+    needs.add_argument(
         "--remote-url",
         default=None,
         help="Repository URL used to synthesize source links; git remotes are accepted.",
     )
-    convert.add_argument(
+    needs.add_argument(
         "--commit",
         default=None,
         help="Commit-ish the reports were produced from.",
     )
-    convert.add_argument(
+    needs.add_argument(
         "--url-pattern",
         default=None,
         help=f"Source-URL template (default: {DEFAULT_URL_PATTERN}).",
     )
-    convert.add_argument(
+    needs.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -160,7 +161,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "and should stay quiet, but a misplaced one must be diagnosable."
         ),
     )
-    config_source = convert.add_mutually_exclusive_group()
+    config_source = needs.add_mutually_exclusive_group()
     config_source.add_argument(
         "--config",
         default=None,
@@ -299,7 +300,7 @@ _DEFAULTS: "dict[str, object]" = {
     "url_pattern": DEFAULT_URL_PATTERN,
 }
 if set(_DEFAULTS) != set(CONVERSION_KEYS):  # pragma: no cover - import-time guard
-    raise RuntimeError("every [test_reports.convert] key needs a built-in default")
+    raise RuntimeError("every [test_reports.build.needs] key needs a built-in default")
 
 #: argparse destination per conversion key, where it differs from the key.
 #: Only the repeatable ``--link-property`` flag does.
@@ -383,12 +384,11 @@ def _build_needs(arguments: argparse.Namespace) -> int:
         print(error, file=sys.stderr)
         return 2
 
-    table = section.get(CONVERT_TABLE, {})
     settings, sources = _resolve_settings(
-        arguments, table if isinstance(table, dict) else {}
+        arguments, dict(needs_settings(section) or {})
     )
 
-    # The loader already rejects a file whose convert.need_type disagrees with
+    # The loader already rejects a file whose build.needs.need_type disagrees with
     # case's type. A --need-type flag (or the default) is not in the file, so
     # the merged value has to be checked here as well, or the converter writes
     # needs of a type the build does not register.

--- a/sphinxcontrib/test_reports/directives/test_case.py
+++ b/sphinxcontrib/test_reports/directives/test_case.py
@@ -6,6 +6,7 @@ from sphinx_needs.utils import add_doc
 from sphinxcontrib.test_reports.config import DEFAULT_OPTIONS
 from sphinxcontrib.test_reports.directives.test_common import TestCommonDirective
 from sphinxcontrib.test_reports.exceptions import TestReportInvalidOptionError
+from sphinxcontrib.test_reports.identity import split_case_name
 
 
 class TestCase(nodes.General, nodes.Element):
@@ -154,18 +155,7 @@ class TestCaseDirective(TestCommonDirective):
         # If time is already a string or None, keep it as is
         style = "tr_" + case["result"]
 
-        import re
-
-        groups = re.match(r"^(?P<name>[^\[]+)($|\[(?P<param>.*)?\])", case["name"])
-        try:
-            case_name = groups["name"]
-            case_parameter = groups["param"]
-        except TypeError:
-            case_name = case_full_name
-            case_parameter = ""
-
-        if case_parameter is None:
-            case_parameter = ""
+        case_name, case_parameter = split_case_name(case["name"])
 
         # Flatten JUnit <properties> into top-level case keys so that
         # the extra-data loop below picks them up as sphinx-needs fields.

--- a/sphinxcontrib/test_reports/fields.py
+++ b/sphinxcontrib/test_reports/fields.py
@@ -102,6 +102,22 @@ CORE_FIELDS: dict[str, dict[str, object]] = {
 SCHEMA_DIALECT = "http://json-schema.org/draft-07/schema#"
 
 
+def declaration(name: str, role: str | None = None) -> tuple[str, str]:
+    """The JSON type and description of one field, as ``(type, description)``.
+
+    A renameable field is looked up by its *role*, so that its description
+    survives the rename; every other field by its name. A name the table does
+    not know -- an entry of the configured extra options -- is a string field
+    described by its own name.
+
+    This is the lookup the extension registers its fields with and the one
+    :func:`case_needs_schema` declares them with, so the two cannot disagree.
+    """
+    if role is not None:
+        return RENAMEABLE_FIELDS[role]
+    return FIELDS.get(name, ("string", name))
+
+
 def extra_field(type_: str, description: str) -> dict[str, object]:
     """Declaration of one registered field, as sphinx-needs writes it.
 
@@ -148,13 +164,15 @@ def case_needs_schema(
         name: dict(declaration) | {"field_type": "core"}
         for name, declaration in CORE_FIELDS.items()
     }
-    for role, (type_, description) in RENAMEABLE_FIELDS.items():
-        properties[names[role]] = extra_field(type_, description)
+    for role in RENAMEABLE_FIELDS:
+        properties[names[role]] = extra_field(*declaration(names[role], role))
     for name in CASE_FIELDS:
-        properties[name] = extra_field(*FIELDS[name])
+        properties[name] = extra_field(*declaration(name))
     for name in extra_options:
-        # A property named like a built-in field is not exported (the built-in
-        # value wins, see ``build_need``), so it must not be declared either.
+        # Declared a string because that is what the converter writes for an
+        # exported property, whatever the name. A property named like a
+        # built-in field is not exported at all (the built-in value wins, see
+        # ``build_need``), so `setdefault` leaves the built-in declaration.
         properties.setdefault(name, extra_field("string", str(name)))
     for name in link_fields:
         properties[name] = link_field()

--- a/sphinxcontrib/test_reports/fields.py
+++ b/sphinxcontrib/test_reports/fields.py
@@ -25,8 +25,13 @@ from typing import Iterable, Mapping
 FIELDS: dict[str, tuple[str, str]] = {
     "suite": ("string", "Test suite name"),
     "case": ("string", "Test case name"),
-    "case_name": ("string", "Test case display name"),
-    "case_parameter": ("string", "Test case parameter"),
+    # pytest spells a parameterised case ``name[param]``; the two halves are
+    # split apart so a filter can address either.
+    "case_name": ("string", "Test case name without its parameter"),
+    "case_parameter": (
+        "string",
+        "Parameter of a parameterised test case ('a-b' for pytest's test_x[a-b])",
+    ),
     "classname": ("string", "Test class name"),
     # A string, not a number, because that is what the directives have always
     # written and what a filter, a needtable and a schema in the field consume.

--- a/sphinxcontrib/test_reports/fields.py
+++ b/sphinxcontrib/test_reports/fields.py
@@ -98,6 +98,19 @@ CORE_FIELDS: dict[str, dict[str, object]] = {
     },
 }
 
+#: Names a renameable field may not be given: the fixed-name fields of this
+#: package and the core fields every need has. Both writers set those on the
+#: same need, so a rename onto one of them makes the directives pass one
+#: keyword twice -- ``add_need`` fails with "multiple values for keyword
+#: argument" -- and the converter write one value over the other. ``status``,
+#: ``links``, ``collapse`` and ``style`` are core fields the directives set
+#: without the converter declaring them.
+RESERVED_NAMES: frozenset[str] = (
+    frozenset(FIELDS)
+    | frozenset(CORE_FIELDS)
+    | frozenset({"status", "links", "collapse", "style"})
+)
+
 #: JSON schema draft the block declares itself against, as sphinx-needs does.
 SCHEMA_DIALECT = "http://json-schema.org/draft-07/schema#"
 

--- a/sphinxcontrib/test_reports/fields.py
+++ b/sphinxcontrib/test_reports/fields.py
@@ -1,0 +1,165 @@
+"""The need fields this package declares, and their JSON schema.
+
+One table for the two writers. The extension registers these fields with
+sphinx-needs at ``config-inited`` so the directives may set them; the
+converter writes the same declarations into the ``needs_schema`` of the
+``needs.json`` it produces, so the file says what the type of each of its
+fields is. A consumer of that file -- a schema check, a metamodel validator,
+S-CORE's tooling -- learns the types from the file instead of having to load
+this extension into a Sphinx build.
+
+**Nothing in this module may import Sphinx.** The converter runs as a build
+action, without the documentation toolchain installed.
+
+The declarations are the *format*, not a description of one report: a field is
+declared whether or not the cases at hand happen to populate it, the way
+sphinx-needs declares every registered field.
+"""
+
+from typing import Iterable, Mapping
+
+#: ``name -> (JSON type, description)`` for every field declared under a fixed
+#: name. The build registers all of them, on test-file, test-suite and
+#: test-case needs alike; the converter writes test-case needs and therefore
+#: declares :data:`CASE_FIELDS`.
+FIELDS: dict[str, tuple[str, str]] = {
+    "suite": ("string", "Test suite name"),
+    "case": ("string", "Test case name"),
+    "case_name": ("string", "Test case display name"),
+    "case_parameter": ("string", "Test case parameter"),
+    "classname": ("string", "Test class name"),
+    # A string, not a number, because that is what the directives have always
+    # written and what a filter, a needtable and a schema in the field consume.
+    # Turning it into a number is issue #156: it has to change here, in both
+    # writers and in every consuming filter at once.
+    "time": ("string", "Test execution time, in seconds"),
+    "result": ("string", "Test result status"),
+    "result_text": ("string", "One-line rendering of the first failure message"),
+    "remote_url": ("string", "URL of the test's source in the remote repository"),
+    "suites": ("integer", "Number of test suites"),
+    "cases": ("integer", "Number of test cases"),
+    "passed": ("integer", "Number of passed tests"),
+    "skipped": ("integer", "Number of skipped tests"),
+    "failed": ("integer", "Number of failed tests"),
+    "errors": ("integer", "Number of test errors"),
+}
+
+#: ``role -> (JSON type, description)`` for the fields whose *name* the
+#: configuration chooses; the roles are the keys of
+#: :data:`~sphinxcontrib.test_reports.projectconfig.DEFAULT_FIELD_NAMES`.
+#: Keying them by role rather than by name is what lets the description follow
+#: a renamed field.
+RENAMEABLE_FIELDS: dict[str, tuple[str, str]] = {
+    "file_option": ("string", "Test file name"),
+    "source_file_option": ("string", "Path of the test's source file"),
+    "source_line_option": ("string", "Line of the test in its source file"),
+}
+
+#: The fixed-name fields of a test-case need, in the order they are declared.
+#: The counts belong to test-file and test-suite needs, which the converter
+#: does not write -- declaring them would promise fields the file never has.
+CASE_FIELDS: tuple[str, ...] = (
+    "suite",
+    "case",
+    "case_name",
+    "case_parameter",
+    "classname",
+    "time",
+    "result",
+    "result_text",
+    "remote_url",
+)
+
+#: Declaration of the core need fields the converter writes, as sphinx-needs
+#: declares them itself (``NeedsCoreFields``). Copied rather than imported:
+#: this module may not import Sphinx. The wording is informational -- what has
+#: to agree between the two writers is the type, and
+#: ``TestImportIntoABuild.test_the_declared_types_match_the_extension_s``
+#: checks that it does.
+CORE_FIELDS: dict[str, dict[str, object]] = {
+    "id": {"type": "string", "description": "ID of the data."},
+    "type": {"type": "string", "description": "Type of the need.", "default": ""},
+    "title": {"type": "string", "description": "Title of the need."},
+    "content": {
+        "type": "string",
+        "description": "The main content of the need.",
+        "default": "",
+    },
+    "tags": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "List of tags.",
+        "default": [],
+    },
+    "external_url": {
+        "type": ["string", "null"],
+        "description": "URL of the need, if it is an external need.",
+        "default": None,
+    },
+}
+
+#: JSON schema draft the block declares itself against, as sphinx-needs does.
+SCHEMA_DIALECT = "http://json-schema.org/draft-07/schema#"
+
+
+def extra_field(type_: str, description: str) -> dict[str, object]:
+    """Declaration of one registered field, as sphinx-needs writes it.
+
+    Registered fields are nullable and default to null, so a need that does
+    not populate one carries no value for it rather than an empty one -- which
+    is what keeps a strict sphinx-needs schema strict (see
+    ``tests/test_schema_validation.py``).
+    """
+    return {
+        "type": [type_, "null"],
+        "description": description,
+        "field_type": "extra",
+        "default": None,
+    }
+
+
+def link_field(description: str = "Link field") -> dict[str, object]:
+    """Declaration of one link field: a list of need IDs, empty by default."""
+    return {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": description,
+        "field_type": "links",
+        "default": [],
+    }
+
+
+def case_needs_schema(
+    names: Mapping[str, str],
+    *,
+    extra_options: Iterable[str] = (),
+    link_fields: Iterable[str] = (),
+) -> dict[str, object]:
+    """The ``needs_schema`` of a ``needs.json`` holding test-case needs.
+
+    *names* maps the roles of :data:`RENAMEABLE_FIELDS` to the field names the
+    configuration selected. *extra_options* are the XML properties exported
+    under their own names, which the build registers as string options.
+    *link_fields* are the fields mapped XML properties become; a mapping onto
+    the name of a built-in field replaces its declaration, because the value
+    written replaces the built-in value too.
+    """
+    properties: dict[str, object] = {
+        name: dict(declaration) | {"field_type": "core"}
+        for name, declaration in CORE_FIELDS.items()
+    }
+    for role, (type_, description) in RENAMEABLE_FIELDS.items():
+        properties[names[role]] = extra_field(type_, description)
+    for name in CASE_FIELDS:
+        properties[name] = extra_field(*FIELDS[name])
+    for name in extra_options:
+        # A property named like a built-in field is not exported (the built-in
+        # value wins, see ``build_need``), so it must not be declared either.
+        properties.setdefault(name, extra_field("string", str(name)))
+    for name in link_fields:
+        properties[name] = link_field()
+    return {
+        "$schema": SCHEMA_DIALECT,
+        "type": "object",
+        "properties": properties,
+    }

--- a/sphinxcontrib/test_reports/identity.py
+++ b/sphinxcontrib/test_reports/identity.py
@@ -35,6 +35,24 @@ def short_hash(value: str, length: int = 5) -> str:
     return letters_only[:length].lower()
 
 
+#: ``name[param]`` as pytest spells a parameterised case.
+_PARAMETERISED = re.compile(r"^(?P<name>[^\[]+)($|\[(?P<param>.*)?\])")
+
+
+def split_case_name(name: str) -> tuple[str, str]:
+    """``("test_x", "a-b")`` for ``"test_x[a-b]"``; the parameter is ``""``
+    when the name carries none.
+
+    One definition for the build's directives and the converter, so an
+    imported need and a locally created one for the same case agree on
+    ``case_name`` and ``case_parameter``.
+    """
+    match = _PARAMETERISED.match(name)
+    if match is None:
+        return name, ""
+    return match.group("name"), match.group("param") or ""
+
+
 def case_display_name(classname: str, name: str) -> str:
     """Human-readable case name: ``Classname__Casename``.
 

--- a/sphinxcontrib/test_reports/identity.py
+++ b/sphinxcontrib/test_reports/identity.py
@@ -40,8 +40,9 @@ _PARAMETERISED = re.compile(r"^(?P<name>[^\[]+)($|\[(?P<param>.*)?\])")
 
 
 def split_case_name(name: str) -> tuple[str, str]:
-    """``("test_x", "a-b")`` for ``"test_x[a-b]"``; the parameter is ``""``
-    when the name carries none.
+    """``("test_x", "a-b")`` for ``"test_x[a-b]"``, ``("test_x", "")`` for
+    ``"test_x"``: the name is always there, the parameter only when pytest
+    spelled one.
 
     One definition for the build's directives and the converter, so an
     imported need and a locally created one for the same case agree on

--- a/sphinxcontrib/test_reports/identity.py
+++ b/sphinxcontrib/test_reports/identity.py
@@ -35,8 +35,11 @@ def short_hash(value: str, length: int = 5) -> str:
     return letters_only[:length].lower()
 
 
-#: ``name[param]`` as pytest spells a parameterised case.
-_PARAMETERISED = re.compile(r"^(?P<name>[^\[]+)($|\[(?P<param>.*)?\])")
+#: ``name[param]`` as pytest spells a parameterised case, and nothing else:
+#: anchored at both ends, so a name that merely contains a bracket -- an
+#: unclosed one, or text after the closing one -- is kept whole rather than
+#: cut at the bracket. The parameter is greedy, so brackets inside it survive.
+_PARAMETERISED = re.compile(r"^(?P<name>[^\[]+)(?:\[(?P<param>.*)\])?$")
 
 
 def split_case_name(name: str) -> tuple[str, str]:

--- a/sphinxcontrib/test_reports/needs_export.py
+++ b/sphinxcontrib/test_reports/needs_export.py
@@ -1,0 +1,236 @@
+"""Turn parsed test reports into a needs.json payload.
+
+Sphinx-free: the conversion runs as a build action, and the documentation build
+only imports the result.
+
+Two rules shape the output:
+
+* **Every field is always present.** Absent XML attributes become empty values
+  rather than missing keys, so a schema can simply require a field and a
+  consumer never has to distinguish "unset" from "absent".
+* **Nothing depends on the wall clock or on dict ordering**, so the file is a
+  cacheable build artifact and a diffable piece of evidence.
+"""
+
+import re
+from typing import Iterable, Iterator, Mapping, Sequence, Union
+
+from sphinxcontrib.test_reports.identity import (
+    UNKNOWN,
+    case_display_name,
+    deterministic_case_id,
+)
+from sphinxcontrib.test_reports.remote import DEFAULT_URL_PATTERN, source_url
+
+#: A need field value as it appears in needs.json.
+FieldValue = Union[str, list[str]]
+NeedItem = dict[str, FieldValue]
+
+#: Version key used when the caller does not supply one. needs.json requires a
+#: ``current_version``, but a converted report has no baseline history.
+DEFAULT_VERSION = "1.0"
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_WHITESPACE = re.compile(r"\s+")
+
+#: The parser keeps the historical spelling ``failure`` -- it is a documented
+#: need field value and a CSS class. Exported data has no such obligation and
+#: uses the migration-target vocabulary (passed|failed|error|skipped|disabled),
+#: which is also what S-CORE's metamodel spells.
+RESULT_NAMES = {"failure": "failed"}
+
+
+def flatten_message(message: str) -> str:
+    """One-line, ANSI-free rendering of a failure message.
+
+    Used for ``result_text``, which exists to be readable in tables and
+    reports; the untruncated detail stays in the need content.
+    """
+    return _WHITESPACE.sub(" ", _ANSI.sub("", message)).strip()
+
+
+def _contains(haystack: str, needle: str) -> bool:
+    """Whitespace-insensitive containment, for de-duplicating failure text."""
+    return _WHITESPACE.sub(" ", needle).strip() in _WHITESPACE.sub(" ", haystack)
+
+
+def _literal_block(title: str, body: str) -> str:
+    """An RST literal block, indented so the need content stays valid."""
+    indented = "\n".join(f"   {line.lstrip()}" for line in body.split("\n"))
+    return f"\n**{title}**::\n\n{indented}\n"
+
+
+def build_content(case: Mapping[str, object]) -> str:
+    """Need content carrying the complete failure evidence.
+
+    googletest reports one ``<failure>`` per failed assertion, each with its own
+    message and body, plus captured output -- keeping only the first of them
+    loses exactly the detail a reader needs.
+    """
+    sections: list[str] = []
+
+    parts = _result_parts(case)
+    for index, part in enumerate(parts, start=1):
+        kind = str(part.get("kind", "result")).capitalize()
+        label = f"{kind} {index}" if len(parts) > 1 else kind
+        message = str(part.get("message", ""))
+        text = str(part.get("text", ""))
+        # googletest repeats the body in the message attribute; a second copy
+        # is noise, so the message is only shown when it adds something.
+        if message and not _contains(text, message):
+            sections.append(_literal_block(f"{label} message", message))
+        if text:
+            sections.append(_literal_block(label, text))
+
+    for key, title in (("system-out", "System-out"), ("system-err", "System-err")):
+        captured = str(case.get(key, ""))
+        if captured:
+            sections.append(_literal_block(title, captured))
+
+    return "".join(sections)
+
+
+def _result_parts(case: Mapping[str, object]) -> list[Mapping[str, object]]:
+    """The case's result parts, as a typed view over the parser's output."""
+    raw = case.get("parts")
+    if not isinstance(raw, list):
+        return []
+    return [part for part in raw if isinstance(part, Mapping)]
+
+
+def _first_message(case: Mapping[str, object]) -> str:
+    for part in _result_parts(case):
+        message = str(part.get("message", ""))
+        if message and message != UNKNOWN:
+            return flatten_message(message)
+    return ""
+
+
+def _optional(value: object, absent: object) -> str:
+    """String form of an attribute, empty when the parser reported it absent."""
+    return "" if value is None or value == absent else str(value)
+
+
+def _mappings(value: object) -> list[Mapping[str, object]]:
+    """Typed view over a list of dicts coming from the parser."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _iter_cases(
+    suites: Iterable[Mapping[str, object]],
+) -> Iterator[tuple[str, Mapping[str, object]]]:
+    """Yield ``(suite_name, case)`` pairs, descending into nested suites."""
+    for suite in suites:
+        name = str(suite.get("name", ""))
+        for case in _mappings(suite.get("testcases")):
+            yield name, case
+        yield from _iter_cases(_mappings(suite.get("testsuite_nested")))
+
+
+def build_need(
+    suite_name: str,
+    case: Mapping[str, object],
+    *,
+    need_type: str = "testcase",
+    tags: Sequence[str] = (),
+    link_properties: Mapping[str, str] | None = None,
+    base_url: str = "",
+    commit: str = "",
+    url_pattern: str = DEFAULT_URL_PATTERN,
+) -> NeedItem:
+    """One test case as a need item."""
+    link_properties = link_properties or {}
+
+    classname = _optional(case.get("classname"), UNKNOWN)
+    name = _optional(case.get("name"), UNKNOWN)
+    source_file = _optional(case.get("file"), UNKNOWN)
+    source_line = _optional(case.get("line"), -1)
+    time = _optional(case.get("time"), -1)
+
+    url = source_url(base_url, commit, source_file, source_line, url_pattern)
+
+    need: NeedItem = {
+        "id": deterministic_case_id(
+            classname=classname, name=name, file=source_file, prefix=need_type
+        ),
+        "type": need_type,
+        "title": case_display_name(classname, name),
+        "content": build_content(case),
+        "tags": list(tags),
+        "name": name,
+        "classname": classname,
+        "suite": suite_name,
+        "file": source_file,
+        "line": source_line,
+        "time": time,
+        "result": RESULT_NAMES.get(
+            str(case.get("result", "")), str(case.get("result", ""))
+        ),
+        "result_text": _first_message(case),
+        # The same URL twice on purpose: external_url drives the external-needs
+        # rendering, while a plain field stays usable for needs imported as
+        # local needs (via a needs_string_links entry).
+        "external_url": url,
+        "remote_url": url,
+    }
+
+    properties = case.get("properties") or {}
+    if not isinstance(properties, Mapping):
+        properties = {}
+
+    # Link fields are emitted even when empty, so a schema can require them.
+    for property_name, link_field in link_properties.items():
+        raw = str(properties.get(property_name, ""))
+        need[link_field] = [item.strip() for item in raw.split(",") if item.strip()]
+
+    for property_name, value in properties.items():
+        if property_name in link_properties or property_name in need:
+            continue
+        need[property_name] = str(value)
+
+    return need
+
+
+def build_needs_file(
+    suites: Iterable[Mapping[str, object]],
+    *,
+    project: str = "",
+    version: str = DEFAULT_VERSION,
+    need_type: str = "testcase",
+    tags: Sequence[str] = (),
+    link_properties: Mapping[str, str] | None = None,
+    base_url: str = "",
+    commit: str = "",
+    url_pattern: str = DEFAULT_URL_PATTERN,
+) -> dict[str, object]:
+    """The complete needs.json payload for a set of parsed reports.
+
+    No ``created`` key is written: a wall clock inside a cacheable build output
+    would change the file on every run.
+    """
+    needs: dict[str, NeedItem] = {}
+    for suite_name, case in _iter_cases(suites):
+        need = build_need(
+            suite_name,
+            case,
+            need_type=need_type,
+            tags=tags,
+            link_properties=link_properties,
+            base_url=base_url,
+            commit=commit,
+            url_pattern=url_pattern,
+        )
+        needs[str(need["id"])] = need
+
+    return {
+        "project": project,
+        "current_version": version,
+        "versions": {
+            version: {
+                "needs": needs,
+                "needs_amount": len(needs),
+            }
+        },
+    }

--- a/sphinxcontrib/test_reports/needs_export.py
+++ b/sphinxcontrib/test_reports/needs_export.py
@@ -20,12 +20,19 @@ from sphinxcontrib.test_reports.identity import (
     UNKNOWN,
     case_display_name,
     deterministic_case_id,
+    split_case_name,
 )
+from sphinxcontrib.test_reports.projectconfig import DEFAULT_FIELD_NAMES
 from sphinxcontrib.test_reports.remote import DEFAULT_URL_PATTERN, source_url
 
 #: A need field value as it appears in needs.json.
 FieldValue = Union[str, list[str]]
 NeedItem = dict[str, FieldValue]
+
+#: A parsed report: the path it was read from, and its top-level suites. The
+#: path is what the build's ``test-file``/``test-case`` directives record as
+#: the report-path field, so it travels with the suites.
+Report = tuple[str, Sequence[Mapping[str, object]]]
 
 #: Version key used when the caller does not supply one. needs.json requires a
 #: ``current_version``, but a converted report has no baseline history.
@@ -115,7 +122,7 @@ def _first_message(case: Mapping[str, object]) -> str:
     return ""
 
 
-def _optional(value: object, absent: object) -> str:
+def optional(value: object, absent: object) -> str:
     """String form of an attribute, empty when the parser reported it absent."""
     return "" if value is None or value == absent else str(value)
 
@@ -127,18 +134,26 @@ def _mappings(value: object) -> list[Mapping[str, object]]:
     return [item for item in value if isinstance(item, Mapping)]
 
 
-def _iter_cases(
+def iter_cases(
     suites: Iterable[Mapping[str, object]],
 ) -> Iterator[tuple[str, Mapping[str, object]]]:
-    """Yield ``(suite_name, case)`` pairs, descending into nested suites."""
+    """Yield ``(suite_name, case)`` pairs, descending into nested suites.
+
+    The parser files the cases of a suite that contains nested ``<testsuite>``
+    elements under ``testsuite_nested`` only, so anything that wants to see
+    every case of a report has to walk this way -- the export does, and so must
+    every diagnostic about the report's cases, or it goes quiet on exactly the
+    nested reports Ant and Maven produce.
+    """
     for suite in suites:
         name = str(suite.get("name", ""))
         for case in _mappings(suite.get("testcases")):
             yield name, case
-        yield from _iter_cases(_mappings(suite.get("testsuite_nested")))
+        yield from iter_cases(_mappings(suite.get("testsuite_nested")))
 
 
 def build_need(
+    report_path: str,
     suite_name: str,
     case: Mapping[str, object],
     *,
@@ -148,22 +163,41 @@ def build_need(
     base_url: str = "",
     commit: str = "",
     url_pattern: str = DEFAULT_URL_PATTERN,
+    fields: Mapping[str, str] | None = None,
+    extra_options: Sequence[str] = (),
     warn: Callable[[str], None] | None = None,
 ) -> NeedItem:
-    """One test case as a need item.
+    """One test case as a need item, shaped like the build's ``test-case``.
+
+    The field names are those of the directives -- ``suite``/``case``/
+    ``case_name``/``case_parameter``/``classname``/``result``/``time`` plus the
+    renameable report-path and source-location fields in *fields* (see
+    :data:`DEFAULT_FIELD_NAMES`) -- so that a need imported from the produced
+    ``needs.json`` and one created locally from the same report are
+    indistinguishable to a schema, a filter or a ``needtable``.
+
+    XML properties become fields under their own names only when listed in
+    *extra_options* -- the same list that makes the build register them as need
+    options and accept them -- so an import never has to drop them as unknown
+    keys. A property mapped by *link_properties* becomes a link field
+    regardless. Everything else is left out; :func:`build_needs_file` reports
+    what was left out, once.
 
     *warn* is called for a property that cannot become a field because its
     name is already taken by a built-in or link field. The property is dropped
-    -- silently overwriting ``result`` or ``file`` would be worse -- but
+    -- silently overwriting ``result`` or the report path would be worse -- but
     silently dropping it is not acceptable either.
     """
     link_properties = link_properties or {}
+    names = {**DEFAULT_FIELD_NAMES, **(fields or {})}
+    exported = set(extra_options)
 
-    classname = _optional(case.get("classname"), UNKNOWN)
-    name = _optional(case.get("name"), UNKNOWN)
-    source_file = _optional(case.get("file"), UNKNOWN)
-    source_line = _optional(case.get("line"), -1)
-    time = _optional(case.get("time"), -1)
+    classname = optional(case.get("classname"), UNKNOWN)
+    name = optional(case.get("name"), UNKNOWN)
+    case_name, case_parameter = split_case_name(name)
+    source_file = optional(case.get("file"), UNKNOWN)
+    source_line = optional(case.get("line"), -1)
+    time = optional(case.get("time"), -1)
 
     url = source_url(base_url, commit, source_file, source_line, url_pattern)
 
@@ -175,11 +209,14 @@ def build_need(
         "title": case_display_name(classname, name),
         "content": build_content(case),
         "tags": list(tags),
-        "name": name,
-        "classname": classname,
         "suite": suite_name,
-        "file": source_file,
-        "line": source_line,
+        "case": name,
+        "case_name": case_name,
+        "case_parameter": case_parameter,
+        "classname": classname,
+        names["file_option"]: report_path,
+        names["source_file_option"]: source_file,
+        names["source_line_option"]: source_line,
         "time": time,
         "result": RESULT_NAMES.get(
             str(case.get("result", "")), str(case.get("result", ""))
@@ -202,7 +239,7 @@ def build_need(
         need[link_field] = [item.strip() for item in raw.split(",") if item.strip()]
 
     for property_name, value in properties.items():
-        if property_name in link_properties:
+        if property_name in link_properties or property_name not in exported:
             continue
         if property_name in need:
             if warn is not None:
@@ -217,7 +254,7 @@ def build_need(
 
 
 def build_needs_file(
-    suites: Iterable[Mapping[str, object]],
+    reports: Iterable[Report],
     *,
     project: str = "",
     version: str = DEFAULT_VERSION,
@@ -227,6 +264,8 @@ def build_needs_file(
     base_url: str = "",
     commit: str = "",
     url_pattern: str = DEFAULT_URL_PATTERN,
+    fields: Mapping[str, str] | None = None,
+    extra_options: Sequence[str] = (),
     warn: Callable[[str], None] | None = None,
 ) -> dict[str, object]:
     """The complete needs.json payload for a set of parsed reports.
@@ -234,7 +273,12 @@ def build_needs_file(
     No ``created`` key is written: a wall clock inside a cacheable build output
     would change the file on every run.
 
-    :raises ValueError: If a test case occurs more than once across *suites*.
+    Properties that are neither in *extra_options* nor mapped by
+    *link_properties* are not exported (see :func:`build_need`); their names are
+    reported through *warn* once, with the key to add them to, so the omission
+    is a decision the user can see rather than a silent one.
+
+    :raises ValueError: If a test case occurs more than once across *reports*.
         Its ID is derived from where the test is, so a repeat means the same
         case was reported twice -- typically the same report given twice. A
         needs.json cannot hold two needs with one ID, and keeping either one
@@ -242,28 +286,44 @@ def build_needs_file(
     """
     needs: dict[str, NeedItem] = {}
     duplicates: set[str] = set()
-    for suite_name, case in _iter_cases(suites):
-        need = build_need(
-            suite_name,
-            case,
-            need_type=need_type,
-            tags=tags,
-            link_properties=link_properties,
-            base_url=base_url,
-            commit=commit,
-            url_pattern=url_pattern,
-            warn=warn,
-        )
-        need_id = str(need["id"])
-        if need_id in needs:
-            duplicates.add(need_id)
-        needs[need_id] = need
+    left_out: set[str] = set()
+    known = set(extra_options) | set(link_properties or {})
+    for report_path, suites in reports:
+        for suite_name, case in iter_cases(suites):
+            properties = case.get("properties")
+            if isinstance(properties, Mapping):
+                left_out.update(str(name) for name in properties if name not in known)
+            need = build_need(
+                report_path,
+                suite_name,
+                case,
+                need_type=need_type,
+                tags=tags,
+                link_properties=link_properties,
+                base_url=base_url,
+                commit=commit,
+                url_pattern=url_pattern,
+                fields=fields,
+                extra_options=extra_options,
+                warn=warn,
+            )
+            need_id = str(need["id"])
+            if need_id in needs:
+                duplicates.add(need_id)
+            needs[need_id] = need
     if duplicates:
         listed = ", ".join(sorted(duplicates))
         raise ValueError(
             f"{len(duplicates)} test case(s) occur more than once across the given "
             f"reports and would collapse into one need each: {listed}. Every case "
             f"must be unique; if the same report was given twice, give it once."
+        )
+    if left_out and warn is not None:
+        warn(
+            f"properties not exported: {', '.join(sorted(left_out))}. Only "
+            f"properties listed in extra_options become need fields (the build "
+            f"accepts exactly those); list them there, or map them to a link "
+            f"field with link_properties."
         )
 
     return {

--- a/sphinxcontrib/test_reports/needs_export.py
+++ b/sphinxcontrib/test_reports/needs_export.py
@@ -3,11 +3,17 @@
 Sphinx-free: the conversion runs as a build action, and the documentation build
 only imports the result.
 
-Two rules shape the output:
+Three rules shape the output:
 
 * **Every field is always present.** Absent XML attributes become empty values
   rather than missing keys, so a schema can simply require a field and a
   consumer never has to distinguish "unset" from "absent".
+* **Every field is declared in the file**, in the ``needs_schema`` sphinx-needs
+  also writes into the files it produces itself, so the type of a field is
+  readable from the artifact instead of only from a Sphinx build with this
+  extension loaded. The declarations come from
+  :mod:`sphinxcontrib.test_reports.fields`, the same table the extension
+  registers its fields from.
 * **Nothing depends on the wall clock or on dict ordering**, so the file is a
   cacheable build artifact and a diffable piece of evidence.
 """
@@ -16,6 +22,7 @@ import re
 import textwrap
 from typing import Callable, Iterable, Iterator, Mapping, Sequence, Union
 
+from sphinxcontrib.test_reports.fields import case_needs_schema
 from sphinxcontrib.test_reports.identity import (
     UNKNOWN,
     case_display_name,
@@ -337,6 +344,15 @@ def build_needs_file(
             version: {
                 "needs": needs,
                 "needs_amount": len(needs),
+                # The type of every field the file uses, as sphinx-needs
+                # declares the fields of the files it writes itself. Without
+                # it the types are knowable only by loading the extension into
+                # a Sphinx build, which a consumer of the artifact does not do.
+                "needs_schema": case_needs_schema(
+                    {**DEFAULT_FIELD_NAMES, **(fields or {})},
+                    extra_options=extra_options,
+                    link_fields=(link_properties or {}).values(),
+                ),
             }
         },
     }

--- a/sphinxcontrib/test_reports/needs_export.py
+++ b/sphinxcontrib/test_reports/needs_export.py
@@ -200,6 +200,7 @@ def build_need(
     time = optional(case.get("time"), -1)
 
     url = source_url(base_url, commit, source_file, source_line, url_pattern)
+    content = build_content(case)
 
     need: NeedItem = {
         "id": deterministic_case_id(
@@ -207,7 +208,10 @@ def build_need(
         ),
         "type": need_type,
         "title": case_display_name(classname, name),
-        "content": build_content(case),
+        # ``content``, as sphinx-needs >= 4 writes and reads it. Older versions
+        # read the need text from ``description`` only, and current ones flag a
+        # file carrying both -- so importing a converted file needs >= 4.
+        "content": content,
         "tags": list(tags),
         "suite": suite_name,
         "case": name,

--- a/sphinxcontrib/test_reports/needs_export.py
+++ b/sphinxcontrib/test_reports/needs_export.py
@@ -6,8 +6,10 @@ only imports the result.
 Three rules shape the output:
 
 * **Every field is always present.** Absent XML attributes become empty values
-  rather than missing keys, so a schema can simply require a field and a
-  consumer never has to distinguish "unset" from "absent".
+  rather than missing keys, and an exported property a case does not carry is
+  ``null`` -- the value the build leaves in a registered field a directive did
+  not set -- so a schema can simply require a field and a consumer never has
+  to distinguish "unset" from "absent".
 * **Every field is declared in the file**, in the ``needs_schema`` sphinx-needs
   also writes into the files it produces itself, so the type of a field is
   readable from the artifact instead of only from a Sphinx build with this
@@ -25,15 +27,15 @@ from typing import Callable, Iterable, Iterator, Mapping, Sequence, Union
 from sphinxcontrib.test_reports.fields import case_needs_schema
 from sphinxcontrib.test_reports.identity import (
     UNKNOWN,
-    case_display_name,
     deterministic_case_id,
     split_case_name,
 )
 from sphinxcontrib.test_reports.projectconfig import DEFAULT_FIELD_NAMES
 from sphinxcontrib.test_reports.remote import DEFAULT_URL_PATTERN, source_url
 
-#: A need field value as it appears in needs.json.
-FieldValue = Union[str, list[str]]
+#: A need field value as it appears in needs.json. ``None`` is the value of an
+#: exported property the case does not carry, as the build leaves it.
+FieldValue = Union[str, list[str], None]
 NeedItem = dict[str, FieldValue]
 
 #: A parsed report: the path it was read from, and its top-level suites. The
@@ -47,12 +49,6 @@ DEFAULT_VERSION = "1.0"
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 _WHITESPACE = re.compile(r"\s+")
-
-#: The parser keeps the historical spelling ``failure`` -- it is a documented
-#: need field value and a CSS class. Exported data has no such obligation and
-#: uses the migration-target vocabulary (passed|failed|error|skipped|disabled),
-#: which is also what S-CORE's metamodel spells.
-RESULT_NAMES = {"failure": "failed"}
 
 
 def flatten_message(message: str) -> str:
@@ -172,32 +168,37 @@ def build_need(
     url_pattern: str = DEFAULT_URL_PATTERN,
     fields: Mapping[str, str] | None = None,
     extra_options: Sequence[str] = (),
-    warn: Callable[[str], None] | None = None,
+    collisions: set[str] | None = None,
 ) -> NeedItem:
     """One test case as a need item, shaped like the build's ``test-case``.
 
     The field names are those of the directives -- ``suite``/``case``/
     ``case_name``/``case_parameter``/``classname``/``result``/``time`` plus the
     renameable report-path and source-location fields in *fields* (see
-    :data:`DEFAULT_FIELD_NAMES`) -- so that a need imported from the produced
-    ``needs.json`` and one created locally from the same report are
-    indistinguishable to a schema, a filter or a ``needtable``.
+    :data:`DEFAULT_FIELD_NAMES`) -- and so are the values: the title is the
+    case name and ``result`` keeps the parser's spelling (``failure``, which is
+    also a documented field value and the ``tr_failure`` CSS class), so that a
+    need imported from the produced ``needs.json`` and one created locally from
+    the same report are indistinguishable to a schema, a filter or a
+    ``needtable``.
 
     XML properties become fields under their own names only when listed in
     *extra_options* -- the same list that makes the build register them as need
     options and accept them -- so an import never has to drop them as unknown
-    keys. A property mapped by *link_properties* becomes a link field
-    regardless. Everything else is left out; :func:`build_needs_file` reports
-    what was left out, once.
+    keys. Every listed name is written, ``None`` when the case has no such
+    property, so the field is there to be required. A property mapped by
+    *link_properties* becomes a link field regardless. Everything else is left
+    out; :func:`build_needs_file` reports what was left out, once.
 
-    *warn* is called for a property that cannot become a field because its
-    name is already taken by a built-in or link field. The property is dropped
-    -- silently overwriting ``result`` or the report path would be worse -- but
-    silently dropping it is not acceptable either.
+    A listed property whose name is already taken by a built-in or link field
+    cannot become a field: the built-in value wins -- silently overwriting
+    ``result`` or the report path would be worse -- but silently dropping the
+    property is not acceptable either, so its name is added to *collisions*
+    when the case carries it, for the caller to report once.
     """
     link_properties = link_properties or {}
     names = {**DEFAULT_FIELD_NAMES, **(fields or {})}
-    exported = set(extra_options)
+    exported = list(dict.fromkeys(extra_options, True))  # deduplicated, in order
 
     classname = optional(case.get("classname"), UNKNOWN)
     name = optional(case.get("name"), UNKNOWN)
@@ -214,7 +215,7 @@ def build_need(
             classname=classname, name=name, file=source_file, prefix=need_type
         ),
         "type": need_type,
-        "title": case_display_name(classname, name),
+        "title": name,
         # ``content``, as sphinx-needs >= 4 writes and reads it. Older versions
         # read the need text from ``description`` only, and current ones flag a
         # file carrying both -- so importing a converted file needs >= 4.
@@ -229,9 +230,7 @@ def build_need(
         names["source_file_option"]: source_file,
         names["source_line_option"]: source_line,
         "time": time,
-        "result": RESULT_NAMES.get(
-            str(case.get("result", "")), str(case.get("result", ""))
-        ),
+        "result": str(case.get("result", "")),
         "result_text": _first_message(case),
         # The same URL twice on purpose: external_url drives the external-needs
         # rendering, while a plain field stays usable for needs imported as
@@ -249,17 +248,17 @@ def build_need(
         raw = str(properties.get(property_name, ""))
         need[link_field] = [item.strip() for item in raw.split(",") if item.strip()]
 
-    for property_name, value in properties.items():
-        if property_name in link_properties or property_name not in exported:
-            continue
+    # Exported properties are emitted for every case too; absent, the field is
+    # null, as the build leaves a registered field a directive did not set.
+    for property_name in exported:
+        if property_name in link_properties:
+            continue  # the link field carries it
         if property_name in need:
-            if warn is not None:
-                warn(
-                    f"{need['id']}: property {property_name!r} is not exported, "
-                    f"its name is taken by a built-in or link field"
-                )
+            if property_name in properties and collisions is not None:
+                collisions.add(property_name)
             continue
-        need[property_name] = str(value)
+        value = properties.get(property_name)
+        need[property_name] = None if value is None else str(value)
 
     return need
 
@@ -287,7 +286,8 @@ def build_needs_file(
     Properties that are neither in *extra_options* nor mapped by
     *link_properties* are not exported (see :func:`build_need`); their names are
     reported through *warn* once, with the key to add them to, so the omission
-    is a decision the user can see rather than a silent one.
+    is a decision the user can see rather than a silent one. So are, once, the
+    names of listed properties that a built-in or link field already owns.
 
     :raises ValueError: If a test case occurs more than once across *reports*.
         Its ID is derived from where the test is, so a repeat means the same
@@ -298,6 +298,7 @@ def build_needs_file(
     needs: dict[str, NeedItem] = {}
     duplicates: set[str] = set()
     left_out: set[str] = set()
+    collisions: set[str] = set()
     known = set(extra_options) | set(link_properties or {})
     for report_path, suites in reports:
         for suite_name, case in iter_cases(suites):
@@ -316,7 +317,7 @@ def build_needs_file(
                 url_pattern=url_pattern,
                 fields=fields,
                 extra_options=extra_options,
-                warn=warn,
+                collisions=collisions,
             )
             need_id = str(need["id"])
             if need_id in needs:
@@ -335,6 +336,13 @@ def build_needs_file(
             f"properties listed in extra_options become need fields (the build "
             f"accepts exactly those); list them there, or map them to a link "
             f"field with link_properties."
+        )
+    if collisions and warn is not None:
+        warn(
+            f"properties not exported, their names are taken by built-in or "
+            f"link fields: {', '.join(sorted(collisions))}. The built-in value "
+            f"wins; rename the property, or map it to a link field with "
+            f"link_properties."
         )
 
     return {

--- a/sphinxcontrib/test_reports/needs_export.py
+++ b/sphinxcontrib/test_reports/needs_export.py
@@ -13,7 +13,8 @@ Two rules shape the output:
 """
 
 import re
-from typing import Iterable, Iterator, Mapping, Sequence, Union
+import textwrap
+from typing import Callable, Iterable, Iterator, Mapping, Sequence, Union
 
 from sphinxcontrib.test_reports.identity import (
     UNKNOWN,
@@ -55,8 +56,16 @@ def _contains(haystack: str, needle: str) -> bool:
 
 
 def _literal_block(title: str, body: str) -> str:
-    """An RST literal block, indented so the need content stays valid."""
-    indented = "\n".join(f"   {line.lstrip()}" for line in body.split("\n"))
+    """An RST literal block, indented so the need content stays valid.
+
+    The body is dedented as a whole, not line by line: XML pretty-printing adds
+    a common indentation that has to go, but a traceback or an assertion diff
+    is only readable if its *relative* indentation survives.
+    """
+    lines = textwrap.dedent(body).strip("\n").split("\n")
+    indented = "\n".join(
+        f"   {line.rstrip()}" if line.strip() else "" for line in lines
+    )
     return f"\n**{title}**::\n\n{indented}\n"
 
 
@@ -139,8 +148,15 @@ def build_need(
     base_url: str = "",
     commit: str = "",
     url_pattern: str = DEFAULT_URL_PATTERN,
+    warn: Callable[[str], None] | None = None,
 ) -> NeedItem:
-    """One test case as a need item."""
+    """One test case as a need item.
+
+    *warn* is called for a property that cannot become a field because its
+    name is already taken by a built-in or link field. The property is dropped
+    -- silently overwriting ``result`` or ``file`` would be worse -- but
+    silently dropping it is not acceptable either.
+    """
     link_properties = link_properties or {}
 
     classname = _optional(case.get("classname"), UNKNOWN)
@@ -186,7 +202,14 @@ def build_need(
         need[link_field] = [item.strip() for item in raw.split(",") if item.strip()]
 
     for property_name, value in properties.items():
-        if property_name in link_properties or property_name in need:
+        if property_name in link_properties:
+            continue
+        if property_name in need:
+            if warn is not None:
+                warn(
+                    f"{need['id']}: property {property_name!r} is not exported, "
+                    f"its name is taken by a built-in or link field"
+                )
             continue
         need[property_name] = str(value)
 
@@ -204,13 +227,21 @@ def build_needs_file(
     base_url: str = "",
     commit: str = "",
     url_pattern: str = DEFAULT_URL_PATTERN,
+    warn: Callable[[str], None] | None = None,
 ) -> dict[str, object]:
     """The complete needs.json payload for a set of parsed reports.
 
     No ``created`` key is written: a wall clock inside a cacheable build output
     would change the file on every run.
+
+    :raises ValueError: If a test case occurs more than once across *suites*.
+        Its ID is derived from where the test is, so a repeat means the same
+        case was reported twice -- typically the same report given twice. A
+        needs.json cannot hold two needs with one ID, and keeping either one
+        silently would lose evidence, so the caller has to sort out its inputs.
     """
     needs: dict[str, NeedItem] = {}
+    duplicates: set[str] = set()
     for suite_name, case in _iter_cases(suites):
         need = build_need(
             suite_name,
@@ -221,8 +252,19 @@ def build_needs_file(
             base_url=base_url,
             commit=commit,
             url_pattern=url_pattern,
+            warn=warn,
         )
-        needs[str(need["id"])] = need
+        need_id = str(need["id"])
+        if need_id in needs:
+            duplicates.add(need_id)
+        needs[need_id] = need
+    if duplicates:
+        listed = ", ".join(sorted(duplicates))
+        raise ValueError(
+            f"{len(duplicates)} test case(s) occur more than once across the given "
+            f"reports and would collapse into one need each: {listed}. Every case "
+            f"must be unique; if the same report was given twice, give it once."
+        )
 
     return {
         "project": project,

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -416,13 +416,12 @@ def _check_need_type_agreement(section: Mapping[str, object], path: Path) -> Non
     registers nor cross-links.
     """
     convert = section.get(CONVERT_TABLE)
-    case = section.get("case")
-    if not isinstance(convert, Mapping) or not isinstance(case, Sequence):
+    case_type = case_need_type(section)
+    if not isinstance(convert, Mapping) or case_type is None:
         return
     need_type: object = convert.get("need_type")
     if not isinstance(need_type, str):
         return
-    case_type: object = case[_TYPE_FIELD_INDEX]
     if case_type != need_type:
         msg = (
             f"{path}: [{SECTION}.{CONVERT_TABLE}] need_type is {need_type!r} but "
@@ -462,6 +461,20 @@ def _check_table_values(
                 f"{_type_label(expected)}, got {type(item).__name__}: {item!r}"
             )
             raise TomlConfigError(msg)
+
+
+def case_need_type(section: Mapping[str, object]) -> str | None:
+    """The need type the build gives test cases, if the section sets ``case``.
+
+    Shared by the loader's own agreement check and by the converter, which has
+    to re-check after merging command-line flags: a ``--need-type`` given on
+    the command line is not in the file and so escapes the loader.
+    """
+    case = section.get("case")
+    if not isinstance(case, Sequence):
+        return None
+    value: object = case[_TYPE_FIELD_INDEX]
+    return value if isinstance(value, str) else None
 
 
 def _wrong_type(

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -17,7 +17,7 @@ Keys fall into two groups:
   (:data:`FIELD_NAME_KEYS`) and ``extra_options``, so the needs it writes have
   the shape of the needs the build creates and carry exactly the fields the
   build accepts;
-* the ``[test_reports.convert]`` sub-table (:data:`CONVERSION_KEYS`): how test
+* the ``[test_reports.build.needs]`` sub-table (:data:`CONVERSION_KEYS`): how test
   reports are turned into a ``needs.json``. The Sphinx bridge never applies it
   to a ``tr_*`` value, but the build validates it like every other key, so a
   typo is caught by whichever consumer reads the file first.
@@ -109,13 +109,21 @@ PATH_KEYS = ("rootdir", "report_template")
 #: list form. ``None`` in :data:`_KEY_TYPES` marks exactly these.
 _DUAL_SPELLING_KEYS = ("file", "suite", "case")
 
-#: The sub-table read by the ``test-reports build needs`` command. It is not a
-#: bridge key: the build never maps it onto a ``tr_*`` value. It is validated
-#: like everything else, so that the build rejects the same typos the converter
-#: would -- one file, one verdict.
-CONVERT_TABLE = "convert"
+#: The sub-table holding what the ``test-reports build`` command line
+#: produces, one table per artifact and named after it, as ubCode spells
+#: ``ubc build needs``. Not a bridge key: the build never maps any of it onto
+#: a ``tr_*`` value. It is validated like everything else, so that the build
+#: rejects the same typos the command line would -- one file, one verdict.
+BUILD_TABLE = "build"
 
-#: Keys of ``[test_reports.convert]``, in the order the converter documents
+#: The artifact ``test-reports build needs`` produces, and its table under
+#: :data:`BUILD_TABLE`.
+NEEDS_TABLE = "needs"
+
+#: How the table is spelled in diagnostics.
+NEEDS_TABLE_PATH = f"{SECTION}.{BUILD_TABLE}.{NEEDS_TABLE}"
+
+#: Keys of ``[test_reports.build.needs]``, in the order the command documents
 #: them. The CLI's flag merge iterates this, so a key cannot be added here
 #: without the CLI being taught a default for it.
 CONVERSION_KEYS = (
@@ -147,8 +155,8 @@ DEFAULT_FIELD_NAMES: dict[str, str] = {
 #: ``case`` entry. Both defaults live here so they cannot drift apart.
 DEFAULT_NEED_TYPE = "testcase"
 
-#: Expected Python type per ``[test_reports.convert]`` key.
-_CONVERT_KEY_TYPES: dict[str, type[object]] = {
+#: Expected Python type per ``[test_reports.build.needs]`` key.
+_NEEDS_KEY_TYPES: dict[str, type[object]] = {
     "project": str,
     "version": str,
     "need_type": str,
@@ -179,7 +187,7 @@ _KEY_TYPES: dict[str, type[object] | None] = {
     "property_link_types": dict,
     "json_mapping": dict,
     "deterministic_case_ids": bool,
-    "convert": dict,
+    "build": dict,
 }
 
 #: Required type of the *values* inside a table-valued key. Without this a
@@ -376,8 +384,8 @@ def _normalise_section(
             _wrong_type(key, value, expected, path)
         if expected is not None and not isinstance(value, expected):
             _wrong_type(key, value, expected, path)
-        if key == CONVERT_TABLE:
-            normalised[key] = _normalise_convert_table(value, path, warn)
+        if key == BUILD_TABLE:
+            normalised[key] = _normalise_build_table(value, path, warn)
         elif key in _DUAL_SPELLING_KEYS:
             normalised[key] = _normalise_type_entry(key, value, path)
         else:
@@ -427,10 +435,38 @@ def _check_field_name_collisions(section: Mapping[str, object], path: Path) -> N
         seen[name] = key
 
 
-def _normalise_convert_table(
+def _normalise_build_table(
     value: object, path: Path, warn: Callable[[str], None] | None
 ) -> dict[str, object]:
-    """Validate ``[test_reports.convert]`` under the section's own policy.
+    """Validate ``[test_reports.build]``: one known sub-table per artifact.
+
+    Only ``needs`` is modelled today. An unknown sub-table is reported and
+    dropped like an unknown key anywhere else -- the command line may grow
+    artifacts this version does not know, and a file naming one must not take
+    a build down.
+    """
+    if not isinstance(value, Mapping):
+        return {}
+    table: dict[str, object] = {str(name): item for name, item in value.items()}
+    unknown = sorted(set(table) - {NEEDS_TABLE})
+    if unknown and warn is not None:
+        warn(
+            f"{path}: ignoring unknown key(s) in [{SECTION}.{BUILD_TABLE}]: "
+            f"{', '.join(unknown)}. Supported keys: {NEEDS_TABLE}"
+        )
+    normalised: dict[str, object] = {}
+    if NEEDS_TABLE in table:
+        artifact = table[NEEDS_TABLE]
+        if not isinstance(artifact, dict):
+            _wrong_type(f"{BUILD_TABLE}.{NEEDS_TABLE}", artifact, dict, path)
+        normalised[NEEDS_TABLE] = _normalise_needs_table(artifact, path, warn)
+    return normalised
+
+
+def _normalise_needs_table(
+    value: object, path: Path, warn: Callable[[str], None] | None
+) -> dict[str, object]:
+    """Validate ``[test_reports.build.needs]`` under the section's own policy.
 
     Same rules as the section: a known key with the wrong type is fatal, an
     unknown key is reported and dropped, table values are checked. The caller
@@ -439,10 +475,10 @@ def _normalise_convert_table(
     if not isinstance(value, Mapping):
         return {}
     table: dict[str, object] = {str(name): item for name, item in value.items()}
-    unknown = sorted(set(table) - set(_CONVERT_KEY_TYPES))
+    unknown = sorted(set(table) - set(_NEEDS_KEY_TYPES))
     if unknown and warn is not None:
         warn(
-            f"{path}: ignoring unknown key(s) in [{SECTION}.{CONVERT_TABLE}]: "
+            f"{path}: ignoring unknown key(s) in [{NEEDS_TABLE_PATH}]: "
             f"{', '.join(unknown)}. Supported keys: "
             f"{', '.join(CONVERSION_KEYS)}"
         )
@@ -450,8 +486,8 @@ def _normalise_convert_table(
     for key, item in table.items():
         if key in unknown:
             continue
-        label = f"{CONVERT_TABLE}.{key}"
-        expected = _CONVERT_KEY_TYPES[key]
+        label = f"{BUILD_TABLE}.{NEEDS_TABLE}.{key}"
+        expected = _NEEDS_KEY_TYPES[key]
         if not isinstance(item, expected):
             _wrong_type(label, item, expected, path)
         if expected is list:
@@ -476,15 +512,28 @@ def _check_link_properties(value: object, path: Path) -> None:
     for name, field in value.items():
         if not str(name).strip() or not (isinstance(field, str) and field.strip()):
             msg = (
-                f"{path}: [{SECTION}.{CONVERT_TABLE}] link_properties expects "
+                f"{path}: [{NEEDS_TABLE_PATH}] link_properties expects "
                 f'PROPERTY = "LINK_FIELD" with both names non-empty, got '
                 f"{name!r} = {field!r}"
             )
             raise TomlConfigError(msg)
 
 
+def needs_settings(section: Mapping[str, object]) -> Mapping[str, object] | None:
+    """The ``[test_reports.build.needs]`` table, or ``None`` when unset.
+
+    The one place that knows how the table is nested, so a consumer never
+    spells the path itself.
+    """
+    build = section.get(BUILD_TABLE)
+    if not isinstance(build, Mapping):
+        return None
+    needs = build.get(NEEDS_TABLE)
+    return needs if isinstance(needs, Mapping) else None
+
+
 def _check_need_type_agreement(section: Mapping[str, object], path: Path) -> None:
-    """``convert.need_type`` and ``case``'s type name the same need type.
+    """``build.needs.need_type`` and ``case``'s type name the same need type.
 
     They are separate keys with separate consumers -- the converter derives the
     need type and the deterministic-ID prefix from ``need_type``, the Sphinx
@@ -494,22 +543,21 @@ def _check_need_type_agreement(section: Mapping[str, object], path: Path) -> Non
     build neither registers nor cross-links.
 
     A side that is not set is compared at its default, not skipped: a
-    customised ``case`` next to a ``convert`` table without ``need_type`` is a
-    disagreement too. The check only applies when the ``convert`` table exists
-    -- a project that only builds and never converts may name its case type
-    freely.
+    customised ``case`` next to a ``build.needs`` table without ``need_type``
+    is a disagreement too. The check only applies when that table exists -- a
+    project that only builds documentation may name its case type freely.
     """
-    convert = section.get(CONVERT_TABLE)
-    if not isinstance(convert, Mapping):
+    needs = needs_settings(section)
+    if needs is None:
         return
-    need_type: object = convert.get("need_type", DEFAULT_NEED_TYPE)
+    need_type: object = needs.get("need_type", DEFAULT_NEED_TYPE)
     case_type = case_need_type(section) or DEFAULT_NEED_TYPE
     if case_type != need_type:
         msg = (
-            f"{path}: [{SECTION}.{CONVERT_TABLE}] need_type is {need_type!r} but "
+            f"{path}: [{NEEDS_TABLE_PATH}] need_type is {need_type!r} but "
             f"[{SECTION}] case's type is {case_type!r} (each defaulting to "
             f"{DEFAULT_NEED_TYPE!r} when not set). Both name the need type of a "
-            f"test case -- need_type for the converter, case for the Sphinx "
+            f"test case -- need_type for `build needs`, case for the Sphinx "
             f"build -- so they must agree, or the produced needs.json and the "
             f"build describe different need types."
         )

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -6,16 +6,20 @@ sphinx-codelinks, sphinx-mounts, ubCode) -- so that a project is described once
 instead of being restated in every tool that acts on it.
 
 **Nothing in this module may import Sphinx.** The section describes the project,
-not this extension, and a report-to-``needs.json`` converter has to be able to
-read it as a build action without the documentation toolchain installed.
+not this extension, and the ``test-reports convert`` command reads it as a
+build action without the documentation toolchain installed.
 
-The keys are the Sphinx-facing configuration (:data:`BRIDGE_KEYS`), spelled
-like the ``tr_*`` config values without the prefix. One sub-table belongs to
-another consumer: ``[test_reports.build]`` holds what the ``test-reports
-build`` command line produces -- ``[test_reports.build.needs]`` for its
-``needs.json`` -- which this reader passes through without interpreting it
-(:data:`FOREIGN_TABLES`). Any other sub-table is an unknown key like any
-other.
+Keys fall into two groups:
+
+* the Sphinx-facing configuration (:data:`BRIDGE_KEYS`), spelled like the
+  ``tr_*`` config values without the prefix, which the extension applies at
+  ``config-inited``;
+* the ``[test_reports.convert]`` sub-table (:data:`CONVERSION_KEYS`): how test
+  reports are turned into a ``needs.json``. The Sphinx bridge never applies it
+  to a ``tr_*`` value, but the build validates it like every other key, so a
+  typo is caught by whichever consumer reads the file first.
+
+Any other sub-table is an unknown key like any other.
 
 **Error policy.** A known key carrying the wrong type is fatal: that is the
 typo class this validation exists to catch, and letting it through would
@@ -102,12 +106,37 @@ PATH_KEYS = ("rootdir", "report_template")
 #: list form. ``None`` in :data:`_KEY_TYPES` marks exactly these.
 _DUAL_SPELLING_KEYS = ("file", "suite", "case")
 
-#: Sub-tables of the section that belong to another consumer. They are
-#: recognised so they do not draw an unknown-key warning, and deliberately not
-#: interpreted: ``build`` holds the settings of the ``test-reports build``
-#: command line, one sub-table per artifact it produces (``build.needs`` for a
-#: ``needs.json``), and this extension produces none of them.
-FOREIGN_TABLES = ("build",)
+#: The sub-table read by the ``test-reports convert`` command. It is not a
+#: bridge key: the build never maps it onto a ``tr_*`` value. It is validated
+#: like everything else, so that the build rejects the same typos the converter
+#: would -- one file, one verdict.
+CONVERT_TABLE = "convert"
+
+#: Keys of ``[test_reports.convert]``, in the order the converter documents
+#: them. The CLI's flag merge iterates this, so a key cannot be added here
+#: without the CLI being taught a default for it.
+CONVERSION_KEYS = (
+    "project",
+    "version",
+    "need_type",
+    "tags",
+    "link_properties",
+    "remote_url",
+    "commit",
+    "url_pattern",
+)
+
+#: Expected Python type per ``[test_reports.convert]`` key.
+_CONVERT_KEY_TYPES: dict[str, type[object]] = {
+    "project": str,
+    "version": str,
+    "need_type": str,
+    "tags": list,
+    "link_properties": dict,
+    "remote_url": str,
+    "commit": str,
+    "url_pattern": str,
+}
 
 #: Expected Python type per key. ``bool`` must be checked *before* ``int``
 #: (bool is an int subclass). ``None`` marks the dual-spelling keys, which are
@@ -129,7 +158,7 @@ _KEY_TYPES: dict[str, type[object] | None] = {
     "property_link_types": dict,
     "json_mapping": dict,
     "deterministic_case_ids": bool,
-    "build": dict,
+    "convert": dict,
 }
 
 #: Required type of the *values* inside a table-valued key. Without this a
@@ -141,12 +170,16 @@ _KEY_TYPES: dict[str, type[object] | None] = {
 _DICT_VALUE_TYPES: dict[str, type[object] | None] = {
     "property_link_types": str,
     "json_mapping": None,
-    "build": None,
+    "link_properties": str,
 }
 
 #: Field order of the positional ``tr_file``-style lists, and the table keys
 #: that spell the same thing readably.
 _TYPE_ENTRY_FIELDS = ("directive", "type", "name", "prefix", "color", "style")
+
+#: Index of ``type`` within :data:`_TYPE_ENTRY_FIELDS`, i.e. of the need type
+#: inside a normalised entry.
+_TYPE_FIELD_INDEX = _TYPE_ENTRY_FIELDS.index("type")
 
 #: ``tomllib.TOMLDecodeError`` bound through an annotation: the attribute
 #: expression itself is typed loosely enough to trip the strict ``Any`` bans,
@@ -322,8 +355,8 @@ def _normalise_section(
             _wrong_type(key, value, expected, path)
         if expected is not None and not isinstance(value, expected):
             _wrong_type(key, value, expected, path)
-        if key in FOREIGN_TABLES:
-            normalised[key] = value
+        if key == CONVERT_TABLE:
+            normalised[key] = _normalise_convert_table(value, path, warn)
         elif key in _DUAL_SPELLING_KEYS:
             normalised[key] = _normalise_type_entry(key, value, path)
         else:
@@ -333,7 +366,72 @@ def _normalise_section(
                 _check_table_values(key, value, path)
             normalised[key] = value
 
+    _check_need_type_agreement(normalised, path)
     return _anchor_paths(normalised, path.parent)
+
+
+def _normalise_convert_table(
+    value: object, path: Path, warn: Callable[[str], None] | None
+) -> dict[str, object]:
+    """Validate ``[test_reports.convert]`` under the section's own policy.
+
+    Same rules as the section: a known key with the wrong type is fatal, an
+    unknown key is reported and dropped, table values are checked. The caller
+    has already established that *value* is a table.
+    """
+    if not isinstance(value, Mapping):
+        return {}
+    table: dict[str, object] = {str(name): item for name, item in value.items()}
+    unknown = sorted(set(table) - set(_CONVERT_KEY_TYPES))
+    if unknown and warn is not None:
+        warn(
+            f"{path}: ignoring unknown key(s) in [{SECTION}.{CONVERT_TABLE}]: "
+            f"{', '.join(unknown)}. Supported keys: "
+            f"{', '.join(CONVERSION_KEYS)}"
+        )
+    normalised: dict[str, object] = {}
+    for key, item in table.items():
+        if key in unknown:
+            continue
+        label = f"{CONVERT_TABLE}.{key}"
+        expected = _CONVERT_KEY_TYPES[key]
+        if not isinstance(item, expected):
+            _wrong_type(label, item, expected, path)
+        if expected is list:
+            _check_list_items(label, item, path)
+        elif expected is dict:
+            _check_table_values(key, item, path, label)
+        normalised[key] = item
+    return normalised
+
+
+def _check_need_type_agreement(section: Mapping[str, object], path: Path) -> None:
+    """``convert.need_type`` and ``case``'s type name the same need type.
+
+    They are separate keys with separate consumers -- the converter derives the
+    need type and the deterministic-ID prefix from ``need_type``, the Sphinx
+    build from ``case``'s ``type`` -- and both default to ``testcase``. Letting
+    them disagree produces exactly the divergence this file exists to prevent:
+    a ``needs.json`` full of ``testcase__*`` needs that the build neither
+    registers nor cross-links.
+    """
+    convert = section.get(CONVERT_TABLE)
+    case = section.get("case")
+    if not isinstance(convert, Mapping) or not isinstance(case, Sequence):
+        return
+    need_type: object = convert.get("need_type")
+    if not isinstance(need_type, str):
+        return
+    case_type: object = case[_TYPE_FIELD_INDEX]
+    if case_type != need_type:
+        msg = (
+            f"{path}: [{SECTION}.{CONVERT_TABLE}] need_type is {need_type!r} but "
+            f"[{SECTION}] case's type is {case_type!r}. Both name the need type "
+            f"of a test case -- need_type for the converter, case for the Sphinx "
+            f"build -- so they must agree, or the produced needs.json and the "
+            f"build describe different need types."
+        )
+        raise TomlConfigError(msg)
 
 
 def _check_list_items(key: str, value: object, path: Path) -> None:
@@ -345,11 +443,14 @@ def _check_list_items(key: str, value: object, path: Path) -> None:
             _wrong_type(key, value, list, path)
 
 
-def _check_table_values(key: str, value: object, path: Path) -> None:
+def _check_table_values(
+    key: str, value: object, path: Path, label: str | None = None
+) -> None:
     """Every value of a table-valued key must have the declared type.
 
     Skipped for keys whose nested shape is free-form (:data:`_DICT_VALUE_TYPES`
-    maps them to ``None``).
+    maps them to ``None``). *label* is how the key is spelled in messages when
+    it sits in a sub-table.
     """
     expected = _DICT_VALUE_TYPES.get(key)
     if expected is None or not isinstance(value, Mapping):
@@ -357,7 +458,7 @@ def _check_table_values(key: str, value: object, path: Path) -> None:
     for name, item in value.items():
         if not isinstance(item, expected):
             msg = (
-                f"{path}: [{SECTION}] {key}.{name} must be "
+                f"{path}: [{SECTION}] {label or key}.{name} must be "
                 f"{_type_label(expected)}, got {type(item).__name__}: {item!r}"
             )
             raise TomlConfigError(msg)

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -6,7 +6,7 @@ sphinx-codelinks, sphinx-mounts, ubCode) -- so that a project is described once
 instead of being restated in every tool that acts on it.
 
 **Nothing in this module may import Sphinx.** The section describes the project,
-not this extension, and the ``test-reports convert`` command reads it as a
+not this extension, and the ``test-reports build needs`` command reads it as a
 build action without the documentation toolchain installed.
 
 Keys fall into two groups:
@@ -109,7 +109,7 @@ PATH_KEYS = ("rootdir", "report_template")
 #: list form. ``None`` in :data:`_KEY_TYPES` marks exactly these.
 _DUAL_SPELLING_KEYS = ("file", "suite", "case")
 
-#: The sub-table read by the ``test-reports convert`` command. It is not a
+#: The sub-table read by the ``test-reports build needs`` command. It is not a
 #: bridge key: the build never maps it onto a ``tr_*`` value. It is validated
 #: like everything else, so that the build rejects the same typos the converter
 #: would -- one file, one verdict.

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -38,6 +38,8 @@ import tomllib
 from pathlib import Path
 from typing import Callable, Mapping, NoReturn, Sequence
 
+from sphinxcontrib.test_reports.fields import RESERVED_NAMES
+
 #: Default file the configuration is read from. Looked up by walking up from
 #: the ``confdir`` (Sphinx) or the working directory (a converter); see
 #: :func:`find_project_config`. ``ubproject.toml`` is the convention shared
@@ -415,16 +417,24 @@ def field_names(section: Mapping[str, object]) -> dict[str, str]:
 
 
 def _check_field_name_collisions(section: Mapping[str, object], path: Path) -> None:
-    """The report-path and source-location fields must have distinct names.
+    """The report-path and source-location fields must have names of their own.
 
-    Two options naming one field would make ``add_need`` receive the same
-    keyword twice (a bare ``TypeError`` inside a directive) and the converter
-    write one value over the other. The build checks its ``conf.py`` values the
-    same way; this covers the declarative spelling for both consumers.
+    Two options naming one field, or one of them naming a fixed field such as
+    ``case`` or ``result``, would make ``add_need`` receive the same keyword
+    twice (a bare ``TypeError`` inside a directive) and the converter write one
+    value over the other. The build checks its ``conf.py`` values the same way;
+    this covers the declarative spelling for both consumers.
     """
     names = field_names(section)
     seen: dict[str, str] = {}
     for key, name in names.items():
+        if name in RESERVED_NAMES:
+            msg = (
+                f"{path}: [{SECTION}] {key} = {name!r}: {name!r} is a field every "
+                f"test-case need has already; the report path and the source "
+                f"location must live in fields of their own"
+            )
+            raise TomlConfigError(msg)
         if name in seen:
             msg = (
                 f"{path}: [{SECTION}] {seen[name]} and {key} both name the need "

--- a/sphinxcontrib/test_reports/projectconfig.py
+++ b/sphinxcontrib/test_reports/projectconfig.py
@@ -13,7 +13,10 @@ Keys fall into two groups:
 
 * the Sphinx-facing configuration (:data:`BRIDGE_KEYS`), spelled like the
   ``tr_*`` config values without the prefix, which the extension applies at
-  ``config-inited``;
+  ``config-inited``. The converter reads the three field-name keys among them
+  (:data:`FIELD_NAME_KEYS`) and ``extra_options``, so the needs it writes have
+  the shape of the needs the build creates and carry exactly the fields the
+  build accepts;
 * the ``[test_reports.convert]`` sub-table (:data:`CONVERSION_KEYS`): how test
   reports are turned into a ``needs.json``. The Sphinx bridge never applies it
   to a ``tr_*`` value, but the build validates it like every other key, so a
@@ -125,6 +128,24 @@ CONVERSION_KEYS = (
     "commit",
     "url_pattern",
 )
+
+#: The three renameable need fields and their default names -- the field
+#: carrying the XML *report* path, and the two carrying the test's *source*
+#: location. The build registers these names (``tr_file_option``,
+#: ``tr_source_file_option``, ``tr_source_line_option``) and the converter
+#: writes them, so an imported need and a locally created one have the same
+#: shape. Both sides take the defaults from here.
+FIELD_NAME_KEYS = ("file_option", "source_file_option", "source_line_option")
+DEFAULT_FIELD_NAMES: dict[str, str] = {
+    "file_option": "file",
+    "source_file_option": "case_file",
+    "source_line_option": "case_line",
+}
+
+#: Need type of a test case when neither consumer is told otherwise: the
+#: converter's ``need_type`` default and the ``type`` of the build's default
+#: ``case`` entry. Both defaults live here so they cannot drift apart.
+DEFAULT_NEED_TYPE = "testcase"
 
 #: Expected Python type per ``[test_reports.convert]`` key.
 _CONVERT_KEY_TYPES: dict[str, type[object]] = {
@@ -367,7 +388,43 @@ def _normalise_section(
             normalised[key] = value
 
     _check_need_type_agreement(normalised, path)
+    _check_field_name_collisions(normalised, path)
     return _anchor_paths(normalised, path.parent)
+
+
+def field_names(section: Mapping[str, object]) -> dict[str, str]:
+    """The report-path and source-location field names the section selects.
+
+    Keys are :data:`FIELD_NAME_KEYS`; a key the section does not set falls
+    back to :data:`DEFAULT_FIELD_NAMES`, which is also the build's default.
+    """
+    names = dict(DEFAULT_FIELD_NAMES)
+    for key in FIELD_NAME_KEYS:
+        value = section.get(key)
+        if isinstance(value, str) and value:
+            names[key] = value
+    return names
+
+
+def _check_field_name_collisions(section: Mapping[str, object], path: Path) -> None:
+    """The report-path and source-location fields must have distinct names.
+
+    Two options naming one field would make ``add_need`` receive the same
+    keyword twice (a bare ``TypeError`` inside a directive) and the converter
+    write one value over the other. The build checks its ``conf.py`` values the
+    same way; this covers the declarative spelling for both consumers.
+    """
+    names = field_names(section)
+    seen: dict[str, str] = {}
+    for key, name in names.items():
+        if name in seen:
+            msg = (
+                f"{path}: [{SECTION}] {seen[name]} and {key} both name the need "
+                f"field {name!r}; the report path and the source location must "
+                f"live in different fields"
+            )
+            raise TomlConfigError(msg)
+        seen[name] = key
 
 
 def _normalise_convert_table(
@@ -401,8 +458,29 @@ def _normalise_convert_table(
             _check_list_items(label, item, path)
         elif expected is dict:
             _check_table_values(key, item, path, label)
+            if key == "link_properties":
+                _check_link_properties(item, path)
         normalised[key] = item
     return normalised
+
+
+def _check_link_properties(value: object, path: Path) -> None:
+    """Every ``PROPERTY = "LINK_FIELD"`` pair must have two non-empty names.
+
+    Checked here rather than only in the converter, so the build and the
+    converter give one verdict on the file: a silently dropped pair would send
+    a link field into ``needs.json`` as a plain field instead.
+    """
+    if not isinstance(value, Mapping):
+        return
+    for name, field in value.items():
+        if not str(name).strip() or not (isinstance(field, str) and field.strip()):
+            msg = (
+                f"{path}: [{SECTION}.{CONVERT_TABLE}] link_properties expects "
+                f'PROPERTY = "LINK_FIELD" with both names non-empty, got '
+                f"{name!r} = {field!r}"
+            )
+            raise TomlConfigError(msg)
 
 
 def _check_need_type_agreement(section: Mapping[str, object], path: Path) -> None:
@@ -410,23 +488,28 @@ def _check_need_type_agreement(section: Mapping[str, object], path: Path) -> Non
 
     They are separate keys with separate consumers -- the converter derives the
     need type and the deterministic-ID prefix from ``need_type``, the Sphinx
-    build from ``case``'s ``type`` -- and both default to ``testcase``. Letting
-    them disagree produces exactly the divergence this file exists to prevent:
-    a ``needs.json`` full of ``testcase__*`` needs that the build neither
-    registers nor cross-links.
+    build from ``case``'s ``type`` -- and both default to
+    :data:`DEFAULT_NEED_TYPE`. Letting them disagree produces exactly the
+    divergence this file exists to prevent: a ``needs.json`` full of needs the
+    build neither registers nor cross-links.
+
+    A side that is not set is compared at its default, not skipped: a
+    customised ``case`` next to a ``convert`` table without ``need_type`` is a
+    disagreement too. The check only applies when the ``convert`` table exists
+    -- a project that only builds and never converts may name its case type
+    freely.
     """
     convert = section.get(CONVERT_TABLE)
-    case_type = case_need_type(section)
-    if not isinstance(convert, Mapping) or case_type is None:
+    if not isinstance(convert, Mapping):
         return
-    need_type: object = convert.get("need_type")
-    if not isinstance(need_type, str):
-        return
+    need_type: object = convert.get("need_type", DEFAULT_NEED_TYPE)
+    case_type = case_need_type(section) or DEFAULT_NEED_TYPE
     if case_type != need_type:
         msg = (
             f"{path}: [{SECTION}.{CONVERT_TABLE}] need_type is {need_type!r} but "
-            f"[{SECTION}] case's type is {case_type!r}. Both name the need type "
-            f"of a test case -- need_type for the converter, case for the Sphinx "
+            f"[{SECTION}] case's type is {case_type!r} (each defaulting to "
+            f"{DEFAULT_NEED_TYPE!r} when not set). Both name the need type of a "
+            f"test case -- need_type for the converter, case for the Sphinx "
             f"build -- so they must agree, or the produced needs.json and the "
             f"build describe different need types."
         )

--- a/sphinxcontrib/test_reports/remote.py
+++ b/sphinxcontrib/test_reports/remote.py
@@ -1,0 +1,66 @@
+"""Web URLs for test sources.
+
+Sphinx-free, like every module the converter CLI depends on.
+
+Only the small amount of URL handling the converter actually needs lives here:
+normalising a git remote into a browsable base, and formatting a line-anchored
+source URL. sphinx-codelinks carries a fuller implementation (giturlparse-based,
+covering more forges); when the two extensions are consolidated the machinery
+should be shared rather than duplicated -- which is why this stays deliberately
+minimal instead of growing a second forge matrix.
+"""
+
+import re
+
+#: GitHub and GitHub-compatible forges. GitLab needs ``{base}/-/blob/...``.
+DEFAULT_URL_PATTERN = "{base}/blob/{commit}/{file}#L{line}"
+
+#: ``git@host:org/repo.git`` and ``ssh://git@host/org/repo.git``.
+_SCP_STYLE = re.compile(
+    r"^(?:ssh://)?(?:[^@/]+@)?(?P<host>[^:/]+)[:/](?P<path>.+?)(?:\.git)?/?$"
+)
+
+
+def normalise_remote_url(remote_url: str) -> str:
+    """Turn a git remote into a browsable ``https`` base URL.
+
+    An already-browsable URL is returned unchanged apart from a trailing
+    ``.git``/``/``; anything unrecognised is passed through, so an explicitly
+    configured base is never mangled.
+    """
+    url = remote_url.strip()
+    if not url:
+        return ""
+
+    if url.startswith(("http://", "https://")):
+        stripped = url.rstrip("/")
+        return stripped.removesuffix(".git")
+
+    match = _SCP_STYLE.match(url)
+    if match is None:
+        return url.rstrip("/")
+
+    host = match.group("host")
+    path = match.group("path")
+    return f"https://{host}/{path}"
+
+
+def source_url(
+    base_url: str,
+    commit: str,
+    file: str,
+    line: str,
+    pattern: str = DEFAULT_URL_PATTERN,
+) -> str:
+    """Line-anchored URL of a test source, or ``""`` without repo metadata.
+
+    A hermetic build has no git remote, so the absence of metadata must yield an
+    empty field rather than a placeholder URL that looks real and 404s.
+    When the line is unknown the anchor is dropped instead of pointing at a
+    fabricated line.
+    """
+    if not base_url or not commit or not file:
+        return ""
+
+    effective_pattern = pattern if line else pattern.split("#")[0]
+    return effective_pattern.format(base=base_url, commit=commit, file=file, line=line)

--- a/sphinxcontrib/test_reports/remote.py
+++ b/sphinxcontrib/test_reports/remote.py
@@ -15,39 +15,68 @@ import re
 #: GitHub and GitHub-compatible forges. GitLab needs ``{base}/-/blob/...``.
 DEFAULT_URL_PATTERN = "{base}/blob/{commit}/{file}#L{line}"
 
-#: ``ssh://git@host[:port]/org/repo.git``. The port belongs to the ssh
+#: The part after ``scheme://`` of an ``ssh://`` or ``git://`` remote:
+#: ``[user@]host[:port]/org/repo[.git]``. The port belongs to the transport
 #: endpoint, not to the web UI, so it must not survive into the browsable base
 #: -- and must not be mistaken for the first path segment.
-_SSH_URL = re.compile(
-    r"^ssh://(?:[^@/]+@)?(?P<host>[^:/]+)(?::\d+)?/(?P<path>.+?)(?:\.git)?/?$"
+_SCHEME_REMOTE = re.compile(
+    r"^(?:[^@/]+@)?(?P<host>[^:/]+)(?::\d+)?/(?P<path>.+?)(?:\.git)?/?$"
 )
 
 #: ``git@host:org/repo.git`` and bare ``host/org/repo``.
 _SCP_STYLE = re.compile(r"^(?:[^@/]+@)?(?P<host>[^:/]+)[:/](?P<path>.+?)(?:\.git)?/?$")
+
+#: Placeholders a URL pattern may use, with representative values for checking
+#: a pattern before any need is built.
+_PATTERN_FIELDS = {"base": "https://h/r", "commit": "c", "file": "f", "line": "1"}
 
 
 def normalise_remote_url(remote_url: str) -> str:
     """Turn a git remote into a browsable ``https`` base URL.
 
     An already-browsable URL is returned unchanged apart from a trailing
-    ``.git``/``/``; anything unrecognised is passed through, so an explicitly
-    configured base is never mangled.
+    ``.git``/``/``; ``ssh://`` and ``git://`` remotes and scp-style
+    ``git@host:path`` become ``https://host/path``. Anything unrecognised -- an
+    unknown scheme, a shape none of the patterns match -- is passed through, so
+    an explicitly configured base is never mangled.
     """
     url = remote_url.strip()
     if not url:
         return ""
 
-    if url.startswith(("http://", "https://")):
-        stripped = url.rstrip("/")
-        return stripped.removesuffix(".git")
-
-    match = _SSH_URL.match(url) or _SCP_STYLE.match(url)
-    if match is None:
+    scheme, separator, rest = url.partition("://")
+    if separator:
+        if scheme in ("http", "https"):
+            return url.rstrip("/").removesuffix(".git")
+        if scheme in ("ssh", "git"):
+            match = _SCHEME_REMOTE.match(rest)
+            if match is not None:
+                return f"https://{match.group('host')}/{match.group('path')}"
         return url.rstrip("/")
 
-    host = match.group("host")
-    path = match.group("path")
-    return f"https://{host}/{path}"
+    match = _SCP_STYLE.match(url)
+    if match is None:
+        return url.rstrip("/")
+    return f"https://{match.group('host')}/{match.group('path')}"
+
+
+def check_url_pattern(pattern: str) -> str | None:
+    """Why *pattern* cannot be used as a source-URL template, or ``None``.
+
+    ``str.format`` only fails when a URL is actually built -- that is, on the
+    first case that carries a file -- and it fails with a traceback. Checking
+    the template up front turns a typo in a flag or in ``ubproject.toml`` into
+    a configuration error at the start of the run.
+    """
+    try:
+        pattern.format(**_PATTERN_FIELDS)
+    except KeyError as error:
+        allowed = ", ".join(f"{{{name}}}" for name in _PATTERN_FIELDS)
+        missing = str(error).strip("'")  # KeyError's str is the quoted key
+        return f"unknown placeholder {{{missing}}}; the placeholders are {allowed}"
+    except (IndexError, ValueError) as error:
+        return f"malformed template ({error}); braces must be balanced and named"
+    return None
 
 
 def source_url(

--- a/sphinxcontrib/test_reports/remote.py
+++ b/sphinxcontrib/test_reports/remote.py
@@ -15,10 +15,15 @@ import re
 #: GitHub and GitHub-compatible forges. GitLab needs ``{base}/-/blob/...``.
 DEFAULT_URL_PATTERN = "{base}/blob/{commit}/{file}#L{line}"
 
-#: ``git@host:org/repo.git`` and ``ssh://git@host/org/repo.git``.
-_SCP_STYLE = re.compile(
-    r"^(?:ssh://)?(?:[^@/]+@)?(?P<host>[^:/]+)[:/](?P<path>.+?)(?:\.git)?/?$"
+#: ``ssh://git@host[:port]/org/repo.git``. The port belongs to the ssh
+#: endpoint, not to the web UI, so it must not survive into the browsable base
+#: -- and must not be mistaken for the first path segment.
+_SSH_URL = re.compile(
+    r"^ssh://(?:[^@/]+@)?(?P<host>[^:/]+)(?::\d+)?/(?P<path>.+?)(?:\.git)?/?$"
 )
+
+#: ``git@host:org/repo.git`` and bare ``host/org/repo``.
+_SCP_STYLE = re.compile(r"^(?:[^@/]+@)?(?P<host>[^:/]+)[:/](?P<path>.+?)(?:\.git)?/?$")
 
 
 def normalise_remote_url(remote_url: str) -> str:
@@ -36,7 +41,7 @@ def normalise_remote_url(remote_url: str) -> str:
         stripped = url.rstrip("/")
         return stripped.removesuffix(".git")
 
-    match = _SCP_STYLE.match(url)
+    match = _SSH_URL.match(url) or _SCP_STYLE.match(url)
     if match is None:
         return url.rstrip("/")
 
@@ -62,5 +67,11 @@ def source_url(
     if not base_url or not commit or not file:
         return ""
 
-    effective_pattern = pattern if line else pattern.split("#")[0]
-    return effective_pattern.format(base=base_url, commit=commit, file=file, line=line)
+    if not line:
+        # Drop the fragment only when the anchor lives there. A pattern that
+        # carries the line elsewhere keeps its shape and gets an empty value,
+        # instead of losing whatever else followed the ``#``.
+        head, hash_sign, fragment = pattern.partition("#")
+        if hash_sign and "{line}" in fragment:
+            pattern = head
+    return pattern.format(base=base_url, commit=commit, file=file, line=line)

--- a/sphinxcontrib/test_reports/remote.py
+++ b/sphinxcontrib/test_reports/remote.py
@@ -11,6 +11,8 @@ minimal instead of growing a second forge matrix.
 """
 
 import re
+import string
+from urllib.parse import urlsplit, urlunsplit
 
 #: GitHub and GitHub-compatible forges. GitLab needs ``{base}/-/blob/...``.
 DEFAULT_URL_PATTERN = "{base}/blob/{commit}/{file}#L{line}"
@@ -26,6 +28,10 @@ _SCHEME_REMOTE = re.compile(
 #: ``git@host:org/repo.git`` and bare ``host/org/repo``.
 _SCP_STYLE = re.compile(r"^(?:[^@/]+@)?(?P<host>[^:/]+)[:/](?P<path>.+?)(?:\.git)?/?$")
 
+#: ``C:\repo`` or ``C:/repo`` -- a Windows path, which the scp-style pattern
+#: would otherwise read as ``host:path`` with the drive letter for a host.
+_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:[\\/]")
+
 #: Placeholders a URL pattern may use, with representative values for checking
 #: a pattern before any need is built.
 _PATTERN_FIELDS = {"base": "https://h/r", "commit": "c", "file": "f", "line": "1"}
@@ -35,10 +41,16 @@ def normalise_remote_url(remote_url: str) -> str:
     """Turn a git remote into a browsable ``https`` base URL.
 
     An already-browsable URL is returned unchanged apart from a trailing
-    ``.git``/``/``; ``ssh://`` and ``git://`` remotes and scp-style
-    ``git@host:path`` become ``https://host/path``. Anything unrecognised -- an
-    unknown scheme, a shape none of the patterns match -- is passed through, so
-    an explicitly configured base is never mangled.
+    ``.git``/``/`` and any credentials; ``ssh://`` and ``git://`` remotes and
+    scp-style ``git@host:path`` become ``https://host/path``. Anything
+    unrecognised -- an unknown scheme, a local path, a shape none of the
+    patterns match -- is passed through, so an explicitly configured base is
+    never mangled.
+
+    Credentials never survive. ``https://gitlab-ci-token:TOKEN@host/repo`` is
+    what GitLab's ``CI_REPOSITORY_URL`` looks like, the natural value to pass;
+    the base ends up in every need of a cached artifact and, once imported, in
+    published HTML.
     """
     url = remote_url.strip()
     if not url:
@@ -47,17 +59,28 @@ def normalise_remote_url(remote_url: str) -> str:
     scheme, separator, rest = url.partition("://")
     if separator:
         if scheme in ("http", "https"):
-            return url.rstrip("/").removesuffix(".git")
+            return _without_userinfo(url).rstrip("/").removesuffix(".git")
         if scheme in ("ssh", "git"):
             match = _SCHEME_REMOTE.match(rest)
             if match is not None:
                 return f"https://{match.group('host')}/{match.group('path')}"
         return url.rstrip("/")
 
+    if _WINDOWS_DRIVE.match(url):
+        return url
     match = _SCP_STYLE.match(url)
     if match is None:
         return url.rstrip("/")
     return f"https://{match.group('host')}/{match.group('path')}"
+
+
+def _without_userinfo(url: str) -> str:
+    """*url* without the ``user:password@`` part of its authority, if any."""
+    parts = urlsplit(url)
+    if "@" not in parts.netloc:
+        return url
+    host = parts.netloc.rpartition("@")[2]
+    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
 
 
 def check_url_pattern(pattern: str) -> str | None:
@@ -67,14 +90,34 @@ def check_url_pattern(pattern: str) -> str | None:
     first case that carries a file -- and it fails with a traceback. Checking
     the template up front turns a typo in a flag or in ``ubproject.toml`` into
     a configuration error at the start of the run.
+
+    The placeholders are enumerated rather than tried: ``str.format`` accepts
+    ``{base.__class__}`` or ``{base[0]}`` -- an attribute or index lookup on
+    the substituted value -- which is not a URL template, and which fails as
+    an ``AttributeError`` no ``KeyError`` handler sees.
     """
+    allowed = ", ".join(f"{{{name}}}" for name in _PATTERN_FIELDS)
     try:
+        fields = [
+            field
+            for _literal, field, _spec, _conversion in string.Formatter().parse(pattern)
+            if field is not None
+        ]
+    except ValueError as error:
+        return f"malformed template ({error}); braces must be balanced and named"
+    for field in fields:
+        if not field or field.isdigit():
+            return (
+                f"malformed template (positional placeholder {{{field}}}); "
+                f"braces must be balanced and named"
+            )
+        if field not in _PATTERN_FIELDS:
+            return f"unknown placeholder {{{field}}}; the placeholders are {allowed}"
+    try:
+        # The names are known to be fine; this catches a format spec
+        # str.format rejects, such as ``{line:zz}``.
         pattern.format(**_PATTERN_FIELDS)
-    except KeyError as error:
-        allowed = ", ".join(f"{{{name}}}" for name in _PATTERN_FIELDS)
-        missing = str(error).strip("'")  # KeyError's str is the quoted key
-        return f"unknown placeholder {{{missing}}}; the placeholders are {allowed}"
-    except (IndexError, ValueError) as error:
+    except ValueError as error:
         return f"malformed template ({error}); braces must be balanced and named"
     return None
 

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -8,8 +8,15 @@ from sphinx.config import Config
 from sphinx.util import logging
 
 # from docutils import nodes
-from sphinx_needs.api import add_dynamic_function, add_need_type
-from sphinx_needs.exceptions import NeedsApiConfigWarning
+# sphinx-needs ships no py.typed marker and no stubs exist, so every import
+# from it is untyped to mypy. Nothing to fix on this side.
+from sphinx_needs.api import (  # type: ignore[import-untyped]
+    add_dynamic_function,
+    add_need_type,
+)
+from sphinx_needs.exceptions import (  # type: ignore[import-untyped]
+    NeedsApiConfigWarning,
+)
 
 from sphinxcontrib.test_reports.directives.test_case import TestCase, TestCaseDirective
 from sphinxcontrib.test_reports.directives.test_env import EnvReport, EnvReportDirective
@@ -220,7 +227,7 @@ def setup(app: Sphinx) -> dict[str, object]:
     }
 
 
-def register_tr_extra_options(app):
+def register_tr_extra_options(app: Sphinx) -> None:
     """Register extra options with directives."""
 
     log = logging.getLogger(__name__)
@@ -229,12 +236,16 @@ def register_tr_extra_options(app):
 
     if tr_extra_options:
         for direc in [TestSuiteDirective, TestFileDirective, TestCaseDirective]:
+            # docutils types `option_spec` as optional on the directive base
+            # class. All three define one, so this keeps mutating the existing
+            # mapping; the assignment only matters in the case the type allows
+            # for and the classes do not produce.
+            spec = direc.option_spec or {}
             for option_name in tr_extra_options:
-                direc.option_spec[option_name] = directives.unchanged
+                spec[option_name] = directives.unchanged
                 log.debug(f"Registered {option_name} with {direc}")
-                log.debug(
-                    f"{direc}.option_spec now has keys: {list(direc.option_spec.keys())}"
-                )
+                log.debug(f"{direc}.option_spec now has keys: {list(spec.keys())}")
+            direc.option_spec = spec
 
 
 def _command_line_overrides(config: Config) -> set[str]:
@@ -326,24 +337,28 @@ def load_toml_config(app: Sphinx, config: Config) -> None:
         )
 
 
-def tr_preparation(app, *args):
+def tr_preparation(app: Sphinx, *args: object) -> None:
     """
     Prepares needed vars in the app context.
     """
-    if not hasattr(app, "tr_types"):
-        app.tr_types = {}
+    # `tr_types` is attached to the application object, which has no such
+    # attribute as far as a type checker is concerned -- the directives read it
+    # back the same way (see `test_common.py`). One narrow ignore for the
+    # attachment; the rest of the function works on a typed mapping.
+    types: dict[str, list[str]] = getattr(app, "tr_types", None) or {}
+    app.tr_types = types  # type: ignore[attr-defined]
 
     # Collects the configured test-report node types
-    app.tr_types[app.config.tr_file[0]] = app.config.tr_file[1:]
-    app.tr_types[app.config.tr_suite[0]] = app.config.tr_suite[1:]
-    app.tr_types[app.config.tr_case[0]] = app.config.tr_case[1:]
+    types[app.config.tr_file[0]] = app.config.tr_file[1:]
+    types[app.config.tr_suite[0]] = app.config.tr_suite[1:]
+    types[app.config.tr_case[0]] = app.config.tr_case[1:]
 
     app.add_directive(app.config.tr_file[0], TestFileDirective)
     app.add_directive(app.config.tr_suite[0], TestSuiteDirective)
     app.add_directive(app.config.tr_case[0], TestCaseDirective)
 
 
-def check_field_name_collisions(config) -> None:
+def check_field_name_collisions(config: Config) -> None:
     """Reject configurations where two field options name the same need field.
 
     The report path and the test-source location are separate fields; if two

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -28,6 +28,7 @@ from sphinxcontrib.test_reports.directives.test_suite import (
 )
 from sphinxcontrib.test_reports.environment import install_styles_static_files
 from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
+from sphinxcontrib.test_reports.fields import FIELDS, RENAMEABLE_FIELDS
 from sphinxcontrib.test_reports.functions import tr_link
 from sphinxcontrib.test_reports.projectconfig import (
     BRIDGE_KEYS,
@@ -43,32 +44,30 @@ from sphinxcontrib.test_reports.projectconfig import (
 
 VERSION = "1.4.0"
 
-# Field descriptions for better semantics
-FIELD_DESCRIPTIONS = {
-    "file": "Test file name",
-    "suite": "Test suite name",
-    "case": "Test case name",
-    "case_name": "Test case display name",
-    "case_parameter": "Test case parameter",
-    "classname": "Test class name",
-    "time": "Test execution time",
-    "suites": "Number of test suites",
-    "cases": "Number of test cases",
-    "passed": "Number of passed tests",
-    "skipped": "Number of skipped tests",
-    "failed": "Number of failed tests",
-    "errors": "Number of test errors",
-    "result": "Test result status",
-}
+
+def _declaration(name, role=None):
+    """The JSON type and description to register *name* with.
+
+    Both come from :mod:`sphinxcontrib.test_reports.fields`, the table the
+    converter also writes into the ``needs_schema`` of the ``needs.json`` it
+    produces, so the two declarations of a field cannot drift apart. A
+    renameable field is looked up by *role*, so its description survives the
+    rename. A name the table does not know -- a ``tr_extra_options`` entry --
+    is a string field described by its own name, as before.
+    """
+    if role is not None:
+        return RENAMEABLE_FIELDS[role]
+    return FIELDS.get(name, ("string", name))
+
 
 try:
     # sphinx-needs >= 7.0: fields are registered through add_field.
     from sphinx_needs.api import add_field as _add_field
 
-    def _register_field(app, name, schema=None):
-        description = FIELD_DESCRIPTIONS.get(name, name)
+    def _register_field(app, name, role=None):
+        type_, description = _declaration(name, role)
         try:
-            _add_field(name, description, schema=schema)
+            _add_field(name, description, schema={"type": type_})
         except NeedsApiConfigWarning:
             # Already registered, e.g. via needs_fields or needs_extra_options
             # in conf.py. Anything else is a real error and must surface.
@@ -79,12 +78,13 @@ try:
 except ImportError:
     from sphinx_needs.api import add_extra_option as _add_extra_option
 
-    def _register_field(app, name, schema=None):
+    def _register_field(app, name, role=None):
         # add_extra_option takes description and schema from sphinx-needs
         # 6.0.1 on, which is the package's floor.
+        type_, description = _declaration(name, role)
         try:
             _add_extra_option(
-                app, name, description=FIELD_DESCRIPTIONS.get(name, name), schema=schema
+                app, name, description=description, schema={"type": type_}
             )
         except NeedsApiConfigWarning:
             logging.getLogger(__name__).debug(
@@ -390,36 +390,21 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
 
     # sphinx-needs >= 6 registers fields with a schema; there is no older
     # branch to keep, the package requires that version.
-    _register_field(
-        app, getattr(config, "tr_file_option", "file"), schema={"type": "string"}
-    )
-    _register_field(
-        app,
-        getattr(config, "tr_source_file_option", "case_file"),
-        schema={"type": "string"},
-    )
-    _register_field(
-        app,
-        getattr(config, "tr_source_line_option", "case_line"),
-        schema={"type": "string"},
-    )
-    _register_field(app, "suite", schema={"type": "string"})
-    _register_field(app, "case", schema={"type": "string"})
-    _register_field(app, "case_name", schema={"type": "string"})
-    _register_field(app, "case_parameter", schema={"type": "string"})
-    _register_field(app, "classname", schema={"type": "string"})
-    _register_field(app, "time", schema={"type": "string"})
-    _register_field(app, "suites", schema={"type": "integer"})
-    _register_field(app, "cases", schema={"type": "integer"})
-    _register_field(app, "passed", schema={"type": "integer"})
-    _register_field(app, "skipped", schema={"type": "integer"})
-    _register_field(app, "failed", schema={"type": "integer"})
-    _register_field(app, "errors", schema={"type": "integer"})
-    _register_field(app, "result", schema={"type": "string"})
-    # Written by the converter only, so a needs.json it produced imports
-    # without sphinx-needs dropping them as unknown keys.
-    _register_field(app, "result_text", schema={"type": "string"})
-    _register_field(app, "remote_url", schema={"type": "string"})
+    #
+    # Type and description of every field come from the shared table in
+    # `fields`, which the converter writes into the `needs_schema` of the
+    # needs.json it produces -- a field registered here and the same field
+    # declared there cannot say different things. `result_text` and
+    # `remote_url` are written by the converter only, and registered here so
+    # that a needs.json it produced imports without sphinx-needs dropping them
+    # as unknown keys.
+    # The renameable fields are registered under the name their `tr_*` value
+    # selects -- spelled like the role with the prefix, as every bridged key is.
+    for role in RENAMEABLE_FIELDS:
+        name = getattr(config, f"tr_{role}", DEFAULT_FIELD_NAMES[role])
+        _register_field(app, name, role=role)
+    for name in FIELDS:
+        _register_field(app, name)
     # Extra dynamic functions
     # For details about usage read
     # https://sphinx-needs.readthedocs.io/en/latest/api.html#sphinx_needs.api.configuration.add_dynamic_function
@@ -429,7 +414,7 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
     # extracted from JUnit XML are accepted by sphinx-needs
     tr_extra_options = getattr(config, "tr_extra_options", [])
     for option_name in tr_extra_options:
-        _register_field(app, option_name, schema={"type": "string"})
+        _register_field(app, option_name)
 
     # Extra need types
     # For details about usage read

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -116,8 +116,7 @@ def setup(app: Sphinx) -> dict[str, object]:
     # hashing (type, title, content) -- the latter moves the ID when a test
     # starts failing differently. Off by default: enabling it changes IDs.
     # Required (not just recommended) when the build consumes a needs.json
-    # produced by `test-reports build needs`, which always writes
-    # deterministic IDs.
+    # produced by `test-reports build needs`, which always writes them.
     app.add_config_value("tr_deterministic_case_ids", False, "html")
     # Declarative configuration: the [test_reports] section of this file
     # overrides the tr_* config values above at config-inited. The default is

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -38,6 +38,7 @@ from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 from sphinxcontrib.test_reports.fields import (
     FIELDS,
     RENAMEABLE_FIELDS,
+    RESERVED_NAMES,
     declaration,
 )
 from sphinxcontrib.test_reports.functions import tr_link
@@ -359,11 +360,13 @@ def tr_preparation(app: Sphinx, *args: object) -> None:
 
 
 def check_field_name_collisions(config: Config) -> None:
-    """Reject configurations where two field options name the same need field.
+    """Reject configurations where a field option names a field already taken.
 
     The report path and the test-source location are separate fields; if two
-    options resolve to one name, ``add_need`` receives the same keyword twice
-    and fails with a bare ``TypeError`` from inside a directive.
+    options resolve to one name, or one of them to a fixed field such as
+    ``case`` or ``result``, ``add_need`` receives the same keyword twice and
+    fails with a bare ``TypeError`` from inside a directive. The loader makes
+    the same check for the declarative file; this covers ``conf.py``.
     """
     options = {
         "tr_file_option": getattr(config, "tr_file_option", "file"),
@@ -372,6 +375,11 @@ def check_field_name_collisions(config: Config) -> None:
     }
 
     for name, value in options.items():
+        if value in RESERVED_NAMES:
+            raise InvalidConfigurationError(
+                f"{name} is set to '{value}', a field every test-case need has "
+                f"already; it must name a field of its own."
+            )
         clashing = [
             other
             for other, other_value in options.items()

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -31,6 +31,7 @@ from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 from sphinxcontrib.test_reports.functions import tr_link
 from sphinxcontrib.test_reports.projectconfig import (
     BRIDGE_KEYS,
+    DEFAULT_FIELD_NAMES,
     DEFAULT_TOML_FILENAME,
     SECTION,
     TomlConfigError,
@@ -100,13 +101,17 @@ def setup(app: Sphinx) -> dict[str, object]:
     """
 
     # Name of the need field carrying the path of the XML *report*.
-    app.add_config_value("tr_file_option", "file", "html")
+    app.add_config_value("tr_file_option", DEFAULT_FIELD_NAMES["file_option"], "html")
     # Names of the need fields carrying the *test source* location taken from
     # the <testcase> file/line attributes. Defaults avoid the collision with
     # tr_file_option above; set both to "file"/"line" (and tr_file_option to
     # something else) to match a metamodel that spells them verbatim.
-    app.add_config_value("tr_source_file_option", "case_file", "html")
-    app.add_config_value("tr_source_line_option", "case_line", "html")
+    app.add_config_value(
+        "tr_source_file_option", DEFAULT_FIELD_NAMES["source_file_option"], "html"
+    )
+    app.add_config_value(
+        "tr_source_line_option", DEFAULT_FIELD_NAMES["source_line_option"], "html"
+    )
     # Derive test-case IDs from the source location and case name instead of
     # hashing (type, title, content) -- the latter moves the ID when a test
     # starts failing differently. Off by default: enabling it changes IDs.
@@ -412,6 +417,10 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
     _register_field(app, "failed", schema={"type": "integer"})
     _register_field(app, "errors", schema={"type": "integer"})
     _register_field(app, "result", schema={"type": "string"})
+    # Written by the converter only, so a needs.json it produced imports
+    # without sphinx-needs dropping them as unknown keys.
+    _register_field(app, "result_text", schema={"type": "string"})
+    _register_field(app, "remote_url", schema={"type": "string"})
     # Extra dynamic functions
     # For details about usage read
     # https://sphinx-needs.readthedocs.io/en/latest/api.html#sphinx_needs.api.configuration.add_dynamic_function

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -28,7 +28,11 @@ from sphinxcontrib.test_reports.directives.test_suite import (
 )
 from sphinxcontrib.test_reports.environment import install_styles_static_files
 from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
-from sphinxcontrib.test_reports.fields import FIELDS, RENAMEABLE_FIELDS
+from sphinxcontrib.test_reports.fields import (
+    FIELDS,
+    RENAMEABLE_FIELDS,
+    declaration,
+)
 from sphinxcontrib.test_reports.functions import tr_link
 from sphinxcontrib.test_reports.projectconfig import (
     BRIDGE_KEYS,
@@ -44,28 +48,12 @@ from sphinxcontrib.test_reports.projectconfig import (
 
 VERSION = "1.4.0"
 
-
-def _declaration(name, role=None):
-    """The JSON type and description to register *name* with.
-
-    Both come from :mod:`sphinxcontrib.test_reports.fields`, the table the
-    converter also writes into the ``needs_schema`` of the ``needs.json`` it
-    produces, so the two declarations of a field cannot drift apart. A
-    renameable field is looked up by *role*, so its description survives the
-    rename. A name the table does not know -- a ``tr_extra_options`` entry --
-    is a string field described by its own name, as before.
-    """
-    if role is not None:
-        return RENAMEABLE_FIELDS[role]
-    return FIELDS.get(name, ("string", name))
-
-
 try:
     # sphinx-needs >= 7.0: fields are registered through add_field.
     from sphinx_needs.api import add_field as _add_field
 
-    def _register_field(app, name, role=None):
-        type_, description = _declaration(name, role)
+    def _register_field(app: Sphinx, name: str, role: str | None = None) -> None:
+        type_, description = declaration(name, role)
         try:
             _add_field(name, description, schema={"type": type_})
         except NeedsApiConfigWarning:
@@ -78,10 +66,10 @@ try:
 except ImportError:
     from sphinx_needs.api import add_extra_option as _add_extra_option
 
-    def _register_field(app, name, role=None):
+    def _register_field(app: Sphinx, name: str, role: str | None = None) -> None:
         # add_extra_option takes description and schema from sphinx-needs
         # 6.0.1 on, which is the package's floor.
-        type_, description = _declaration(name, role)
+        type_, description = declaration(name, role)
         try:
             _add_extra_option(
                 app, name, description=description, schema={"type": type_}

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -33,7 +33,7 @@ def run_convert(tmp_path, arguments, toml=None, config_name=None, subdir=None):
     A project-root marker bounds the upward search, so the outcome never depends
     on what happens to sit above the temporary directory.
     """
-    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    (tmp_path / ".git").mkdir(exist_ok=True)  # bounds the upward search
     if toml is not None:
         _write(tmp_path, toml, name=config_name or DEFAULT_TOML_FILENAME)
     workdir = tmp_path

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -43,7 +43,7 @@ def run_convert(tmp_path, arguments, toml=None, config_name=None, subdir=None):
     previous = os.getcwd()
     os.chdir(workdir)
     try:
-        code = main(["convert", PYTEST_XML, "-o", "needs.json", *arguments])
+        code = main(["build", "needs", PYTEST_XML, "-o", "needs.json", *arguments])
     finally:
         os.chdir(previous)
     payload = {}
@@ -202,7 +202,16 @@ class TestFileLookup:
     def test_config_and_no_config_are_mutually_exclusive(self):
         with pytest.raises(SystemExit):
             main(
-                ["convert", PYTEST_XML, "-o", "n.json", "--no-config", "--config", "x"]
+                [
+                    "build",
+                    "needs",
+                    PYTEST_XML,
+                    "-o",
+                    "n.json",
+                    "--no-config",
+                    "--config",
+                    "x",
+                ]
             )
 
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -19,6 +19,7 @@ from sphinxcontrib.test_reports.projectconfig import (
 
 UTILS = Path(__file__).parent / "doc_test" / "utils"
 PYTEST_XML = str(UTILS / "pytest_data.xml")
+GTEST_XML = str(UTILS / "gtest_data.xml")  # carries <property> elements
 
 
 def _write(directory, toml_source, name=DEFAULT_TOML_FILENAME):
@@ -27,7 +28,9 @@ def _write(directory, toml_source, name=DEFAULT_TOML_FILENAME):
     return config
 
 
-def run_convert(tmp_path, arguments, toml=None, config_name=None, subdir=None):
+def run_convert(
+    tmp_path, arguments, toml=None, config_name=None, subdir=None, xml=PYTEST_XML
+):
     """Run ``build needs`` from *tmp_path* (or a subdirectory) and parse the output.
 
     A project-root marker bounds the upward search, so the outcome never depends
@@ -43,7 +46,7 @@ def run_convert(tmp_path, arguments, toml=None, config_name=None, subdir=None):
     previous = os.getcwd()
     os.chdir(workdir)
     try:
-        code = main(["build", "needs", PYTEST_XML, "-o", "needs.json", *arguments])
+        code = main(["build", "needs", xml, "-o", "needs.json", *arguments])
     finally:
         os.chdir(previous)
     payload = {}
@@ -217,7 +220,45 @@ class TestFileLookup:
 
 
 class TestVerbosity:
-    """A config-less run is quiet; ``-v`` makes a misplaced file diagnosable."""
+    """A config-less run is quiet, a discovered file is named, ``-v`` says more.
+
+    The file the search adopts may sit directories above the invocation and it
+    shapes the bytes written, so it is named on every run, as the build logs it
+    at INFO. ``-v`` adds where a fruitless search ended, so a misplaced file can
+    be placed right, and names a file given with ``--config``.
+    """
+
+    def test_a_discovered_file_is_named_without_verbose(self, tmp_path, capsys):
+        code, _ = run_convert(
+            tmp_path,
+            [],
+            toml='[test_reports.build.needs]\nproject = "p"\n',
+            subdir="build/testlogs",
+        )
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "reading [test_reports] from" in err
+        assert str(tmp_path / DEFAULT_TOML_FILENAME) in err
+
+    def test_an_explicit_config_file_is_named_only_with_verbose(self, tmp_path, capsys):
+        # The user typed the path; repeating it is noise unless asked for.
+        toml = '[test_reports.build.needs]\nproject = "p"\n'
+        code, _ = run_convert(
+            tmp_path,
+            ["--config", "staging.toml"],
+            toml=toml,
+            config_name="staging.toml",
+        )
+        assert code == 0
+        assert "reading [test_reports]" not in capsys.readouterr().err
+        code, _ = run_convert(
+            tmp_path,
+            ["--config", "staging.toml", "-v"],
+            toml=toml,
+            config_name="staging.toml",
+        )
+        assert code == 0
+        assert "reading [test_reports] from staging.toml" in capsys.readouterr().err
 
     def test_a_configless_run_is_quiet_by_default(self, tmp_path, capsys):
         # Nothing about the search on stderr -- other diagnostics (here the
@@ -377,6 +418,36 @@ class TestDiagnostics:
         assert code == 2
         assert "the default need_type is 'testcase'" in capsys.readouterr().err
 
+    def test_need_type_flag_without_a_case_entry_is_checked_against_the_default(
+        self, tmp_path, capsys
+    ):
+        # A side that is not set is compared at its default, as in the loader:
+        # a file that leaves case alone configures the build with 'testcase',
+        # so a flag asking for anything else writes needs the build drops.
+        code, payload = run_convert(
+            tmp_path, ["--need-type", "check"], toml="[test_reports]\n"
+        )
+        assert code == 2
+        assert payload == {}
+        message = capsys.readouterr().err
+        assert "--need-type is 'check'" in message
+        assert "does not set case" in message
+        assert "'testcase'" in message
+
+    def test_need_type_flag_without_a_config_file_is_free(self, tmp_path):
+        # Without a file there is nothing to hold the flag against; the output
+        # depends on the arguments alone, as with --no-config.
+        code, payload = run_convert(tmp_path, ["--need-type", "check"])
+        assert code == 0
+        assert _first_need(payload)["type"] == "check"
+        code, payload = run_convert(
+            tmp_path,
+            ["--no-config", "--need-type", "check"],
+            toml="[test_reports]\n",
+        )
+        assert code == 0
+        assert _first_need(payload)["type"] == "check"
+
     def test_a_matching_need_type_flag_is_fine(self, tmp_path):
         code, payload = run_convert(
             tmp_path,
@@ -393,6 +464,66 @@ class TestDiagnostics:
         )
         assert code == 0
         assert _first_need(payload)["type"] == "check"
+
+
+class TestExtraOptionFlag:
+    """The flag adds to the section's list; a name the list lacks is reported.
+
+    A repeatable flag reads as additive, so it is one -- ``--no-config`` is the
+    way to leave the file's list out. The build registers exactly the section's
+    ``extra_options`` as fields, so a field exported under any other name is
+    dropped by ``needimport`` as an unknown key -- the flag may stand in for a
+    build configured elsewhere, but the mismatch must not be silent.
+    """
+
+    def test_the_flag_adds_to_the_section_s_list(self, tmp_path):
+        code, payload = run_convert(
+            tmp_path,
+            ["--extra-option", "Requirement"],
+            toml='[test_reports]\nextra_options = ["TestType"]\n',
+            xml=GTEST_XML,
+        )
+        assert code == 0
+        needs = payload["versions"][payload["current_version"]]["needs"]
+        assert all(
+            "TestType" in need and "Requirement" in need for need in needs.values()
+        )
+        declared = payload["versions"][payload["current_version"]]["needs_schema"]
+        assert {"TestType", "Requirement"} <= set(declared["properties"])
+
+    def test_a_name_outside_the_section_s_list_warns(self, tmp_path, capsys):
+        code, payload = run_convert(
+            tmp_path,
+            ["--extra-option", "Requirement"],
+            toml='[test_reports]\nextra_options = ["TestType"]\n',
+            xml=GTEST_XML,
+        )
+        assert code == 0
+        needs = payload["versions"][payload["current_version"]]["needs"]
+        assert all("Requirement" in need for need in needs.values())
+        err = capsys.readouterr().err
+        assert "--extra-option Requirement" in err
+        assert "extra_options" in err and DEFAULT_TOML_FILENAME in err
+        assert "needimport" in err
+
+    def test_a_name_from_the_section_s_list_is_quiet(self, tmp_path, capsys):
+        code, _ = run_convert(
+            tmp_path,
+            ["--extra-option", "TestType"],
+            toml='[test_reports]\nextra_options = ["TestType", "Requirement"]\n',
+            xml=GTEST_XML,
+        )
+        assert code == 0
+        assert "--extra-option" not in capsys.readouterr().err
+
+    def test_without_a_config_file_there_is_nothing_to_compare_against(
+        self, tmp_path, capsys
+    ):
+        code, _ = run_convert(
+            tmp_path, ["--extra-option", "Requirement"], xml=GTEST_XML
+        )
+        assert code == 0
+        assert "--extra-option" not in capsys.readouterr().err
 
 
 def test_every_conversion_key_has_a_builtin_default():

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,4 +1,4 @@
-"""The convert CLI reads ``[test_reports.convert]`` from ``ubproject.toml``.
+"""``build needs`` reads ``[test_reports.build.needs]`` from ``ubproject.toml``.
 
 Precedence is flag > TOML table > built-in default, and the file is found the
 way the Sphinx build finds it -- searched for upwards to the project root -- so
@@ -28,7 +28,7 @@ def _write(directory, toml_source, name=DEFAULT_TOML_FILENAME):
 
 
 def run_convert(tmp_path, arguments, toml=None, config_name=None, subdir=None):
-    """Run ``convert`` from *tmp_path* (or a subdirectory) and parse the output.
+    """Run ``build needs`` from *tmp_path* (or a subdirectory) and parse the output.
 
     A project-root marker bounds the upward search, so the outcome never depends
     on what happens to sit above the temporary directory.
@@ -65,7 +65,7 @@ class TestPrecedence:
             tmp_path,
             [],
             toml="""
-            [test_reports.convert]
+            [test_reports.build.needs]
             project = "My Project"
             version = "2.0"
             tags = ["ci", "unit"]
@@ -83,7 +83,7 @@ class TestPrecedence:
         code, payload = run_convert(
             tmp_path,
             ["--version", "9.9"],
-            toml="[test_reports.convert]\nversion = '2.0'\n",
+            toml="[test_reports.build.needs]\nversion = '2.0'\n",
         )
         assert code == 0
         assert payload["current_version"] == "9.9"
@@ -94,7 +94,7 @@ class TestPrecedence:
         code, payload = run_convert(
             tmp_path,
             [],
-            toml="[test_reports.convert]\nneed_type = 'check'\n"
+            toml="[test_reports.build.needs]\nneed_type = 'check'\n"
             """
             [test_reports.case]
             directive = "test-case"
@@ -117,7 +117,7 @@ class TestPrecedence:
     def test_an_explicit_empty_flag_beats_the_table(self, tmp_path):
         # "" is a value, not "not given": the flag clears the file's tags.
         code, payload = run_convert(
-            tmp_path, ["--tags", ""], toml="[test_reports.convert]\ntags = ['x']\n"
+            tmp_path, ["--tags", ""], toml="[test_reports.build.needs]\ntags = ['x']\n"
         )
         assert code == 0
         assert _first_need(payload)["tags"] == []
@@ -126,7 +126,7 @@ class TestPrecedence:
         code, payload = run_convert(
             tmp_path,
             ["--link-property", "Verifies=verifies"],
-            toml='[test_reports.convert]\nlink_properties = { Other = "other_field" }\n',
+            toml='[test_reports.build.needs]\nlink_properties = { Other = "other_field" }\n',
         )
         assert code == 0
         need = _first_need(payload)
@@ -147,7 +147,7 @@ class TestPrecedence:
             source_line_option = "line"
             extra_options = ["more_info"]
 
-            [test_reports.convert]
+            [test_reports.build.needs]
             project = "p"
             """,
         )
@@ -169,7 +169,7 @@ class TestFileLookup:
         code, payload = run_convert(
             tmp_path,
             [],
-            toml='[test_reports.convert]\nproject = "from the root"\n',
+            toml='[test_reports.build.needs]\nproject = "from the root"\n',
             subdir="build/testlogs",
         )
         assert code == 0
@@ -179,7 +179,7 @@ class TestFileLookup:
         code, payload = run_convert(
             tmp_path,
             ["--config", "staging.toml"],
-            toml='[test_reports.convert]\nproject = "staged"\n',
+            toml='[test_reports.build.needs]\nproject = "staged"\n',
             config_name="staging.toml",
         )
         assert code == 0
@@ -194,7 +194,7 @@ class TestFileLookup:
         code, payload = run_convert(
             tmp_path,
             ["--no-config"],
-            toml='[test_reports.convert]\nproject = "from toml"\n',
+            toml='[test_reports.build.needs]\nproject = "from toml"\n',
         )
         assert code == 0
         assert payload["project"] == ""
@@ -239,7 +239,7 @@ class TestVerbosity:
 
     def test_verbose_names_the_file_used(self, tmp_path, capsys):
         code, _ = run_convert(
-            tmp_path, ["--verbose"], toml='[test_reports.convert]\nproject = "p"\n'
+            tmp_path, ["--verbose"], toml='[test_reports.build.needs]\nproject = "p"\n'
         )
         assert code == 0
         err = capsys.readouterr().err
@@ -252,10 +252,10 @@ class TestDiagnostics:
 
     def test_wrong_type_in_the_table_is_an_error(self, tmp_path, capsys):
         code, _ = run_convert(
-            tmp_path, [], toml="[test_reports.convert]\ntags = 'ci'\n"
+            tmp_path, [], toml="[test_reports.build.needs]\ntags = 'ci'\n"
         )
         assert code == 2
-        assert "convert.tags" in capsys.readouterr().err
+        assert "build.needs.tags" in capsys.readouterr().err
 
     def test_wrong_type_elsewhere_in_the_section_is_an_error_too(
         self, tmp_path, capsys
@@ -272,13 +272,13 @@ class TestDiagnostics:
         code, payload = run_convert(
             tmp_path,
             [],
-            toml='[test_reports.convert]\nproject = "p"\nno_such_key = 1\n',
+            toml='[test_reports.build.needs]\nproject = "p"\nno_such_key = 1\n',
         )
         assert code == 0
         assert payload["project"] == "p"
         err = capsys.readouterr().err
         assert "no_such_key" in err
-        assert "[test_reports.convert]" in err
+        assert "[test_reports.build.needs]" in err
 
     def test_half_remote_pair_from_the_table_names_the_table(self, tmp_path, capsys):
         # The value came from the file, so naming only the flags would point at
@@ -286,12 +286,12 @@ class TestDiagnostics:
         code, _ = run_convert(
             tmp_path,
             [],
-            toml='[test_reports.convert]\nremote_url = "https://gh.com/o/r"\n',
+            toml='[test_reports.build.needs]\nremote_url = "https://gh.com/o/r"\n',
         )
         assert code == 2
         message = capsys.readouterr().err
         assert "remote_url and --commit" in message
-        assert "[test_reports.convert]" in message
+        assert "[test_reports.build.needs]" in message
         assert DEFAULT_TOML_FILENAME in message
 
     def test_half_remote_pair_from_flags_names_the_flags(self, tmp_path, capsys):
@@ -299,7 +299,7 @@ class TestDiagnostics:
         assert code == 2
         message = capsys.readouterr().err
         assert "--remote-url and --commit" in message
-        assert "[test_reports.convert]" not in message
+        assert "[test_reports.build.needs]" not in message
 
     def test_need_type_disagreeing_with_the_case_type_is_an_error(
         self, tmp_path, capsys
@@ -310,7 +310,7 @@ class TestDiagnostics:
             tmp_path,
             [],
             toml="""
-            [test_reports.convert]
+            [test_reports.build.needs]
             need_type = "testcase"
 
             [test_reports.case]
@@ -329,7 +329,7 @@ class TestDiagnostics:
         code, _ = run_convert(
             tmp_path,
             [],
-            toml='[test_reports.convert]\nlink_properties = { Verifies = ["v"] }\n',
+            toml='[test_reports.build.needs]\nlink_properties = { Verifies = ["v"] }\n',
         )
         assert code == 2
         assert "link_properties" in capsys.readouterr().err

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -11,8 +11,11 @@ from pathlib import Path
 
 import pytest
 
-from sphinxcontrib.test_reports.cli import main
-from sphinxcontrib.test_reports.projectconfig import DEFAULT_TOML_FILENAME
+from sphinxcontrib.test_reports.cli import _DEFAULTS, main
+from sphinxcontrib.test_reports.projectconfig import (
+    CONVERSION_KEYS,
+    DEFAULT_TOML_FILENAME,
+)
 
 UTILS = Path(__file__).parent / "doc_test" / "utils"
 PYTEST_XML = str(UTILS / "pytest_data.xml")
@@ -269,3 +272,67 @@ class TestDiagnostics:
         )
         assert code == 2
         assert "link_properties" in capsys.readouterr().err
+
+    def test_need_type_flag_disagreeing_with_the_case_type_is_an_error(
+        self, tmp_path, capsys
+    ):
+        # The loader only sees the file. A flag is not in the file, so the
+        # merged value has to be checked again, or the flag bypasses the rule.
+        code, _ = run_convert(
+            tmp_path,
+            ["--need-type", "testcase"],
+            toml="""
+            [test_reports.case]
+            directive = "test-case"
+            type = "check"
+            name = "Check"
+            prefix = "CH_"
+            color = "#999999"
+            style = "rectangle"
+            """,
+        )
+        assert code == 2
+        message = capsys.readouterr().err
+        assert "--need-type is 'testcase'" in message
+        assert "'check'" in message
+
+    def test_the_default_need_type_disagreeing_with_the_case_type_is_an_error(
+        self, tmp_path, capsys
+    ):
+        code, _ = run_convert(
+            tmp_path,
+            [],
+            toml="""
+            [test_reports.case]
+            directive = "test-case"
+            type = "check"
+            name = "Check"
+            prefix = "CH_"
+            color = "#999999"
+            style = "rectangle"
+            """,
+        )
+        assert code == 2
+        assert "the default need_type is 'testcase'" in capsys.readouterr().err
+
+    def test_a_matching_need_type_flag_is_fine(self, tmp_path):
+        code, payload = run_convert(
+            tmp_path,
+            ["--need-type", "check"],
+            toml="""
+            [test_reports.case]
+            directive = "test-case"
+            type = "check"
+            name = "Check"
+            prefix = "CH_"
+            color = "#999999"
+            style = "rectangle"
+            """,
+        )
+        assert code == 0
+        assert _first_need(payload)["type"] == "check"
+
+
+def test_every_conversion_key_has_a_builtin_default():
+    # The import-time guard says the same; this keeps saying it under -O.
+    assert set(_DEFAULTS) == set(CONVERSION_KEYS)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -89,8 +89,21 @@ class TestPrecedence:
         assert payload["current_version"] == "9.9"
 
     def test_table_overrides_the_builtin_default(self, tmp_path):
+        # A need type other than the default has to be the build's too -- so
+        # the file also names it as the case type.
         code, payload = run_convert(
-            tmp_path, [], toml="[test_reports.convert]\nneed_type = 'check'\n"
+            tmp_path,
+            [],
+            toml="[test_reports.convert]\nneed_type = 'check'\n"
+            """
+            [test_reports.case]
+            directive = "test-case"
+            type = "check"
+            name = "Check"
+            prefix = "CH_"
+            color = "#999999"
+            style = "rectangle"
+            """,
         )
         assert code == 0
         assert _first_need(payload)["type"] == "check"
@@ -120,15 +133,18 @@ class TestPrecedence:
         assert "verifies" in need
         assert "other_field" not in need
 
-    def test_sphinx_side_keys_do_not_leak_into_the_conversion(self, tmp_path):
-        # The same file configures the build. Its bridge keys are none of the
-        # converter's business and must not alter the output.
+    def test_field_names_from_the_section_shape_the_output(self, tmp_path):
+        # The same file configures the build. Its field-name keys are read on
+        # purpose -- the output has to have the shape of the build's needs --
+        # while its other bridge keys are none of the converter's business.
         code, payload = run_convert(
             tmp_path,
             [],
             toml="""
             [test_reports]
             file_option = "report_file"
+            source_file_option = "file"
+            source_line_option = "line"
             extra_options = ["more_info"]
 
             [test_reports.convert]
@@ -137,7 +153,11 @@ class TestPrecedence:
         )
         assert code == 0
         assert payload["project"] == "p"
-        assert "report_file" not in _first_need(payload)
+        need = _first_need(payload)
+        assert need["report_file"].endswith("pytest_data.xml")
+        assert "file" in need and "line" in need
+        assert "case_file" not in need
+        assert "more_info" not in need
 
 
 class TestFileLookup:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -157,7 +157,8 @@ class TestPrecedence:
         assert need["report_file"].endswith("pytest_data.xml")
         assert "file" in need and "line" in need
         assert "case_file" not in need
-        assert "more_info" not in need
+        # Listed, so the field is there -- null, as no case carries it.
+        assert need["more_info"] is None
 
 
 class TestFileLookup:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -215,6 +215,38 @@ class TestFileLookup:
             )
 
 
+class TestVerbosity:
+    """A config-less run is quiet; ``-v`` makes a misplaced file diagnosable."""
+
+    def test_a_configless_run_is_quiet_by_default(self, tmp_path, capsys):
+        # Nothing about the search on stderr -- other diagnostics (here the
+        # fixture's missing source lines) are not what is under test.
+        code, _ = run_convert(tmp_path, [])
+        assert code == 0
+        err = capsys.readouterr().err
+        assert DEFAULT_TOML_FILENAME not in err
+        assert "repository root" not in err
+
+    def test_verbose_reports_where_the_search_ended(self, tmp_path, capsys):
+        # The same message the loader gives the Sphinx bridge at -v: the
+        # directory whose marker ended the search, so a misplaced file can be
+        # placed right.
+        code, _ = run_convert(tmp_path, ["-v"], subdir="build/testlogs")
+        assert code == 0
+        err = capsys.readouterr().err
+        assert f"no {DEFAULT_TOML_FILENAME} in" in err
+        assert "repository root" in err and str(tmp_path) in err
+
+    def test_verbose_names_the_file_used(self, tmp_path, capsys):
+        code, _ = run_convert(
+            tmp_path, ["--verbose"], toml='[test_reports.convert]\nproject = "p"\n'
+        )
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "reading [test_reports] from" in err
+        assert DEFAULT_TOML_FILENAME in err
+
+
 class TestDiagnostics:
     """Errors name what the user wrote, and warnings do not stop the run."""
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,271 @@
+"""The convert CLI reads ``[test_reports.convert]`` from ``ubproject.toml``.
+
+Precedence is flag > TOML table > built-in default, and the file is found the
+way the Sphinx build finds it -- searched for upwards to the project root -- so
+the two consumers of one project never read different descriptions of it.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from sphinxcontrib.test_reports.cli import main
+from sphinxcontrib.test_reports.projectconfig import DEFAULT_TOML_FILENAME
+
+UTILS = Path(__file__).parent / "doc_test" / "utils"
+PYTEST_XML = str(UTILS / "pytest_data.xml")
+
+
+def _write(directory, toml_source, name=DEFAULT_TOML_FILENAME):
+    config = directory / name
+    config.write_text(toml_source, encoding="utf-8")
+    return config
+
+
+def run_convert(tmp_path, arguments, toml=None, config_name=None, subdir=None):
+    """Run ``convert`` from *tmp_path* (or a subdirectory) and parse the output.
+
+    A project-root marker bounds the upward search, so the outcome never depends
+    on what happens to sit above the temporary directory.
+    """
+    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    if toml is not None:
+        _write(tmp_path, toml, name=config_name or DEFAULT_TOML_FILENAME)
+    workdir = tmp_path
+    if subdir is not None:
+        workdir = tmp_path / subdir
+        workdir.mkdir(parents=True, exist_ok=True)
+    previous = os.getcwd()
+    os.chdir(workdir)
+    try:
+        code = main(["convert", PYTEST_XML, "-o", "needs.json", *arguments])
+    finally:
+        os.chdir(previous)
+    payload = {}
+    output = workdir / "needs.json"
+    if output.is_file():
+        payload = json.loads(output.read_text(encoding="utf-8"))
+    return code, payload
+
+
+def _first_need(payload):
+    return next(iter(payload["versions"][payload["current_version"]]["needs"].values()))
+
+
+class TestPrecedence:
+    """Flag > TOML > built-in default."""
+
+    def test_table_provides_the_conversion_settings(self, tmp_path):
+        code, payload = run_convert(
+            tmp_path,
+            [],
+            toml="""
+            [test_reports.convert]
+            project = "My Project"
+            version = "2.0"
+            tags = ["ci", "unit"]
+            link_properties = { PartiallyVerifies = "partially_verifies" }
+            """,
+        )
+        assert code == 0
+        assert payload["project"] == "My Project"
+        assert payload["current_version"] == "2.0"
+        need = _first_need(payload)
+        assert need["tags"] == ["ci", "unit"]
+        assert need["partially_verifies"] == []
+
+    def test_flag_overrides_the_table(self, tmp_path):
+        code, payload = run_convert(
+            tmp_path,
+            ["--version", "9.9"],
+            toml="[test_reports.convert]\nversion = '2.0'\n",
+        )
+        assert code == 0
+        assert payload["current_version"] == "9.9"
+
+    def test_table_overrides_the_builtin_default(self, tmp_path):
+        code, payload = run_convert(
+            tmp_path, [], toml="[test_reports.convert]\nneed_type = 'check'\n"
+        )
+        assert code == 0
+        assert _first_need(payload)["type"] == "check"
+
+    def test_no_file_uses_the_defaults(self, tmp_path):
+        code, payload = run_convert(tmp_path, [])
+        assert code == 0
+        assert payload["project"] == ""
+        assert payload["current_version"] == "1.0"
+
+    def test_an_explicit_empty_flag_beats_the_table(self, tmp_path):
+        # "" is a value, not "not given": the flag clears the file's tags.
+        code, payload = run_convert(
+            tmp_path, ["--tags", ""], toml="[test_reports.convert]\ntags = ['x']\n"
+        )
+        assert code == 0
+        assert _first_need(payload)["tags"] == []
+
+    def test_link_property_flag_replaces_the_table(self, tmp_path):
+        code, payload = run_convert(
+            tmp_path,
+            ["--link-property", "Verifies=verifies"],
+            toml='[test_reports.convert]\nlink_properties = { Other = "other_field" }\n',
+        )
+        assert code == 0
+        need = _first_need(payload)
+        assert "verifies" in need
+        assert "other_field" not in need
+
+    def test_sphinx_side_keys_do_not_leak_into_the_conversion(self, tmp_path):
+        # The same file configures the build. Its bridge keys are none of the
+        # converter's business and must not alter the output.
+        code, payload = run_convert(
+            tmp_path,
+            [],
+            toml="""
+            [test_reports]
+            file_option = "report_file"
+            extra_options = ["more_info"]
+
+            [test_reports.convert]
+            project = "p"
+            """,
+        )
+        assert code == 0
+        assert payload["project"] == "p"
+        assert "report_file" not in _first_need(payload)
+
+
+class TestFileLookup:
+    """Where the file comes from, and what happens when it does not."""
+
+    def test_walks_up_to_the_project_root(self, tmp_path):
+        # The canonical layout: ubproject.toml at the root, the converter run
+        # from a build directory below it.
+        code, payload = run_convert(
+            tmp_path,
+            [],
+            toml='[test_reports.convert]\nproject = "from the root"\n',
+            subdir="build/testlogs",
+        )
+        assert code == 0
+        assert payload["project"] == "from the root"
+
+    def test_explicit_config_by_path(self, tmp_path):
+        code, payload = run_convert(
+            tmp_path,
+            ["--config", "staging.toml"],
+            toml='[test_reports.convert]\nproject = "staged"\n',
+            config_name="staging.toml",
+        )
+        assert code == 0
+        assert payload["project"] == "staged"
+
+    def test_explicit_missing_config_is_an_error(self, tmp_path, capsys):
+        code, _ = run_convert(tmp_path, ["--config", "other.toml"])
+        assert code == 2
+        assert "other.toml" in capsys.readouterr().err
+
+    def test_no_config_ignores_the_file(self, tmp_path):
+        code, payload = run_convert(
+            tmp_path,
+            ["--no-config"],
+            toml='[test_reports.convert]\nproject = "from toml"\n',
+        )
+        assert code == 0
+        assert payload["project"] == ""
+
+    def test_config_and_no_config_are_mutually_exclusive(self):
+        with pytest.raises(SystemExit):
+            main(
+                ["convert", PYTEST_XML, "-o", "n.json", "--no-config", "--config", "x"]
+            )
+
+
+class TestDiagnostics:
+    """Errors name what the user wrote, and warnings do not stop the run."""
+
+    def test_wrong_type_in_the_table_is_an_error(self, tmp_path, capsys):
+        code, _ = run_convert(
+            tmp_path, [], toml="[test_reports.convert]\ntags = 'ci'\n"
+        )
+        assert code == 2
+        assert "convert.tags" in capsys.readouterr().err
+
+    def test_wrong_type_elsewhere_in_the_section_is_an_error_too(
+        self, tmp_path, capsys
+    ):
+        # One file, one verdict: the converter rejects what the build rejects,
+        # even for a key it does not itself use.
+        code, _ = run_convert(
+            tmp_path, [], toml="[test_reports]\nsuite_id_length = 'four'\n"
+        )
+        assert code == 2
+        assert "suite_id_length" in capsys.readouterr().err
+
+    def test_unknown_key_in_the_table_warns_but_converts(self, tmp_path, capsys):
+        code, payload = run_convert(
+            tmp_path,
+            [],
+            toml='[test_reports.convert]\nproject = "p"\nno_such_key = 1\n',
+        )
+        assert code == 0
+        assert payload["project"] == "p"
+        err = capsys.readouterr().err
+        assert "no_such_key" in err
+        assert "[test_reports.convert]" in err
+
+    def test_half_remote_pair_from_the_table_names_the_table(self, tmp_path, capsys):
+        # The value came from the file, so naming only the flags would point at
+        # options that appear nowhere in the invocation.
+        code, _ = run_convert(
+            tmp_path,
+            [],
+            toml='[test_reports.convert]\nremote_url = "https://gh.com/o/r"\n',
+        )
+        assert code == 2
+        message = capsys.readouterr().err
+        assert "remote_url and --commit" in message
+        assert "[test_reports.convert]" in message
+        assert DEFAULT_TOML_FILENAME in message
+
+    def test_half_remote_pair_from_flags_names_the_flags(self, tmp_path, capsys):
+        code, _ = run_convert(tmp_path, ["--commit", "abc"])
+        assert code == 2
+        message = capsys.readouterr().err
+        assert "--remote-url and --commit" in message
+        assert "[test_reports.convert]" not in message
+
+    def test_need_type_disagreeing_with_the_case_type_is_an_error(
+        self, tmp_path, capsys
+    ):
+        # The build takes its need type from case.type; a needs.json written
+        # with another type would neither register nor cross-link there.
+        code, _ = run_convert(
+            tmp_path,
+            [],
+            toml="""
+            [test_reports.convert]
+            need_type = "testcase"
+
+            [test_reports.case]
+            directive = "test-case"
+            type = "check"
+            name = "Check"
+            prefix = "CH_"
+            color = "#999999"
+            style = "rectangle"
+            """,
+        )
+        assert code == 2
+        assert "need_type" in capsys.readouterr().err
+
+    def test_malformed_link_property_value_is_an_error(self, tmp_path, capsys):
+        code, _ = run_convert(
+            tmp_path,
+            [],
+            toml='[test_reports.convert]\nlink_properties = { Verifies = ["v"] }\n',
+        )
+        assert code == 2
+        assert "link_properties" in capsys.readouterr().err

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -1,0 +1,400 @@
+"""Tests for the Sphinx-free ``test-reports convert`` CLI (TR-A).
+
+This is the keystone of the build-system story: a test-XML to needs.json
+conversion that runs as a build action *outside* Sphinx, so the docs build only
+imports the result. Two properties are load-bearing and therefore tested
+explicitly rather than assumed:
+
+* the CLI must not import Sphinx -- otherwise a Bazel action pulls the whole
+  documentation toolchain into the test-result conversion;
+* the output must be byte-stable, because it is a cached build artifact and
+  qualification evidence.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+UTILS = Path(__file__).parent / "doc_test" / "utils"
+GTEST_XML = UTILS / "gtest_data.xml"
+PYTEST_XML = UTILS / "pytest_data.xml"
+
+
+def _convert(tmp_path, *args, xml=GTEST_XML):
+    """Run the converter and return (exit_code, parsed output or None)."""
+    from sphinxcontrib.test_reports.cli import main
+
+    output = tmp_path / "needs.json"
+    code = main(["convert", str(xml), "--output", str(output), *args])
+    data = json.loads(output.read_text(encoding="utf-8")) if output.exists() else None
+    return code, data
+
+
+def _needs(data):
+    version = data["current_version"]
+    return data["versions"][version]["needs"]
+
+
+class TestNoSphinxImport:
+    """The converter has to be usable without the documentation toolchain."""
+
+    def test_importing_the_cli_does_not_import_sphinx(self):
+        script = (
+            "import sys;"
+            "import sphinxcontrib.test_reports.cli;"
+            "leaked = sorted(m for m in sys.modules"
+            " if m == 'sphinx' or m.startswith(('sphinx.', 'sphinx_needs')));"
+            "print(','.join(leaked))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        assert result.stdout.strip() == ""
+
+
+class TestEnvelope:
+    def test_output_passes_the_sphinx_needs_schema(self, tmp_path):
+        """The output must validate against sphinx-needs' own needs.json schema."""
+        needsfile = pytest.importorskip("sphinx_needs.needsfile")
+        if not hasattr(needsfile, "check_needs_data"):
+            # Older sphinx-needs releases do not ship the schema check; the
+            # envelope contract itself is version-independent, so skip rather
+            # than pin the whole suite to the newest sphinx-needs.
+            pytest.skip("sphinx-needs has no check_needs_data")
+
+        code, data = _convert(tmp_path)
+
+        assert code == 0
+        assert needsfile.check_needs_data(data).schema == []
+
+    def test_envelope_carries_project_and_current_version(self, tmp_path):
+        _, data = _convert(tmp_path, "--project", "Score Docs-as-Code")
+
+        assert data["project"] == "Score Docs-as-Code"
+        assert data["current_version"] in data["versions"]
+
+    def test_needs_amount_matches_the_number_of_cases(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        version = data["versions"][data["current_version"]]
+        assert version["needs_amount"] == len(version["needs"]) == 5
+
+    def test_no_timestamp_is_written(self, tmp_path):
+        """A wall clock would defeat action caching and evidence diffs."""
+        _, data = _convert(tmp_path)
+
+        assert "created" not in data
+        assert "created" not in data["versions"][data["current_version"]]
+
+    def test_output_is_byte_stable_across_runs(self, tmp_path):
+        from sphinxcontrib.test_reports.cli import main
+
+        first = tmp_path / "first.json"
+        second = tmp_path / "second.json"
+        for output in (first, second):
+            assert main(["convert", str(GTEST_XML), "--output", str(output)]) == 0
+
+        assert first.read_bytes() == second.read_bytes()
+
+
+class TestNeedContent:
+    def test_ids_match_the_deterministic_scheme(self, tmp_path):
+        from sphinxcontrib.test_reports.identity import deterministic_case_id
+
+        _, data = _convert(tmp_path)
+
+        expected = deterministic_case_id(
+            classname="MathTest", name="Addition", file="src/math_test.cc"
+        )
+        assert expected in _needs(data)
+
+    def test_source_location_is_emitted_verbatim(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["file"] == "src/math_test.cc"
+        assert need["line"] == "12"
+
+    def test_type_and_title_are_score_shaped(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["type"] == "testcase"
+        assert need["title"] == "MathTest__Addition"
+
+    def test_result_vocabulary_includes_disabled(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__DISABLED_Division_jnyzp"]
+        assert need["result"] == "disabled"
+
+    def test_content_keeps_every_failure_part(self, tmp_path):
+        """R2: the debug output has to survive the conversion."""
+        _, data = _convert(tmp_path)
+
+        content = _needs(data)["testcase__MathTest__Subtraction_srmht"]["content"]
+        assert "Expected equality of these values" in content
+        assert "Actual: false" in content
+        assert "overflow guard hit" in content
+
+    def test_result_text_is_the_first_failure_message(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Subtraction_srmht"]
+        assert need["result_text"].startswith("src/math_test.cc:22")
+        assert "\n" not in need["result_text"]
+
+    def test_properties_become_fields(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["TestType"] == "requirements-based"
+
+    def test_tags_are_configurable(self, tmp_path):
+        _, data = _convert(tmp_path, "--tags", "TEST")
+
+        assert _needs(data)["testcase__MathTest__Addition_hcuyy"]["tags"] == ["TEST"]
+
+
+class TestLinkProperties:
+    def test_a_property_can_be_promoted_to_a_link_field(self, tmp_path):
+        _, data = _convert(
+            tmp_path, "--link-property", "PartiallyVerifies=partially_verifies"
+        )
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["partially_verifies"] == ["REQ_1", "REQ_2"]
+        assert "PartiallyVerifies" not in need
+
+    def test_link_fields_are_always_present_even_when_empty(self, tmp_path):
+        """A converter must emit its fields unconditionally, so schemas can require them."""
+        _, data = _convert(
+            tmp_path, "--link-property", "PartiallyVerifies=partially_verifies"
+        )
+
+        need = _needs(data)["testcase__MathTest__DISABLED_Division_jnyzp"]
+        assert need["partially_verifies"] == []
+
+    def test_malformed_link_property_is_rejected(self, tmp_path):
+        from sphinxcontrib.test_reports.cli import main
+
+        code = main(
+            [
+                "convert",
+                str(GTEST_XML),
+                "--output",
+                str(tmp_path / "out.json"),
+                "--link-property",
+                "NoEqualsSign",
+            ]
+        )
+
+        assert code != 0
+
+
+class TestRemoteUrls:
+    def test_external_url_and_remote_url_are_synthesized(self, tmp_path):
+        _, data = _convert(
+            tmp_path,
+            "--remote-url",
+            "https://github.com/org/repo",
+            "--commit",
+            "abc123",
+        )
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        expected = "https://github.com/org/repo/blob/abc123/src/math_test.cc#L12"
+        assert need["external_url"] == expected
+        assert need["remote_url"] == expected
+
+    def test_scp_style_remote_is_normalised(self, tmp_path):
+        _, data = _convert(
+            tmp_path,
+            "--remote-url",
+            "git@github.com:org/repo.git",
+            "--commit",
+            "abc123",
+        )
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["remote_url"].startswith("https://github.com/org/repo/blob/abc123/")
+
+    def test_url_pattern_is_configurable(self, tmp_path):
+        _, data = _convert(
+            tmp_path,
+            "--remote-url",
+            "https://gitlab.com/org/repo",
+            "--commit",
+            "abc123",
+            "--url-pattern",
+            "{base}/-/blob/{commit}/{file}#L{line}",
+        )
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["remote_url"] == (
+            "https://gitlab.com/org/repo/-/blob/abc123/src/math_test.cc#L12"
+        )
+
+    def test_without_repo_metadata_the_url_fields_are_empty(self, tmp_path):
+        """A hermetic sandbox has no git remote; that must not drop the need."""
+        _, data = _convert(tmp_path)
+
+        need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
+        assert need["remote_url"] == ""
+        assert need["external_url"] == ""
+
+
+class TestMultipleInputs:
+    def test_several_reports_are_merged_into_one_file(self, tmp_path):
+        from sphinxcontrib.test_reports.cli import main
+
+        output = tmp_path / "needs.json"
+        code = main(
+            ["convert", str(GTEST_XML), str(PYTEST_XML), "--output", str(output)]
+        )
+        data = json.loads(output.read_text(encoding="utf-8"))
+
+        assert code == 0
+        assert len(_needs(data)) > 5
+
+    def test_a_missing_input_file_exits_nonzero(self, tmp_path):
+        from sphinxcontrib.test_reports.cli import main
+
+        code = main(
+            [
+                "convert",
+                str(tmp_path / "nope.xml"),
+                "--output",
+                str(tmp_path / "out.json"),
+            ]
+        )
+
+        assert code != 0
+
+
+class TestDiagnostics:
+    def test_absent_line_attributes_warn_about_junit_family(self, tmp_path, capsys):
+        """pytest's default junit_family drops file/line; say so, don't guess."""
+        from sphinxcontrib.test_reports.cli import main
+
+        main(
+            [
+                "convert",
+                str(PYTEST_XML),
+                "--output",
+                str(tmp_path / "out.json"),
+            ]
+        )
+
+        assert "junit_family" in capsys.readouterr().err
+
+    def test_reports_with_line_attributes_do_not_warn(self, tmp_path, capsys):
+        from sphinxcontrib.test_reports.cli import main
+
+        main(["convert", str(GTEST_XML), "--output", str(tmp_path / "out.json")])
+
+        assert "junit_family" not in capsys.readouterr().err
+
+
+def test_the_cli_is_runnable_as_a_module():
+    result = subprocess.run(
+        [sys.executable, "-m", "sphinxcontrib.test_reports.cli", "convert", "--help"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "--output" in result.stdout
+
+
+def test_console_script_is_installed():
+    """The name that goes into a BUILD file has to be a real entry point."""
+    script = Path(sys.executable).parent / "test-reports"
+    if not script.exists():
+        pytest.skip("package not installed into this environment")
+
+    result = subprocess.run(
+        [str(script), "convert", "--help"], capture_output=True, text=True
+    )
+
+    assert result.returncode == 0
+    assert "--output" in result.stdout
+
+
+@pytest.mark.parametrize("flag", ["--remote-url", "--commit"])
+def test_url_synthesis_needs_both_parts(tmp_path, flag):
+    """Half the metadata cannot produce a URL; fail loudly instead of guessing."""
+    from sphinxcontrib.test_reports.cli import main
+
+    code = main(
+        [
+            "convert",
+            str(GTEST_XML),
+            "--output",
+            str(tmp_path / "out.json"),
+            flag,
+            "value",
+        ]
+    )
+
+    assert code != 0
+
+
+class TestResultVocabulary:
+    """The export uses the migration-target vocabulary, not the parser's.
+
+    The parser reports ``failure`` and must keep doing so -- it is a documented
+    need field value and a CSS class (``tr_failure``). The exported needs.json
+    is a new surface with no such obligation, and its consumers' metamodels
+    (S-CORE's included) spell it ``failed``.
+    """
+
+    def test_failure_is_exported_as_failed(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        assert (
+            _needs(data)["testcase__MathTest__Subtraction_srmht"]["result"] == "failed"
+        )
+
+    @pytest.mark.parametrize(
+        ("need_id", "expected"),
+        [
+            ("testcase__MathTest__Addition_hcuyy", "passed"),
+            ("testcase__MathTest__DISABLED_Division_jnyzp", "disabled"),
+            ("testcase__ParamTest_0__Legacy_owuvz", "skipped"),
+        ],
+    )
+    def test_other_results_are_unchanged(self, tmp_path, need_id, expected):
+        _, data = _convert(tmp_path)
+
+        assert _needs(data)[need_id]["result"] == expected
+
+
+class TestContentIsNotDuplicated:
+    """googletest repeats the failure text in the message attribute.
+
+    Emitting both verbatim shows the same stack trace twice in the rendered
+    need; the message block is only worth its space when it says something the
+    body does not.
+    """
+
+    def test_a_message_contained_in_the_body_is_not_repeated(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        content = _needs(data)["testcase__MathTest__Subtraction_srmht"]["content"]
+        assert content.count("Expected equality of these values") == 1
+        assert "message" not in content
+
+    def test_a_message_absent_from_the_body_is_kept(self, tmp_path):
+        _, data = _convert(tmp_path)
+
+        content = _needs(data)["testcase__ParamTest_0__Legacy_owuvz"]["content"]
+        assert "Skipped via GTEST_SKIP" in content
+        assert "not applicable on this platform" in content

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -489,6 +489,27 @@ class TestDiagnostics:
 
         assert "junit_family" not in capsys.readouterr().err
 
+    def test_a_report_without_test_cases_warns(self, tmp_path, capsys):
+        # A pom.xml parses as one empty suite: a valid, empty needs.json with
+        # exit 0 is the one outcome a cached build action must never get
+        # silently.
+        pom = tmp_path / "pom.xml"
+        pom.write_text(
+            "<project><modelVersion>4.0.0</modelVersion></project>\n", encoding="utf-8"
+        )
+        code, data = _convert(tmp_path, "--no-config", xml=pom)
+        assert code == 0
+        assert data["versions"][data["current_version"]]["needs_amount"] == 0
+        message = capsys.readouterr().err
+        assert "pom.xml" in message and "no test cases" in message
+
+    def test_a_report_with_test_cases_does_not_get_the_empty_warning(
+        self, tmp_path, capsys
+    ):
+        code, _ = _convert(tmp_path, "--no-config")
+        assert code == 0
+        assert "no test cases" not in capsys.readouterr().err
+
 
 def test_the_cli_is_runnable_as_a_module():
     result = subprocess.run(

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -274,6 +274,34 @@ class TestRemoteUrls:
             "https://gitlab.com/org/repo/-/blob/abc123/src/math_test.cc#L12"
         )
 
+    def test_credentials_in_the_remote_url_are_not_written(self, tmp_path):
+        # GitLab's CI_REPOSITORY_URL embeds the job token; the base lands in
+        # every need of a cached artifact and, imported, in published HTML.
+        from sphinxcontrib.test_reports.cli import main
+
+        output = tmp_path / "needs.json"
+        code = main(
+            [
+                "build",
+                "needs",
+                str(GTEST_XML),
+                "--output",
+                str(output),
+                "--no-config",
+                "--remote-url",
+                "https://gitlab-ci-token:glcbt-secret@gitlab.example.com/org/repo.git",
+                "--commit",
+                "abc123",
+            ]
+        )
+        assert code == 0
+        text = output.read_text(encoding="utf-8")
+        assert "glcbt-secret" not in text and "gitlab-ci-token" not in text
+        need = _needs(json.loads(text))["testcase__MathTest__Addition_hcuyy"]
+        assert need["remote_url"] == (
+            "https://gitlab.example.com/org/repo/blob/abc123/src/math_test.cc#L12"
+        )
+
     def test_without_repo_metadata_the_url_fields_are_empty(self, tmp_path):
         """A hermetic sandbox has no git remote; that must not drop the need."""
         _, data = _convert(tmp_path)
@@ -309,6 +337,40 @@ class TestUrlPatternErrors:
         )
         assert code == 2
         assert "malformed" in capsys.readouterr().err
+
+    def test_an_attribute_lookup_is_an_error_not_a_traceback(self, tmp_path, capsys):
+        # str.format resolves {base.__class__}; only KeyError was caught.
+        code, data = _convert(
+            tmp_path,
+            "--no-config",
+            "--remote-url",
+            "https://github.com/o/r",
+            "--commit",
+            "abc",
+            "--url-pattern",
+            "{base.__class__}/{file}",
+        )
+        assert code == 2
+        assert data is None
+        message = capsys.readouterr().err
+        assert "unknown placeholder {base.__class__}" in message
+        assert "Traceback" not in message
+
+    def test_the_pattern_is_checked_before_any_report_is_read(self, tmp_path, capsys):
+        # A missing report and a bad pattern: the pattern error wins, because
+        # the template is checked before the first file is opened.
+        code, data = _convert(
+            tmp_path,
+            "--no-config",
+            "--url-pattern",
+            "{base}/blob/{ref}/{file}",
+            xml=tmp_path / "does-not-exist.xml",
+        )
+        assert code == 2
+        assert data is None
+        message = capsys.readouterr().err
+        assert "{ref}" in message
+        assert "no such file" not in message
 
 
 class TestMultipleInputs:

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -119,8 +119,10 @@ class TestNeedContent:
         _, data = _convert(tmp_path)
 
         need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
-        assert need["file"] == "src/math_test.cc"
-        assert need["line"] == "12"
+        assert need["case_file"] == "src/math_test.cc"
+        assert need["case_line"] == "12"
+        # `file` is the report path, as in a locally created test-case need.
+        assert need["file"] == str(GTEST_XML)
 
     def test_type_and_title_are_score_shaped(self, tmp_path):
         _, data = _convert(tmp_path)
@@ -151,11 +153,25 @@ class TestNeedContent:
         assert need["result_text"].startswith("src/math_test.cc:22")
         assert "\n" not in need["result_text"]
 
-    def test_properties_become_fields(self, tmp_path):
-        _, data = _convert(tmp_path)
-
+    def test_named_properties_become_fields(self, tmp_path, capsys):
+        # Only properties the build would accept (extra_options, or here the
+        # flag standing in for it) become fields; the rest is reported once.
+        code, data = _convert(tmp_path, "--no-config", "--extra-option", "TestType")
+        assert code == 0
         need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
         assert need["TestType"] == "requirements-based"
+        assert "PartiallyVerifies" not in need
+        message = capsys.readouterr().err
+        assert "properties not exported" in message
+        assert "PartiallyVerifies" in message
+        assert "extra_options" in message
+
+    def test_unnamed_properties_are_left_out_quietly_when_none_exist(
+        self, tmp_path, capsys
+    ):
+        code, _ = _convert(tmp_path, "--no-config", xml=PYTEST_XML)
+        assert code == 0
+        assert "properties not exported" not in capsys.readouterr().err
 
     def test_tags_are_configurable(self, tmp_path):
         _, data = _convert(tmp_path, "--tags", "TEST")
@@ -251,6 +267,34 @@ class TestRemoteUrls:
         assert need["external_url"] == ""
 
 
+class TestUrlPatternErrors:
+    """A bad template is a configuration error at the start, not a traceback."""
+
+    def test_an_unknown_placeholder_is_an_error(self, tmp_path, capsys):
+        code, data = _convert(
+            tmp_path,
+            "--no-config",
+            "--remote-url",
+            "https://github.com/o/r",
+            "--commit",
+            "abc",
+            "--url-pattern",
+            "{base}/blob/{ref}/{file}#L{line}",
+        )
+        assert code == 2
+        assert data is None
+        message = capsys.readouterr().err
+        assert "--url-pattern" in message
+        assert "{ref}" in message
+
+    def test_an_unbalanced_brace_is_an_error(self, tmp_path, capsys):
+        code, _ = _convert(
+            tmp_path, "--no-config", "--url-pattern", "{base/blob/{commit}/{file}"
+        )
+        assert code == 2
+        assert "malformed" in capsys.readouterr().err
+
+
 class TestMultipleInputs:
     def test_several_reports_are_merged_into_one_file(self, tmp_path):
         from sphinxcontrib.test_reports.cli import main
@@ -315,6 +359,17 @@ class TestDiagnostics:
             ]
         )
 
+        assert "junit_family" in capsys.readouterr().err
+
+    def test_nested_suites_get_the_hint_too(self, tmp_path, capsys):
+        # The parser files the cases of a nested report under testsuite_nested;
+        # a hint that only looked at the top level went quiet on exactly the
+        # Ant/Maven-shaped reports that most often lack source locations.
+        code, data = _convert(
+            tmp_path, "--no-config", xml=UTILS / "pytest_nested_example.xml"
+        )
+        assert code == 0
+        assert all(need["case_line"] == "" for need in _needs(data).values())
         assert "junit_family" in capsys.readouterr().err
 
     def test_reports_with_line_attributes_do_not_warn(self, tmp_path, capsys):
@@ -420,3 +475,55 @@ class TestContentIsNotDuplicated:
         content = _needs(data)["testcase__ParamTest_0__Legacy_owuvz"]["content"]
         assert "Skipped via GTEST_SKIP" in content
         assert "not applicable on this platform" in content
+
+
+class TestImportIntoABuild:
+    """The documented consumption path: ``needimport`` of the produced file.
+
+    The converter writes needs shaped like the build's own test-case needs, so
+    a build with the extension has to import them without dropping fields.
+    """
+
+    def test_converted_needs_import_without_loss(self, tmp_path):
+        from io import StringIO
+        from shutil import copytree
+
+        from sphinx.application import Sphinx
+
+        docs = tmp_path / "docs"
+        copytree(Path(__file__).parent / "doc_test" / "basic_doc", docs)
+        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        with (docs / "conf.py").open("a", encoding="utf-8") as handle:
+            # The IDs are lowercase; sphinx-needs' default regex is not.
+            handle.write('\nneeds_id_regex = "^[A-Za-z0-9_]{5,}"\n')
+        (docs / "index.rst").write_text(
+            "Imported\n========\n\n.. needimport:: needs.json\n", encoding="utf-8"
+        )
+        # One declarative file for both consumers: the build registers these
+        # properties as need options, the converter exports exactly these.
+        config = docs / "ubproject.toml"
+        config.write_text(
+            '[test_reports]\nextra_options = ["TestType", "Requirement", "PartiallyVerifies"]\n',
+            encoding="utf-8",
+        )
+        code, data = _convert(docs, "--config", str(config), xml=GTEST_XML)
+        assert code == 0
+
+        warnings = StringIO()
+        app = Sphinx(
+            srcdir=docs,
+            confdir=docs,
+            outdir=docs / "_build" / "html",
+            doctreedir=docs / "_build" / "doctrees",
+            buildername="html",
+            freshenv=True,
+            status=None,
+            warning=warnings,
+        )
+        app.build()
+        text = warnings.getvalue()
+        assert "Unknown keys" not in text, text
+        assert "could not be imported" not in text, text
+        html = (docs / "_build" / "html" / "index.html").read_text(encoding="utf-8")
+        for need_id in _needs(data):
+            assert need_id in html

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -139,12 +139,14 @@ class TestNeedContent:
         # `file` is the report path, as in a locally created test-case need.
         assert need["file"] == str(GTEST_XML)
 
-    def test_type_and_title_are_score_shaped(self, tmp_path):
+    def test_type_and_title_match_the_directive_s(self, tmp_path):
+        # The directive titles a case need with the case name; a needtable
+        # title column must not tell an imported case from a built one.
         _, data = _convert(tmp_path)
 
         need = _needs(data)["testcase__MathTest__Addition_hcuyy"]
         assert need["type"] == "testcase"
-        assert need["title"] == "MathTest__Addition"
+        assert need["title"] == "Addition"
 
     def test_result_vocabulary_includes_disabled(self, tmp_path):
         _, data = _convert(tmp_path)
@@ -180,6 +182,33 @@ class TestNeedContent:
         assert "properties not exported" in message
         assert "PartiallyVerifies" in message
         assert "extra_options" in message
+
+    def test_unexported_properties_are_reported_once_for_all_names(
+        self, tmp_path, capsys
+    ):
+        # One line naming every left-out property -- not one line per name,
+        # and not one per case that carries it.
+        code, _ = _convert(tmp_path, "--no-config")
+        assert code == 0
+        lines = [
+            line
+            for line in capsys.readouterr().err.splitlines()
+            if "properties not exported" in line
+        ]
+        assert len(lines) == 1
+        assert "PartiallyVerifies" in lines[0] and "TestType" in lines[0]
+
+    def test_an_exported_property_is_present_on_every_case(self, tmp_path):
+        # Null where the case has no such property, as the build leaves a
+        # registered field a directive did not set -- so one schema can
+        # require the field of imported and locally created needs alike.
+        _, data = _convert(tmp_path, "--no-config", "--extra-option", "TestType")
+        needs = _needs(data)
+        assert needs["testcase__MathTest__Addition_hcuyy"]["TestType"] == (
+            "requirements-based"
+        )
+        assert needs["testcase__MathTest__Subtraction_srmht"]["TestType"] is None
+        assert all("TestType" in need for need in needs.values())
 
     def test_unnamed_properties_are_left_out_quietly_when_none_exist(
         self, tmp_path, capsys
@@ -514,19 +543,19 @@ def test_url_synthesis_needs_both_parts(tmp_path, flag):
 
 
 class TestResultVocabulary:
-    """The export uses the migration-target vocabulary, not the parser's.
+    """The export uses the parser's vocabulary, which is the build's.
 
-    The parser reports ``failure`` and must keep doing so -- it is a documented
-    need field value and a CSS class (``tr_failure``). The exported needs.json
-    is a new surface with no such obligation, and its consumers' metamodels
-    (S-CORE's included) spell it ``failed``.
+    ``failure`` is a documented need field value and a CSS class
+    (``tr_failure``), and the shipped report template filters on it. A project
+    that mixes imported and locally created test-case needs filters both with
+    one expression only if the two writers spell the result alike.
     """
 
-    def test_failure_is_exported_as_failed(self, tmp_path):
+    def test_failure_is_exported_as_the_build_spells_it(self, tmp_path):
         _, data = _convert(tmp_path)
 
         assert (
-            _needs(data)["testcase__MathTest__Subtraction_srmht"]["result"] == "failed"
+            _needs(data)["testcase__MathTest__Subtraction_srmht"]["result"] == "failure"
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -264,6 +264,28 @@ class TestMultipleInputs:
         assert code == 0
         assert len(_needs(data)) > 5
 
+    def test_the_same_report_given_twice_is_refused(self, tmp_path, capsys):
+        # Silently collapsing the repeats would produce a valid file that has
+        # lost half its evidence -- the worst outcome for a cached artifact.
+        from sphinxcontrib.test_reports.cli import main
+
+        output = tmp_path / "needs.json"
+        code = main(
+            [
+                "convert",
+                str(GTEST_XML),
+                str(GTEST_XML),
+                "--no-config",
+                "-o",
+                str(output),
+            ]
+        )
+        assert code == 2
+        assert not output.exists()
+        message = capsys.readouterr().err
+        assert "more than once" in message
+        assert "testcase__" in message
+
     def test_a_missing_input_file_exits_nonzero(self, tmp_path):
         from sphinxcontrib.test_reports.cli import main
 

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -501,7 +501,7 @@ class TestImportIntoABuild:
 
         docs = tmp_path / "docs"
         copytree(Path(__file__).parent / "doc_test" / "basic_doc", docs)
-        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        (tmp_path / ".git").mkdir(exist_ok=True)  # bounds the upward search
         with (docs / "conf.py").open("a", encoding="utf-8") as handle:
             # The IDs are lowercase; sphinx-needs' default regex is not.
             handle.write('\nneeds_id_regex = "^[A-Za-z0-9_]{5,}"\n')

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -1,4 +1,4 @@
-"""Tests for the Sphinx-free ``test-reports convert`` CLI (TR-A).
+"""Tests for the Sphinx-free ``test-reports build needs`` CLI (TR-A).
 
 This is the keystone of the build-system story: a test-XML to needs.json
 conversion that runs as a build action *outside* Sphinx, so the docs build only
@@ -28,7 +28,7 @@ def _convert(tmp_path, *args, xml=GTEST_XML):
     from sphinxcontrib.test_reports.cli import main
 
     output = tmp_path / "needs.json"
-    code = main(["convert", str(xml), "--output", str(output), *args])
+    code = main(["build", "needs", str(xml), "--output", str(output), *args])
     data = json.loads(output.read_text(encoding="utf-8")) if output.exists() else None
     return code, data
 
@@ -99,7 +99,9 @@ class TestEnvelope:
         first = tmp_path / "first.json"
         second = tmp_path / "second.json"
         for output in (first, second):
-            assert main(["convert", str(GTEST_XML), "--output", str(output)]) == 0
+            assert (
+                main(["build", "needs", str(GTEST_XML), "--output", str(output)]) == 0
+            )
 
         assert first.read_bytes() == second.read_bytes()
 
@@ -203,7 +205,8 @@ class TestLinkProperties:
 
         code = main(
             [
-                "convert",
+                "build",
+                "needs",
                 str(GTEST_XML),
                 "--output",
                 str(tmp_path / "out.json"),
@@ -301,7 +304,7 @@ class TestMultipleInputs:
 
         output = tmp_path / "needs.json"
         code = main(
-            ["convert", str(GTEST_XML), str(PYTEST_XML), "--output", str(output)]
+            ["build", "needs", str(GTEST_XML), str(PYTEST_XML), "--output", str(output)]
         )
         data = json.loads(output.read_text(encoding="utf-8"))
 
@@ -316,7 +319,8 @@ class TestMultipleInputs:
         output = tmp_path / "needs.json"
         code = main(
             [
-                "convert",
+                "build",
+                "needs",
                 str(GTEST_XML),
                 str(GTEST_XML),
                 "--no-config",
@@ -335,7 +339,8 @@ class TestMultipleInputs:
 
         code = main(
             [
-                "convert",
+                "build",
+                "needs",
                 str(tmp_path / "nope.xml"),
                 "--output",
                 str(tmp_path / "out.json"),
@@ -352,7 +357,8 @@ class TestDiagnostics:
 
         main(
             [
-                "convert",
+                "build",
+                "needs",
                 str(PYTEST_XML),
                 "--output",
                 str(tmp_path / "out.json"),
@@ -375,14 +381,21 @@ class TestDiagnostics:
     def test_reports_with_line_attributes_do_not_warn(self, tmp_path, capsys):
         from sphinxcontrib.test_reports.cli import main
 
-        main(["convert", str(GTEST_XML), "--output", str(tmp_path / "out.json")])
+        main(["build", "needs", str(GTEST_XML), "--output", str(tmp_path / "out.json")])
 
         assert "junit_family" not in capsys.readouterr().err
 
 
 def test_the_cli_is_runnable_as_a_module():
     result = subprocess.run(
-        [sys.executable, "-m", "sphinxcontrib.test_reports.cli", "convert", "--help"],
+        [
+            sys.executable,
+            "-m",
+            "sphinxcontrib.test_reports.cli",
+            "build",
+            "needs",
+            "--help",
+        ],
         capture_output=True,
         text=True,
     )
@@ -398,7 +411,7 @@ def test_console_script_is_installed():
         pytest.skip("package not installed into this environment")
 
     result = subprocess.run(
-        [str(script), "convert", "--help"], capture_output=True, text=True
+        [str(script), "build", "needs", "--help"], capture_output=True, text=True
     )
 
     assert result.returncode == 0
@@ -412,7 +425,8 @@ def test_url_synthesis_needs_both_parts(tmp_path, flag):
 
     code = main(
         [
-            "convert",
+            "build",
+            "needs",
             str(GTEST_XML),
             "--output",
             str(tmp_path / "out.json"),

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -62,12 +62,7 @@ class TestNoSphinxImport:
 class TestEnvelope:
     def test_output_passes_the_sphinx_needs_schema(self, tmp_path):
         """The output must validate against sphinx-needs' own needs.json schema."""
-        needsfile = pytest.importorskip("sphinx_needs.needsfile")
-        if not hasattr(needsfile, "check_needs_data"):
-            # Older sphinx-needs releases do not ship the schema check; the
-            # envelope contract itself is version-independent, so skip rather
-            # than pin the whole suite to the newest sphinx-needs.
-            pytest.skip("sphinx-needs has no check_needs_data")
+        from sphinx_needs import needsfile
 
         code, data = _convert(tmp_path)
 
@@ -502,14 +497,7 @@ class TestImportIntoABuild:
         from io import StringIO
         from shutil import copytree
 
-        import sphinx_needs
-        from packaging.version import Version
         from sphinx.application import Sphinx
-
-        if Version(sphinx_needs.__version__) < Version("4.0"):
-            # needimport read the need text from `description` only; the
-            # converter writes `content`, the spelling of every version since.
-            pytest.skip("needimport reads `content` only from sphinx-needs 4 on")
 
         docs = tmp_path / "docs"
         copytree(Path(__file__).parent / "doc_test" / "basic_doc", docs)

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -38,6 +38,14 @@ def _needs(data):
     return data["versions"][version]["needs"]
 
 
+def _field_type(declaration):
+    """The declared type, with the nullability the schema spells separately."""
+    kind = declaration["type"]
+    if isinstance(kind, str):
+        return kind
+    return next(iter(set(kind) - {"null"}))
+
+
 class TestNoSphinxImport:
     """The converter has to be usable without the documentation toolchain."""
 
@@ -80,6 +88,16 @@ class TestEnvelope:
 
         version = data["versions"][data["current_version"]]
         assert version["needs_amount"] == len(version["needs"]) == 5
+
+    def test_every_written_field_is_declared(self, tmp_path):
+        """The file says what its fields are, without a Sphinx build to ask."""
+        _, data = _convert(tmp_path)
+
+        version = data["versions"][data["current_version"]]
+        declared = set(version["needs_schema"]["properties"])
+        written = {key for need in version["needs"].values() for key in need}
+
+        assert written - declared == set()
 
     def test_no_timestamp_is_written(self, tmp_path):
         """A wall clock would defeat action caching and evidence diffs."""
@@ -536,3 +554,76 @@ class TestImportIntoABuild:
         html = (docs / "_build" / "html" / "index.html").read_text(encoding="utf-8")
         for need_id in _needs(data):
             assert need_id in html
+
+    def test_the_declared_types_match_the_extension_s(self, tmp_path):
+        """What the file declares is what the build registers.
+
+        The extension declares its fields to sphinx-needs, the converter
+        declares them into the file, and an import brings the two together --
+        so a field the two type differently is an import-time type error
+        waiting to happen. Only the type is compared: the wording of a core
+        field's description belongs to sphinx-needs and moves with its
+        version.
+        """
+        from shutil import copytree
+
+        from sphinx.application import Sphinx
+
+        docs = tmp_path / "docs"
+        copytree(Path(__file__).parent / "doc_test" / "basic_doc", docs)
+        (tmp_path / ".git").mkdir(exist_ok=True)  # bounds the upward search
+        with (docs / "conf.py").open("a", encoding="utf-8") as handle:
+            # The build has to write a needs.json of its own to compare with.
+            handle.write("\nneeds_build_json = True\n")
+            handle.write('needs_id_regex = "^[A-Za-z0-9_]{5,}"\n')
+        (docs / "index.rst").write_text(
+            "Imported\n========\n\n.. needimport:: needs.json\n", encoding="utf-8"
+        )
+        config = docs / "ubproject.toml"
+        config.write_text(
+            '[test_reports]\nextra_options = ["TestType"]\n', encoding="utf-8"
+        )
+        code, data = _convert(docs, "--config", str(config), xml=GTEST_XML)
+        assert code == 0
+
+        app = Sphinx(
+            srcdir=docs,
+            confdir=docs,
+            outdir=docs / "_build" / "html",
+            doctreedir=docs / "_build" / "doctrees",
+            buildername="html",
+            freshenv=True,
+            status=None,
+            warning=None,
+        )
+        app.build()
+        built = json.loads(
+            (docs / "_build" / "html" / "needs.json").read_text(encoding="utf-8")
+        )
+        registered = built["versions"][built["current_version"]].get("needs_schema")
+        if registered is None:
+            pytest.skip("this sphinx-needs does not declare its fields in needs.json")
+
+        declared = data["versions"][data["current_version"]]["needs_schema"]
+        shared = set(declared["properties"]) & set(registered["properties"])
+        # Guard against a vacuous comparison: these are the fields the
+        # converter writes beyond the core ones.
+        assert {
+            "case",
+            "case_file",
+            "case_line",
+            "case_name",
+            "case_parameter",
+            "classname",
+            "file",
+            "remote_url",
+            "result",
+            "result_text",
+            "suite",
+            "time",
+            "TestType",
+        } <= shared
+
+        assert {name: _field_type(declared["properties"][name]) for name in shared} == {
+            name: _field_type(registered["properties"][name]) for name in shared
+        }

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -488,7 +488,14 @@ class TestImportIntoABuild:
         from io import StringIO
         from shutil import copytree
 
+        import sphinx_needs
+        from packaging.version import Version
         from sphinx.application import Sphinx
+
+        if Version(sphinx_needs.__version__) < Version("4.0"):
+            # needimport read the need text from `description` only; the
+            # converter writes `content`, the spelling of every version since.
+            pytest.skip("needimport reads `content` only from sphinx-needs 4 on")
 
         docs = tmp_path / "docs"
         copytree(Path(__file__).parent / "doc_test" / "basic_doc", docs)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -22,6 +22,7 @@ from sphinxcontrib.test_reports.identity import (
     case_display_name,
     deterministic_case_id,
     short_hash,
+    split_case_name,
 )
 
 
@@ -52,6 +53,38 @@ class TestCaseDisplayName:
     def test_unknown_classname_is_treated_as_absent(self):
         """The parser reports "unknown" when the attribute is missing."""
         assert case_display_name("unknown", "Standalone") == "Standalone"
+
+
+class TestSplitCaseName:
+    """``name[param]`` as pytest spells it, split for both writers alike.
+
+    The one definition the directives and the converter share; the shapes
+    pinned here are the ones a report can carry, so a change to the pattern
+    shows up as a failing test rather than as two writers disagreeing.
+    """
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("test_x", ("test_x", "")),
+            ("test_x[a-b]", ("test_x", "a-b")),
+            ("tests.test_cli.test_help[1-2]", ("tests.test_cli.test_help", "1-2")),
+            # An empty parameter list is a parameter of "".
+            ("test_x[]", ("test_x", "")),
+            # The parameter is greedy: brackets inside it survive.
+            ("test_x[a[0]-b]", ("test_x", "a[0]-b")),
+            # googletest's parameterised spelling carries no brackets at all.
+            ("Works/0", ("Works/0", "")),
+            # Not the pytest shape: the name is kept whole, never cut at a
+            # bracket -- an unclosed one, text after the closing one, or a
+            # name that starts with one.
+            ("test_x[abc", ("test_x[abc", "")),
+            ("test_x[a]b", ("test_x[a]b", "")),
+            ("[only]", ("[only]", "")),
+        ],
+    )
+    def test_splits_pytest_s_shape_and_only_that(self, name, expected):
+        assert split_case_name(name) == expected
 
 
 class TestDeterministicCaseId:

--- a/tests/test_needs_export.py
+++ b/tests/test_needs_export.py
@@ -12,7 +12,11 @@ from sphinxcontrib.test_reports.needs_export import (
     build_need,
     build_needs_file,
 )
-from sphinxcontrib.test_reports.remote import normalise_remote_url, source_url
+from sphinxcontrib.test_reports.remote import (
+    check_url_pattern,
+    normalise_remote_url,
+    source_url,
+)
 
 
 def _case(name="test_x", **extra):
@@ -45,16 +49,16 @@ class TestDuplicateCases:
     def test_a_case_reported_twice_is_refused(self):
         # Its ID is derived from where the test is, so a repeat is the same
         # case twice; collapsing them would silently lose evidence.
-        suites = [
-            {"name": "s", "testcases": [_case(), _case("test_y")]},
-            {"name": "s", "testcases": [_case()]},
+        reports = [
+            ("a.xml", [{"name": "s", "testcases": [_case(), _case("test_y")]}]),
+            ("b.xml", [{"name": "s", "testcases": [_case()]}]),
         ]
         with pytest.raises(ValueError, match="1 test case.*testcase__Suite__test_x"):
-            build_needs_file(suites)
+            build_needs_file(reports)
 
     def test_distinct_cases_are_all_kept(self):
-        suites = [{"name": "s", "testcases": [_case(), _case("test_y")]}]
-        payload = build_needs_file(suites)
+        reports = [("a.xml", [{"name": "s", "testcases": [_case(), _case("test_y")]}])]
+        payload = build_needs_file(reports)
         assert payload["versions"]["1.0"]["needs_amount"] == 2
 
 
@@ -62,8 +66,10 @@ class TestPropertyCollisions:
     def test_a_property_named_like_a_builtin_field_warns_and_is_dropped(self):
         reported = []
         need = build_need(
+            "r.xml",
             "s",
             _case(properties={"result": "tampered", "owner": "me"}),
+            extra_options=("result", "owner"),
             warn=reported.append,
         )
         assert need["result"] != "tampered"
@@ -72,8 +78,70 @@ class TestPropertyCollisions:
         assert "'result'" in reported[0]
 
     def test_without_a_reporter_the_property_is_still_dropped(self):
-        need = build_need("s", _case(properties={"file": "elsewhere.py"}))
+        # `file` is the report-path field by default, so a property of that
+        # name collides with it and the report path wins.
+        need = build_need(
+            "r.xml",
+            "s",
+            _case(properties={"file": "elsewhere.py"}),
+            extra_options=("file",),
+        )
+        assert need["file"] == "r.xml"
+
+
+class TestNeedShape:
+    def test_matches_the_build_s_test_case_need(self):
+        need = build_need("reports/r.xml", "suite-1", _case("test_x[a-b]"))
+        assert need["suite"] == "suite-1"
+        assert need["case"] == "test_x[a-b]"
+        assert need["case_name"] == "test_x"
+        assert need["case_parameter"] == "a-b"
+        assert need["classname"] == "Suite"
+        assert need["file"] == "reports/r.xml"
+        assert need["case_file"] == "t.py"
+        assert need["case_line"] == "3"
+
+    def test_field_names_follow_the_section(self):
+        # The names the build's file_option / source_*_option select.
+        fields = {
+            "file_option": "report_file",
+            "source_file_option": "file",
+            "source_line_option": "line",
+        }
+        need = build_need("r.xml", "s", _case(), fields=fields)
+        assert need["report_file"] == "r.xml"
         assert need["file"] == "t.py"
+        assert need["line"] == "3"
+        assert "case_file" not in need
+
+
+class TestPropertyGate:
+    def test_only_named_properties_are_exported(self):
+        case = _case(properties={"TestType": "unit", "Owner": "me"})
+        need = build_need("r.xml", "s", case, extra_options=("TestType",))
+        assert need["TestType"] == "unit"
+        assert "Owner" not in need
+
+    def test_left_out_properties_are_reported_once(self):
+        reported = []
+        reports = [
+            (
+                "a.xml",
+                [
+                    {
+                        "name": "s",
+                        "testcases": [
+                            _case("t1", properties={"Owner": "me", "Kind": "x"}),
+                            _case("t2", properties={"Owner": "you"}),
+                        ],
+                    }
+                ],
+            ),
+        ]
+        build_needs_file(reports, extra_options=("Kind",), warn=reported.append)
+        assert len(reported) == 1
+        assert "Owner" in reported[0] and "Kind" not in reported[0]
+        assert "extra_options" in reported[0]
 
 
 class TestRemoteUrls:
@@ -88,6 +156,8 @@ class TestRemoteUrls:
             ("git@github.com:org/repo.git", "https://github.com/org/repo"),
             ("https://github.com/org/repo.git/", "https://github.com/org/repo"),
             ("gitlab.example.com/org/repo", "https://gitlab.example.com/org/repo"),
+            ("git://github.com/org/repo.git", "https://github.com/org/repo"),
+            ("file:///srv/git/repo.git", "file:///srv/git/repo.git"),  # passed through
         ],
     )
     def test_remotes_normalise_to_a_browsable_base(self, remote, base):
@@ -111,3 +181,23 @@ class TestRemoteUrls:
             "https://h/r", "abc", "f.py", "", "{base}/{file}?ref={commit}&line={line}"
         )
         assert url == "https://h/r/f.py?ref=abc&line="
+
+
+class TestUrlPatternCheck:
+    def test_the_default_and_a_custom_pattern_pass(self):
+        assert check_url_pattern("{base}/blob/{commit}/{file}#L{line}") is None
+        assert check_url_pattern("{base}/-/blob/{commit}/{file}#L{line}") is None
+
+    def test_an_unknown_placeholder_is_named(self):
+        problem = check_url_pattern("{base}/blob/{ref}/{file}#L{line}")
+        assert problem is not None
+        assert "{ref}" in problem
+        assert "{commit}" in problem  # the allowed names are listed
+
+    @pytest.mark.parametrize(
+        "pattern", ["{base/blob/{commit}/{file}", "{}/{file}", "{base}}"]
+    )
+    def test_a_malformed_template_is_rejected(self, pattern):
+        problem = check_url_pattern(pattern)
+        assert problem is not None
+        assert "malformed" in problem

--- a/tests/test_needs_export.py
+++ b/tests/test_needs_export.py
@@ -63,21 +63,52 @@ class TestDuplicateCases:
 
 
 class TestPropertyCollisions:
-    def test_a_property_named_like_a_builtin_field_warns_and_is_dropped(self):
-        reported = []
+    def test_a_property_named_like_a_builtin_field_is_dropped_and_collected(self):
+        collisions = set()
         need = build_need(
             "r.xml",
             "s",
             _case(properties={"result": "tampered", "owner": "me"}),
             extra_options=("result", "owner"),
-            warn=reported.append,
+            collisions=collisions,
         )
         assert need["result"] != "tampered"
         assert need["owner"] == "me"
-        assert len(reported) == 1
-        assert "'result'" in reported[0]
+        assert collisions == {"result"}
 
-    def test_without_a_reporter_the_property_is_still_dropped(self):
+    def test_a_listed_name_no_case_carries_is_not_a_collision(self):
+        collisions = set()
+        build_need(
+            "r.xml", "s", _case(), extra_options=("result",), collisions=collisions
+        )
+        assert collisions == set()
+
+    def test_collisions_are_reported_once_per_run(self):
+        # Every other diagnostic fires once per run; so does this one, however
+        # many cases carry the property.
+        reported = []
+        reports = [
+            (
+                "a.xml",
+                [
+                    {
+                        "name": "s",
+                        "testcases": [
+                            _case("t1", properties={"result": "x"}),
+                            _case("t2", properties={"result": "y", "time": "z"}),
+                        ],
+                    }
+                ],
+            ),
+        ]
+        build_needs_file(
+            reports, extra_options=("result", "time"), warn=reported.append
+        )
+        assert len(reported) == 1
+        assert "result" in reported[0] and "time" in reported[0]
+        assert "taken by built-in or link fields" in reported[0]
+
+    def test_without_a_collector_the_property_is_still_dropped(self):
         # `file` is the report-path field by default, so a property of that
         # name collides with it and the report path wins.
         need = build_need(
@@ -122,9 +153,9 @@ class TestPropertyGate:
         assert need["TestType"] == "unit"
         assert "Owner" not in need
 
-    def test_left_out_properties_are_reported_once(self):
-        reported = []
-        reports = [
+    @staticmethod
+    def _two_cases_with_properties():
+        return [
             (
                 "a.xml",
                 [
@@ -138,10 +169,31 @@ class TestPropertyGate:
                 ],
             ),
         ]
-        build_needs_file(reports, extra_options=("Kind",), warn=reported.append)
+
+    def test_left_out_properties_are_reported_once_for_all_names(self):
+        # One report naming both -- not one per name, not one per case.
+        reported = []
+        build_needs_file(self._two_cases_with_properties(), warn=reported.append)
+        assert len(reported) == 1
+        assert "Owner" in reported[0] and "Kind" in reported[0]
+        assert "extra_options" in reported[0]
+
+    def test_exported_properties_are_not_reported(self):
+        reported = []
+        build_needs_file(
+            self._two_cases_with_properties(),
+            extra_options=("Kind",),
+            warn=reported.append,
+        )
         assert len(reported) == 1
         assert "Owner" in reported[0] and "Kind" not in reported[0]
-        assert "extra_options" in reported[0]
+
+    def test_an_exported_property_absent_from_a_case_is_null(self):
+        # The field is always there, so a schema can require it; null is what
+        # the build leaves in a registered field a directive did not set.
+        need = build_need("r.xml", "s", _case(), extra_options=("TestType",))
+        assert "TestType" in need
+        assert need["TestType"] is None
 
 
 class TestRemoteUrls:
@@ -315,9 +367,10 @@ class TestDeclaredSchema:
 
     def test_an_extra_option_is_declared_even_when_no_case_carries_it(self):
         # The option is what the build registers, so the file says the field
-        # exists; a case without the property simply has no value for it.
+        # exists; a case without the property carries it as null -- the type
+        # the declaration allows for exactly that.
         schema, needs = self._declared(extra_options=("TestType",))
-        assert "TestType" not in next(iter(needs.values()))
+        assert next(iter(needs.values()))["TestType"] is None
         assert schema["properties"]["TestType"]["type"] == ["string", "null"]
 
     def test_the_counts_of_file_and_suite_needs_are_not_declared(self):

--- a/tests/test_needs_export.py
+++ b/tests/test_needs_export.py
@@ -1,0 +1,113 @@
+"""Unit tests for the needs.json writer and the URL helpers behind it.
+
+The CLI tests cover the end-to-end shape; these pin down the pieces whose
+failure would be silent in that shape -- evidence text mangled but present,
+cases lost but the file valid, a URL that looks right and 404s.
+"""
+
+import pytest
+
+from sphinxcontrib.test_reports.needs_export import (
+    build_content,
+    build_need,
+    build_needs_file,
+)
+from sphinxcontrib.test_reports.remote import normalise_remote_url, source_url
+
+
+def _case(name="test_x", **extra):
+    return {"classname": "Suite", "name": name, "file": "t.py", "line": 3, **extra}
+
+
+class TestEvidenceText:
+    def test_relative_indentation_survives(self):
+        # A traceback is only readable with its indentation; only the common
+        # indentation XML pretty-printing adds may go.
+        text = (
+            "\n"
+            "      Traceback (most recent call last):\n"
+            '        File "t.py", line 3, in test_x\n'
+            "          assert a == b\n"
+            "                 ^^^^^^\n"
+            "      AssertionError\n"
+            "    "
+        )
+        content = build_content({"parts": [{"kind": "failure", "text": text}]})
+        assert '   Traceback (most recent call last):\n     File "t.py"' in content
+        assert "            ^^^^^^\n   AssertionError" in content
+
+    def test_blank_lines_carry_no_trailing_whitespace(self):
+        content = build_content({"parts": [{"kind": "failure", "text": "a\n\nb"}]})
+        assert "\n   a\n\n   b\n" in content
+
+
+class TestDuplicateCases:
+    def test_a_case_reported_twice_is_refused(self):
+        # Its ID is derived from where the test is, so a repeat is the same
+        # case twice; collapsing them would silently lose evidence.
+        suites = [
+            {"name": "s", "testcases": [_case(), _case("test_y")]},
+            {"name": "s", "testcases": [_case()]},
+        ]
+        with pytest.raises(ValueError, match="1 test case.*testcase__Suite__test_x"):
+            build_needs_file(suites)
+
+    def test_distinct_cases_are_all_kept(self):
+        suites = [{"name": "s", "testcases": [_case(), _case("test_y")]}]
+        payload = build_needs_file(suites)
+        assert payload["versions"]["1.0"]["needs_amount"] == 2
+
+
+class TestPropertyCollisions:
+    def test_a_property_named_like_a_builtin_field_warns_and_is_dropped(self):
+        reported = []
+        need = build_need(
+            "s",
+            _case(properties={"result": "tampered", "owner": "me"}),
+            warn=reported.append,
+        )
+        assert need["result"] != "tampered"
+        assert need["owner"] == "me"
+        assert len(reported) == 1
+        assert "'result'" in reported[0]
+
+    def test_without_a_reporter_the_property_is_still_dropped(self):
+        need = build_need("s", _case(properties={"file": "elsewhere.py"}))
+        assert need["file"] == "t.py"
+
+
+class TestRemoteUrls:
+    @pytest.mark.parametrize(
+        ("remote", "base"),
+        [
+            (
+                "ssh://git@gitlab.example.com:2222/org/repo.git",
+                "https://gitlab.example.com/org/repo",
+            ),
+            ("ssh://git@github.com/org/repo.git", "https://github.com/org/repo"),
+            ("git@github.com:org/repo.git", "https://github.com/org/repo"),
+            ("https://github.com/org/repo.git/", "https://github.com/org/repo"),
+            ("gitlab.example.com/org/repo", "https://gitlab.example.com/org/repo"),
+        ],
+    )
+    def test_remotes_normalise_to_a_browsable_base(self, remote, base):
+        # An ssh port belongs to the ssh endpoint, not the web UI -- and must
+        # not be mistaken for the first path segment.
+        assert normalise_remote_url(remote) == base
+
+    def test_without_a_line_the_anchor_is_dropped(self):
+        assert (
+            source_url("https://h/r", "abc", "f.py", "") == "https://h/r/blob/abc/f.py"
+        )
+
+    def test_without_a_line_a_fragment_without_the_line_is_kept(self):
+        url = source_url(
+            "https://h/r", "abc", "f.py", "", "{base}/{file}?ref={commit}#src"
+        )
+        assert url == "https://h/r/f.py?ref=abc#src"
+
+    def test_without_a_line_a_query_pattern_keeps_its_shape(self):
+        url = source_url(
+            "https://h/r", "abc", "f.py", "", "{base}/{file}?ref={commit}&line={line}"
+        )
+        assert url == "https://h/r/f.py?ref=abc&line="

--- a/tests/test_needs_export.py
+++ b/tests/test_needs_export.py
@@ -201,3 +201,99 @@ class TestUrlPatternCheck:
         problem = check_url_pattern(pattern)
         assert problem is not None
         assert "malformed" in problem
+
+
+class TestDeclaredSchema:
+    """Every field the file uses is declared in the file.
+
+    sphinx-needs writes a ``needs_schema`` into the ``needs.json`` it produces
+    and the converter has to do the same, or the type of a field is knowable
+    only by loading this extension into a Sphinx build -- which a consumer of
+    the artifact (a schema check, S-CORE's tooling, a plain jsonschema
+    validator) does not do.
+    """
+
+    @staticmethod
+    def _declared(**kwargs):
+        """The schema block and the needs of a one-case report."""
+        reports = [("a.xml", [{"name": "s", "testcases": [_case()]}])]
+        payload = build_needs_file(reports, **kwargs)
+        version = payload["versions"][payload["current_version"]]
+        return version["needs_schema"], version["needs"]
+
+    def test_the_block_is_a_json_schema(self):
+        schema, _ = self._declared()
+        assert schema["$schema"] == "http://json-schema.org/draft-07/schema#"
+        assert schema["type"] == "object"
+
+    def test_no_field_of_a_need_is_undeclared(self):
+        schema, needs = self._declared(
+            link_properties={"Verifies": "verifies"},
+            extra_options=("TestType",),
+        )
+        written = {key for need in needs.values() for key in need}
+        assert written - set(schema["properties"]) == set()
+
+    def test_the_core_fields_are_declared_as_core(self):
+        schema, _ = self._declared()
+        properties = schema["properties"]
+        assert properties["id"]["field_type"] == "core"
+        assert properties["tags"]["type"] == "array"
+        assert properties["content"]["type"] == "string"
+
+    def test_time_is_declared_as_the_string_it_is(self):
+        # Pins today's type. It is the field's declared type in the build too,
+        # so the two change together or not at all.
+        schema, _ = self._declared()
+        assert schema["properties"]["time"]["type"] == ["string", "null"]
+
+    def test_every_declaration_carries_a_description(self):
+        # A type alone does not say what a field holds; `case_line` and
+        # `result_text` are not self-explanatory.
+        schema, _ = self._declared(
+            link_properties={"Verifies": "verifies"}, extra_options=("TestType",)
+        )
+        undescribed = [
+            name
+            for name, declaration in schema["properties"].items()
+            if not declaration.get("description")
+        ]
+        assert undescribed == []
+
+    def test_renamed_fields_are_declared_under_their_names(self):
+        schema, _ = self._declared(
+            fields={
+                "file_option": "report_file",
+                "source_file_option": "file",
+                "source_line_option": "line",
+            }
+        )
+        properties = schema["properties"]
+        assert properties["report_file"]["description"] == "Test file name"
+        assert "line" in properties
+        assert "case_file" not in properties
+        assert "case_line" not in properties
+
+    def test_a_mapped_link_field_is_declared_as_a_list_of_ids(self):
+        schema, _ = self._declared(link_properties={"Verifies": "verifies"})
+        assert schema["properties"]["verifies"] == {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Link field",
+            "field_type": "links",
+            "default": [],
+        }
+
+    def test_an_extra_option_is_declared_even_when_no_case_carries_it(self):
+        # The option is what the build registers, so the file says the field
+        # exists; a case without the property simply has no value for it.
+        schema, needs = self._declared(extra_options=("TestType",))
+        assert "TestType" not in next(iter(needs.values()))
+        assert schema["properties"]["TestType"]["type"] == ["string", "null"]
+
+    def test_the_counts_of_file_and_suite_needs_are_not_declared(self):
+        # The converter writes test-case needs only; declaring `passed` and
+        # friends would promise fields the file never carries.
+        schema, _ = self._declared()
+        assert "passed" not in schema["properties"]
+        assert "suites" not in schema["properties"]

--- a/tests/test_needs_export.py
+++ b/tests/test_needs_export.py
@@ -158,6 +158,17 @@ class TestRemoteUrls:
             ("gitlab.example.com/org/repo", "https://gitlab.example.com/org/repo"),
             ("git://github.com/org/repo.git", "https://github.com/org/repo"),
             ("file:///srv/git/repo.git", "file:///srv/git/repo.git"),  # passed through
+            # GitLab's CI_REPOSITORY_URL: the job token must not reach the file.
+            (
+                "https://gitlab-ci-token:glcbt-xyz@gitlab.example.com/org/repo.git",
+                "https://gitlab.example.com/org/repo",
+            ),
+            ("https://user:pass@github.com/org/repo/", "https://github.com/org/repo"),
+            ("token@github.com:org/repo.git", "https://github.com/org/repo"),
+            # Local paths are passed through -- a drive letter is not a host.
+            ("C:\\repos\\repo", "C:\\repos\\repo"),
+            ("C:/repos/repo", "C:/repos/repo"),
+            ("/srv/git/repo", "/srv/git/repo"),
         ],
     )
     def test_remotes_normalise_to_a_browsable_base(self, remote, base):
@@ -195,12 +206,30 @@ class TestUrlPatternCheck:
         assert "{commit}" in problem  # the allowed names are listed
 
     @pytest.mark.parametrize(
-        "pattern", ["{base/blob/{commit}/{file}", "{}/{file}", "{base}}"]
+        "pattern",
+        [
+            "{base/blob/{commit}/{file}",
+            "{}/{file}",
+            "{0}/{file}",
+            "{base}}",
+            "{line:zz}",
+        ],
     )
     def test_a_malformed_template_is_rejected(self, pattern):
         problem = check_url_pattern(pattern)
         assert problem is not None
         assert "malformed" in problem
+
+    @pytest.mark.parametrize(
+        "pattern", ["{base.__class__}/{file}", "{base[0]}/{file}", "{base.anything}"]
+    )
+    def test_an_attribute_or_index_lookup_is_an_unknown_placeholder(self, pattern):
+        # str.format would resolve these on the substituted value -- and fail
+        # with an AttributeError, not a KeyError, on the first case.
+        problem = check_url_pattern(pattern)
+        assert problem is not None
+        assert "unknown placeholder {base" in problem
+        assert "{commit}" in problem
 
 
 class TestDeclaredSchema:

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -18,8 +18,8 @@ import pytest
 from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 from sphinxcontrib.test_reports.projectconfig import (
     BRIDGE_KEYS,
+    CONVERT_TABLE,
     DEFAULT_TOML_FILENAME,
-    FOREIGN_TABLES,
     SECTION,
     TomlConfigError,
     find_project_config,
@@ -66,26 +66,95 @@ class TestLoader:
         assert config["extra_options"] == ["more_info"]
         assert config["property_link_types"] == {"request": "req"}
 
-    def test_foreign_sub_table_is_kept_without_a_warning(self, tmp_path):
-        # [test_reports.build] belongs to the command line. This reader must
-        # neither complain about it nor apply it to a tr_* value -- the section
-        # describes the project, not just this extension.
+    def test_convert_table_is_validated_but_never_bridged(self, tmp_path):
+        # [test_reports.convert] belongs to the converter. The build validates
+        # it -- one file, one verdict -- but must not map it onto a tr_* value.
         _write(
             tmp_path,
             """
             [test_reports]
             file_option = "report_file"
 
-            [test_reports.build.needs]
+            [test_reports.convert]
             project = "demo"
             need_type = "check"
+            tags = ["ci"]
             """,
         )
         reported = []
         section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME, reported.append)
         assert reported == []
-        assert section["build"] == {"needs": {"project": "demo", "need_type": "check"}}
-        assert not set(FOREIGN_TABLES) & set(BRIDGE_KEYS)
+        assert section[CONVERT_TABLE] == {
+            "project": "demo",
+            "need_type": "check",
+            "tags": ["ci"],
+        }
+        assert CONVERT_TABLE not in BRIDGE_KEYS
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("project", "42"),
+            ("tags", '"ci, unit"'),  # a bare string is not an array
+            ("tags", "[1]"),
+            ("link_properties", '["a"]'),
+            ("link_properties", '{ Verifies = ["verifies"] }'),  # values too
+        ],
+    )
+    def test_convert_wrong_types_are_rejected(self, tmp_path, key, value):
+        _write(tmp_path, f"[test_reports.convert]\n{key} = {value}\n")
+        with pytest.raises(TomlConfigError, match=f"convert.{key}"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_convert_unknown_key_is_reported_but_not_fatal(self, tmp_path):
+        _write(tmp_path, "[test_reports.convert]\nprojct = 'typo'\nproject = 'p'\n")
+        reported = []
+        section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME, reported.append)
+        assert section[CONVERT_TABLE] == {"project": "p"}
+        assert len(reported) == 1
+        assert "projct" in reported[0]
+        assert "[test_reports.convert]" in reported[0]
+
+    def test_need_type_and_case_type_must_agree(self, tmp_path):
+        # The converter takes the need type (and the deterministic-ID prefix)
+        # from convert.need_type, the build from case's type. Disagreeing
+        # produces a needs.json the build neither registers nor cross-links.
+        _write(
+            tmp_path,
+            """
+            [test_reports.convert]
+            need_type = "testcase"
+
+            [test_reports.case]
+            directive = "test-case"
+            type = "check"
+            name = "Check"
+            prefix = "CH_"
+            color = "#999999"
+            style = "rectangle"
+            """,
+        )
+        with pytest.raises(TomlConfigError, match="need_type"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_need_type_and_case_type_agreeing_is_fine(self, tmp_path):
+        _write(
+            tmp_path,
+            """
+            [test_reports.convert]
+            need_type = "check"
+
+            [test_reports.case]
+            directive = "test-case"
+            type = "check"
+            name = "Check"
+            prefix = "CH_"
+            color = "#999999"
+            style = "rectangle"
+            """,
+        )
+        section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+        assert section["case"][1] == section[CONVERT_TABLE]["need_type"] == "check"
 
     def test_unknown_key_is_reported_but_not_fatal(self, tmp_path):
         # ubproject.toml is shared with tools on independent release cadences,
@@ -586,6 +655,18 @@ class TestBridgePrecedence:
         app, warnings = _build(docs)
         assert "no_such_key" in warnings
         assert app.config.tr_file_option == "ok"
+
+    def test_convert_table_is_not_applied_to_the_build(self, tmp_path):
+        docs = _basic_doc(
+            tmp_path,
+            "[test_reports]\nfile_option = 'ok'\n\n[test_reports.convert]\nproject = 'p'\n",
+        )
+        app, warnings = _build(docs)
+        # Only this table's fate is under test; other builds in the process may
+        # already have emitted unrelated Sphinx warnings.
+        assert "convert" not in warnings
+        assert app.config.tr_file_option == "ok"
+        assert not hasattr(app.config, "tr_convert")
 
     def test_walks_up_from_the_confdir(self, tmp_path):
         # ubproject.toml at the repo root, conf.py in docs/ -- the layout the

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -18,7 +18,7 @@ import pytest
 from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 from sphinxcontrib.test_reports.projectconfig import (
     BRIDGE_KEYS,
-    CONVERT_TABLE,
+    BUILD_TABLE,
     DEFAULT_FIELD_NAMES,
     DEFAULT_TOML_FILENAME,
     SECTION,
@@ -26,6 +26,7 @@ from sphinxcontrib.test_reports.projectconfig import (
     field_names,
     find_project_config,
     load_project_config,
+    needs_settings,
 )
 
 
@@ -68,16 +69,17 @@ class TestLoader:
         assert config["extra_options"] == ["more_info"]
         assert config["property_link_types"] == {"request": "req"}
 
-    def test_convert_table_is_validated_but_never_bridged(self, tmp_path):
-        # [test_reports.convert] belongs to the converter. The build validates
-        # it -- one file, one verdict -- but must not map it onto a tr_* value.
+    def test_build_needs_table_is_validated_but_never_bridged(self, tmp_path):
+        # [test_reports.build.needs] belongs to the command line. The build
+        # validates it -- one file, one verdict -- but must not map it onto a
+        # tr_* value.
         _write(
             tmp_path,
             """
             [test_reports]
             file_option = "report_file"
 
-            [test_reports.convert]
+            [test_reports.build.needs]
             project = "demo"
             tags = ["ci"]
             """,
@@ -85,8 +87,8 @@ class TestLoader:
         reported = []
         section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME, reported.append)
         assert reported == []
-        assert section[CONVERT_TABLE] == {"project": "demo", "tags": ["ci"]}
-        assert CONVERT_TABLE not in BRIDGE_KEYS
+        assert needs_settings(section) == {"project": "demo", "tags": ["ci"]}
+        assert BUILD_TABLE not in BRIDGE_KEYS
 
     @pytest.mark.parametrize(
         ("key", "value"),
@@ -98,28 +100,55 @@ class TestLoader:
             ("link_properties", '{ Verifies = ["verifies"] }'),  # values too
         ],
     )
-    def test_convert_wrong_types_are_rejected(self, tmp_path, key, value):
-        _write(tmp_path, f"[test_reports.convert]\n{key} = {value}\n")
-        with pytest.raises(TomlConfigError, match=f"convert.{key}"):
+    def test_build_needs_wrong_types_are_rejected(self, tmp_path, key, value):
+        _write(tmp_path, f"[test_reports.build.needs]\n{key} = {value}\n")
+        with pytest.raises(TomlConfigError, match=f"build.needs.{key}"):
             load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
 
-    def test_convert_unknown_key_is_reported_but_not_fatal(self, tmp_path):
-        _write(tmp_path, "[test_reports.convert]\nprojct = 'typo'\nproject = 'p'\n")
+    def test_unknown_artifact_under_build_is_reported_but_not_fatal(self, tmp_path):
+        # `build` holds one table per artifact the command line produces. A
+        # newer command may produce one this version does not know, and a file
+        # naming it must not take the build down.
+        _write(
+            tmp_path,
+            """
+            [test_reports.build.needs]
+            project = "p"
+
+            [test_reports.build.graph]
+            format = "svg"
+            """,
+        )
         reported = []
         section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME, reported.append)
-        assert section[CONVERT_TABLE] == {"project": "p"}
+        assert needs_settings(section) == {"project": "p"}
+        assert section[BUILD_TABLE] == {"needs": {"project": "p"}}
+        assert len(reported) == 1
+        assert "graph" in reported[0]
+        assert "[test_reports.build]" in reported[0]
+
+    def test_a_non_table_needs_artifact_is_rejected(self, tmp_path):
+        _write(tmp_path, '[test_reports.build]\nneeds = "yes"\n')
+        with pytest.raises(TomlConfigError, match="build.needs"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_build_needs_unknown_key_is_reported_but_not_fatal(self, tmp_path):
+        _write(tmp_path, "[test_reports.build.needs]\nprojct = 'typo'\nproject = 'p'\n")
+        reported = []
+        section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME, reported.append)
+        assert needs_settings(section) == {"project": "p"}
         assert len(reported) == 1
         assert "projct" in reported[0]
-        assert "[test_reports.convert]" in reported[0]
+        assert "[test_reports.build.needs]" in reported[0]
 
     def test_need_type_and_case_type_must_agree(self, tmp_path):
         # The converter takes the need type (and the deterministic-ID prefix)
-        # from convert.need_type, the build from case's type. Disagreeing
+        # from build.needs.need_type, the build from case's type. Disagreeing
         # produces a needs.json the build neither registers nor cross-links.
         _write(
             tmp_path,
             """
-            [test_reports.convert]
+            [test_reports.build.needs]
             need_type = "testcase"
 
             [test_reports.case]
@@ -140,7 +169,7 @@ class TestLoader:
         _write(
             tmp_path,
             """
-            [test_reports.convert]
+            [test_reports.build.needs]
             project = "p"
 
             [test_reports.case]
@@ -155,7 +184,7 @@ class TestLoader:
         with pytest.raises(TomlConfigError, match="'testcase'.*'check'"):
             load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
         # ... and the mirror: need_type set, case left at its default.
-        _write(tmp_path, '[test_reports.convert]\nneed_type = "check"\n')
+        _write(tmp_path, '[test_reports.build.needs]\nneed_type = "check"\n')
         with pytest.raises(TomlConfigError, match="'check'.*'testcase'"):
             load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
 
@@ -181,7 +210,8 @@ class TestLoader:
         # One verdict for both consumers: the build refuses what the converter
         # would refuse.
         _write(
-            tmp_path, '[test_reports.convert]\nlink_properties = { Verifies = "" }\n'
+            tmp_path,
+            '[test_reports.build.needs]\nlink_properties = { Verifies = "" }\n',
         )
         with pytest.raises(TomlConfigError, match="link_properties"):
             load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
@@ -204,7 +234,7 @@ class TestLoader:
         _write(
             tmp_path,
             """
-            [test_reports.convert]
+            [test_reports.build.needs]
             need_type = "check"
 
             [test_reports.case]
@@ -217,7 +247,7 @@ class TestLoader:
             """,
         )
         section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
-        assert section["case"][1] == section[CONVERT_TABLE]["need_type"] == "check"
+        assert section["case"][1] == needs_settings(section)["need_type"] == "check"
 
     def test_unknown_key_is_reported_but_not_fatal(self, tmp_path):
         # ubproject.toml is shared with tools on independent release cadences,
@@ -719,10 +749,10 @@ class TestBridgePrecedence:
         assert "no_such_key" in warnings
         assert app.config.tr_file_option == "ok"
 
-    def test_convert_table_is_not_applied_to_the_build(self, tmp_path):
+    def test_build_needs_table_is_not_applied_to_the_build(self, tmp_path):
         docs = _basic_doc(
             tmp_path,
-            "[test_reports]\nfile_option = 'ok'\n\n[test_reports.convert]\nproject = 'p'\n",
+            "[test_reports]\nfile_option = 'ok'\n\n[test_reports.build.needs]\nproject = 'p'\n",
         )
         app, warnings = _build(docs)
         # Only this table's fate is under test; other builds in the process may

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -19,9 +19,11 @@ from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 from sphinxcontrib.test_reports.projectconfig import (
     BRIDGE_KEYS,
     CONVERT_TABLE,
+    DEFAULT_FIELD_NAMES,
     DEFAULT_TOML_FILENAME,
     SECTION,
     TomlConfigError,
+    field_names,
     find_project_config,
     load_project_config,
 )
@@ -77,18 +79,13 @@ class TestLoader:
 
             [test_reports.convert]
             project = "demo"
-            need_type = "check"
             tags = ["ci"]
             """,
         )
         reported = []
         section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME, reported.append)
         assert reported == []
-        assert section[CONVERT_TABLE] == {
-            "project": "demo",
-            "need_type": "check",
-            "tags": ["ci"],
-        }
+        assert section[CONVERT_TABLE] == {"project": "demo", "tags": ["ci"]}
         assert CONVERT_TABLE not in BRIDGE_KEYS
 
     @pytest.mark.parametrize(
@@ -135,6 +132,72 @@ class TestLoader:
             """,
         )
         with pytest.raises(TomlConfigError, match="need_type"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_a_missing_side_is_compared_at_its_default(self, tmp_path):
+        # A customised case next to a convert table without need_type is a
+        # disagreement too: the converter would write the default type.
+        _write(
+            tmp_path,
+            """
+            [test_reports.convert]
+            project = "p"
+
+            [test_reports.case]
+            directive = "test-case"
+            type = "check"
+            name = "Check"
+            prefix = "CH_"
+            color = "#999999"
+            style = "rectangle"
+            """,
+        )
+        with pytest.raises(TomlConfigError, match="'testcase'.*'check'"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+        # ... and the mirror: need_type set, case left at its default.
+        _write(tmp_path, '[test_reports.convert]\nneed_type = "check"\n')
+        with pytest.raises(TomlConfigError, match="'check'.*'testcase'"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_without_a_convert_table_the_case_type_is_free(self, tmp_path):
+        # A project that only builds may name its case type as it likes.
+        _write(
+            tmp_path,
+            """
+            [test_reports.case]
+            directive = "test-case"
+            type = "check"
+            name = "Check"
+            prefix = "CH_"
+            color = "#999999"
+            style = "rectangle"
+            """,
+        )
+        assert (
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)["case"][1] == "check"
+        )
+
+    def test_empty_link_property_names_are_rejected_by_the_loader(self, tmp_path):
+        # One verdict for both consumers: the build refuses what the converter
+        # would refuse.
+        _write(
+            tmp_path, '[test_reports.convert]\nlink_properties = { Verifies = "" }\n'
+        )
+        with pytest.raises(TomlConfigError, match="link_properties"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
+    def test_field_names_default_to_the_build_s(self, tmp_path):
+        _write(tmp_path, "[test_reports]\nsource_file_option = 'src'\n")
+        section = load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+        names = field_names(section)
+        assert names["source_file_option"] == "src"
+        assert names["file_option"] == DEFAULT_FIELD_NAMES["file_option"] == "file"
+        assert names["source_line_option"] == "case_line"
+
+    def test_colliding_field_names_are_rejected(self, tmp_path):
+        # file (report path) and file (source path) cannot share a field.
+        _write(tmp_path, "[test_reports]\nsource_file_option = 'file'\n")
+        with pytest.raises(TomlConfigError, match="both name the need field 'file'"):
             load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
 
     def test_need_type_and_case_type_agreeing_is_fine(self, tmp_path):

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -230,6 +230,21 @@ class TestLoader:
         with pytest.raises(TomlConfigError, match="both name the need field 'file'"):
             load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
 
+    @pytest.mark.parametrize(
+        ("key", "name"),
+        [
+            ("file_option", "case"),
+            ("source_file_option", "result"),
+            ("source_line_option", "id"),
+        ],
+    )
+    def test_a_rename_onto_a_fixed_field_is_rejected(self, tmp_path, key, name):
+        # Every test-case need has these already: the directives would pass
+        # the keyword twice, the converter overwrite one value with the other.
+        _write(tmp_path, f"[test_reports]\n{key} = '{name}'\n")
+        with pytest.raises(TomlConfigError, match=f"{key} = '{name}'"):
+            load_project_config(tmp_path / DEFAULT_TOML_FILENAME)
+
     def test_need_type_and_case_type_agreeing_is_fine(self, tmp_path):
         _write(
             tmp_path,

--- a/tests/test_source_location.py
+++ b/tests/test_source_location.py
@@ -142,6 +142,24 @@ class TestFieldNameCollisionIsRejected:
         with pytest.raises(InvalidConfigurationError):
             check_field_name_collisions(config)
 
+    def test_a_rename_onto_a_fixed_field_is_an_error(self):
+        # The same failure as two options sharing a name: every test-case
+        # directive passes `case` to add_need already.
+        from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
+        from sphinxcontrib.test_reports.test_reports import check_field_name_collisions
+
+        config = self._Config(
+            tr_file_option="case",
+            tr_source_file_option="case_file",
+            tr_source_line_option="case_line",
+        )
+
+        with pytest.raises(InvalidConfigurationError) as exc:
+            check_field_name_collisions(config)
+
+        assert "tr_file_option" in str(exc.value)
+        assert "'case'" in str(exc.value)
+
     def test_distinct_names_are_accepted(self):
         from sphinxcontrib.test_reports.test_reports import check_field_name_collisions
 


### PR DESCRIPTION
Based directly on master, independent of useblocks/sphinx-test-reports#151 (pytest plugin). Both touch `docs/changelog.rst` and `docs/index.rst`, so whichever lands second needs a trivial rebase.

Restores the converter from useblocks/sphinx-test-reports#144 — merged ahead of the configuration work and reverted in useblocks/sphinx-test-reports#146 — rebuilt on top of the declarative config so it reads its settings from `ubproject.toml` from the start.

## What

`test-reports build needs FILE... --output needs.json` (named as `ubc build needs` is) turns test-result XML into a schema-conform `needs.json` **without running Sphinx**, so a build system can schedule and cache the conversion and the documentation build only imports the result.

- **No Sphinx import** anywhere in the command's import chain (asserted by a test; the lazy `setup` it relies on arrived with useblocks/sphinx-test-reports#145).
- **Byte-stable output**: sorted keys, fixed indent, no wall clock.
- **Shaped like the build's own needs.** A converted need has exactly the fields the `test-case` directive creates, with the same values in them — the title is the case name, `result` is spelled as the build spells it (`passed`, `failure`, `error`, `skipped`, `disabled`), so one filter matches imported and local cases alike — `suite`, `case`, `case_name`, `case_parameter`, `classname`, `result`, `time`, the report path under `file`, the source location under `case_file`/`case_line` — with the three renameable field names taken from the same `[test_reports]` section the build reads (`file_option`, `source_file_option`, `source_line_option`; defaults defined once, in `projectconfig.DEFAULT_FIELD_NAMES`). XML properties become fields only when listed in `extra_options` — the list that makes the build register and accept them — or added with `--extra-option` (additive; a name the file's list lacks is reported, because the build drops it on import). A listed property is written for every case, `null` where a case has none; the rest is reported once. An end-to-end test `needimport`s a converted file into a real build driven by the same `ubproject.toml` and asserts nothing is dropped.
- Deterministic case IDs, source location, synthesized source URLs (`https://`, `ssh://[:port]`, `git://` and scp-style remotes); `--link-property` promotes properties to link fields; a report given twice, or any case reported twice, is refused rather than silently collapsed. Credentials in the remote URL are stripped before it is written into the needs, and a report without a single test case is reported instead of quietly adding nothing.

## Configuration: `[test_reports.build.needs]`

The command's settings live in a table named after the command — `build` holds one table per artifact it produces — inside the shared `[test_reports]` section of `ubproject.toml` — the file the Sphinx build reads (#145) — so the two consumers of a project never work from different descriptions of it.

```toml
[test_reports]
extra_options = ["TestType", "DerivationTechnique"]

[test_reports.build.needs]
project = "My Project"
version = "2.0"
need_type = "testcase"
tags = ["ci", "unit"]
link_properties = { PartiallyVerifies = "partially_verifies" }
remote_url = "https://github.com/org/repo"
url_pattern = "{base}/blob/{commit}/{file}#L{line}"
```

- **Precedence**: flag > table > built-in default. Flags stay for per-invocation values such as `--commit "$(git rev-parse HEAD)"`.
- **Lookup** mirrors the build: `ubproject.toml` is searched for upwards from the working directory to the project root. `--config PATH` names a file explicitly; `--no-config` makes the output depend only on the arguments. The file the search finds is named on stderr on every run, since it may sit directories above and the output depends on it.
- **Validation** follows the section's policy (#145): a known key with the wrong type is fatal, an unknown key is reported and dropped, table values are checked. The **whole** section is validated, and the build validates the `build.needs` table too — one file, one verdict. `url_pattern` is checked before any report is read. A renameable field may not take a fixed field's name (`case`, `result`, ...), in the file or in `conf.py`; the renames must live in `ubproject.toml` for the converter to see them.
- **Cross-key rule**: `build.needs.need_type` and the `type` of `case` both name the need type of a test case; a side that is not set is compared at its default, and the command re-checks the *merged* value so a `--need-type` flag cannot bypass the rule.

## Review

Reviewed in this PR (comment below): 30 verified findings from the correctness pass plus a manual pass, all addressed. The CLI-side findings of the useblocks/sphinx-test-reports#145 review land here as well. Importing a converted file needs sphinx-needs ≥ 4 (older `needimport` read `description`, not `content`) — moot with useblocks/sphinx-test-reports#150's floor.

Second round — @chrisjsewell's review (five blocking, eight worth fixing, the nits) and @MaximilianSoerenPollak's questions — addressed at `d8940fc` in six commits (`423e51b..d8940fc`), each green on its own.

## Tests

162 on top of master (331 in total): `test_cli_convert.py` (conversion, `needimport` into a real build), `test_cli_config.py` (precedence, lookup, diagnostics), `test_needs_export.py` (writer and URL helpers), `test_identity.py` (the `name[param]` split), and the field-name and table validation in `test_project_config.py`.



