### PR TITLE
build: require sphinx-needs 6.0.1 and Sphinx 7.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.11", "3.12"]
         sphinx-version: ["7.4.7", "8.1.3"]
-        sphinx_needs-version: ["6.0.1", "6.3.0", "8.0.0"]
+        sphinx_needs-version: ["6.0.1", "6.3.0", "7.0.0", "8.0.0"]
     steps:
       - uses: actions/checkout@v2
       - name: Set Up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.11", "3.12"]
         sphinx-version: ["7.4.7", "8.1.3"]
-        sphinx_needs-version: ["6.0.0", "6.3.0", "8.0.0"]
+        sphinx_needs-version: ["6.0.1", "6.3.0", "8.0.0"]
     steps:
       - uses: actions/checkout@v2
       - name: Set Up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.11", "3.12"]
-        sphinx-version: ["5.0", "8.1.3"]
-        sphinx_needs-version: ["2.1", "4.2", "5.1", "6.3.0", "8.0.0"]
+        sphinx-version: ["7.4.7", "8.1.3"]
+        sphinx_needs-version: ["6.0.0", "6.3.0", "8.0.0"]
     steps:
       - uses: actions/checkout@v2
       - name: Set Up Python ${{ matrix.python-version }}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,10 @@ Unreleased
 * Support: Python 3.10 is no longer supported. It reached the end of upstream
   support, and dropping it lets the package read TOML with ``tomllib`` from the
   standard library instead of carrying a backport.
+* Support: sphinx-needs 6.0 and Sphinx 7.4 are the oldest supported versions.
+  Every sphinx-needs release since 6.0 registers need fields with a schema,
+  which this extension relies on; sphinx-needs 6 itself requires Sphinx 7.4.
+  The compatibility branches for older releases are gone.
 
 .. _`release:1.4.0`:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,10 +25,10 @@ Unreleased
 * Support: Python 3.10 is no longer supported. It reached the end of upstream
   support, and dropping it lets the package read TOML with ``tomllib`` from the
   standard library instead of carrying a backport.
-* Support: sphinx-needs 6.0 and Sphinx 7.4 are the oldest supported versions.
-  Every sphinx-needs release since 6.0 registers need fields with a schema,
-  which this extension relies on; sphinx-needs 6 itself requires Sphinx 7.4.
-  The compatibility branches for older releases are gone.
+* Support: sphinx-needs 6.0.1 and Sphinx 7.4 are the oldest supported versions.
+  6.0.1 is the first release whose ``add_extra_option`` takes a schema, which
+  this extension registers its fields with; sphinx-needs 6 itself requires
+  Sphinx 7.4. The compatibility branches for older releases are gone.
 
 .. _`release:1.4.0`:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ plantuml_output_format = "png"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates", "ub_theme/templates"]
-if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("7.0.0"):
     needs_fields = {
         "more_info": {"nullable": True},
     }

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ from nox import session
 
 PYTHON_VERSIONS = ["3.11", "3.12"]
 SPHINX_VERSIONS = ["7.4.7", "8.1.3"]
-SPHINX_NEEDS_VERSIONS = ["6.0.1", "6.3.0", "8.0.0"]
+SPHINX_NEEDS_VERSIONS = ["6.0.1", "6.3.0", "7.0.0", "8.0.0"]
 
 
 def run_tests(session, sphinx, sphinx_needs):

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ from nox import session
 
 PYTHON_VERSIONS = ["3.11", "3.12"]
 SPHINX_VERSIONS = ["7.4.7", "8.1.3"]
-SPHINX_NEEDS_VERSIONS = ["6.0.0", "6.3.0", "8.0.0"]
+SPHINX_NEEDS_VERSIONS = ["6.0.1", "6.3.0", "8.0.0"]
 
 
 def run_tests(session, sphinx, sphinx_needs):

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,8 +2,8 @@ import nox
 from nox import session
 
 PYTHON_VERSIONS = ["3.11", "3.12"]
-SPHINX_VERSIONS = ["5.0", "7.2.5", "8.1.3"]
-SPHINX_NEEDS_VERSIONS = ["2.1", "4.2", "5.1", "6.0.0", "6.3.0", "8.0.0"]
+SPHINX_VERSIONS = ["7.4.7", "8.1.3"]
+SPHINX_NEEDS_VERSIONS = ["6.0.0", "6.3.0", "8.0.0"]
 
 
 def run_tests(session, sphinx, sphinx_needs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 keywords = ["sphinx", "documentation", "test-reports"]
 requires-python = ">=3.11"
-dependencies = ["sphinx>=7.4", "lxml", "sphinx-needs>=6.0.0", "packaging>=20.0"]
+dependencies = ["sphinx>=7.4", "lxml", "sphinx-needs>=6.0.1", "packaging>=20.0"]
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 keywords = ["sphinx", "documentation", "test-reports"]
 requires-python = ">=3.11"
-dependencies = ["sphinx>4.0", "lxml", "sphinx-needs>=1.0.1", "packaging>=20.0"]
+dependencies = ["sphinx>=7.4", "lxml", "sphinx-needs>=6.0.0", "packaging>=20.0"]
 
 [project.optional-dependencies]
 test = [

--- a/sphinxcontrib/test_reports/directives/test_env.py
+++ b/sphinxcontrib/test_reports/directives/test_env.py
@@ -2,18 +2,10 @@ import copy
 import json
 import os
 
-import sphinx
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from packaging.version import Version
+from sphinx.util import logging
 
-sphinx_version = sphinx.__version__
-if Version(sphinx_version) >= Version("1.6"):
-    from sphinx.util import logging
-else:
-    import logging
-
-    logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 

--- a/sphinxcontrib/test_reports/environment.py
+++ b/sphinxcontrib/test_reports/environment.py
@@ -1,17 +1,9 @@
 import os
 
-import sphinx
-from packaging.version import Version
 from sphinx.application import Sphinx
 from sphinx.util.console import brown  # type: ignore[import-not-found]
+from sphinx.util.display import status_iterator
 from sphinx.util.osutil import copyfile, ensuredir
-
-sphinx_version = sphinx.__version__
-if Version(sphinx_version) >= Version("1.6"):
-    if Version(sphinx_version) >= Version("6.1"):
-        from sphinx.util.display import status_iterator
-    else:
-        from sphinx.util import status_iterator  # noqa: F401 # Sphinx 1.5
 
 STATICS_DIR_NAME = "_static"
 
@@ -83,10 +75,6 @@ def install_styles_static_files(app, env):
 
     # Be sure no "old" css layout is already set
     safe_remove_file("sphinx-test-reports/common.css", app)
-
-    if Version(sphinx_version) < Version("1.6"):
-        global status_iterator
-        status_iterator = app.status_iterator
 
     for source_file_path in status_iterator(
         iterable=files_to_copy,

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -2,12 +2,10 @@
 import inspect
 import os
 
-import sphinx
-import sphinx_needs
 from docutils.parsers.rst import directives
-from packaging.version import Version
 from sphinx.application import Sphinx
 from sphinx.config import Config
+from sphinx.util import logging
 
 # from docutils import nodes
 from sphinx_needs.api import add_dynamic_function, add_need_type
@@ -30,12 +28,6 @@ from sphinxcontrib.test_reports.directives.test_suite import (
 from sphinxcontrib.test_reports.environment import install_styles_static_files
 from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 from sphinxcontrib.test_reports.functions import tr_link
-
-sphinx_version = sphinx.__version__
-if Version(sphinx_version) >= Version("1.6"):
-    from sphinx.util import logging
-else:
-    import logging
 
 # fmt: on
 
@@ -269,53 +261,34 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
 
     check_field_name_collisions(config)
 
-    needs_version = Version(sphinx_needs.__version__)
-    use_schema = needs_version >= Version("6.0.0")
-
-    if use_schema:
-        _register_field(
-            app, getattr(config, "tr_file_option", "file"), schema={"type": "string"}
-        )
-        _register_field(
-            app,
-            getattr(config, "tr_source_file_option", "case_file"),
-            schema={"type": "string"},
-        )
-        _register_field(
-            app,
-            getattr(config, "tr_source_line_option", "case_line"),
-            schema={"type": "string"},
-        )
-        _register_field(app, "suite", schema={"type": "string"})
-        _register_field(app, "case", schema={"type": "string"})
-        _register_field(app, "case_name", schema={"type": "string"})
-        _register_field(app, "case_parameter", schema={"type": "string"})
-        _register_field(app, "classname", schema={"type": "string"})
-        _register_field(app, "time", schema={"type": "string"})
-        _register_field(app, "suites", schema={"type": "integer"})
-        _register_field(app, "cases", schema={"type": "integer"})
-        _register_field(app, "passed", schema={"type": "integer"})
-        _register_field(app, "skipped", schema={"type": "integer"})
-        _register_field(app, "failed", schema={"type": "integer"})
-        _register_field(app, "errors", schema={"type": "integer"})
-        _register_field(app, "result", schema={"type": "string"})
-    else:
-        _register_field(app, getattr(config, "tr_file_option", "file"))
-        _register_field(app, getattr(config, "tr_source_file_option", "case_file"))
-        _register_field(app, getattr(config, "tr_source_line_option", "case_line"))
-        _register_field(app, "suite")
-        _register_field(app, "case")
-        _register_field(app, "case_name")
-        _register_field(app, "case_parameter")
-        _register_field(app, "classname")
-        _register_field(app, "time")
-        _register_field(app, "suites")
-        _register_field(app, "cases")
-        _register_field(app, "passed")
-        _register_field(app, "skipped")
-        _register_field(app, "failed")
-        _register_field(app, "errors")
-        _register_field(app, "result")
+    # sphinx-needs >= 6 registers fields with a schema; there is no older
+    # branch to keep, the package requires that version.
+    _register_field(
+        app, getattr(config, "tr_file_option", "file"), schema={"type": "string"}
+    )
+    _register_field(
+        app,
+        getattr(config, "tr_source_file_option", "case_file"),
+        schema={"type": "string"},
+    )
+    _register_field(
+        app,
+        getattr(config, "tr_source_line_option", "case_line"),
+        schema={"type": "string"},
+    )
+    _register_field(app, "suite", schema={"type": "string"})
+    _register_field(app, "case", schema={"type": "string"})
+    _register_field(app, "case_name", schema={"type": "string"})
+    _register_field(app, "case_parameter", schema={"type": "string"})
+    _register_field(app, "classname", schema={"type": "string"})
+    _register_field(app, "time", schema={"type": "string"})
+    _register_field(app, "suites", schema={"type": "integer"})
+    _register_field(app, "cases", schema={"type": "integer"})
+    _register_field(app, "passed", schema={"type": "integer"})
+    _register_field(app, "skipped", schema={"type": "integer"})
+    _register_field(app, "failed", schema={"type": "integer"})
+    _register_field(app, "errors", schema={"type": "integer"})
+    _register_field(app, "result", schema={"type": "string"})
     # Extra dynamic functions
     # For details about usage read
     # https://sphinx-needs.readthedocs.io/en/latest/api.html#sphinx_needs.api.configuration.add_dynamic_function
@@ -325,10 +298,7 @@ def sphinx_needs_update(app: Sphinx, config: Config) -> None:
     # extracted from JUnit XML are accepted by sphinx-needs
     tr_extra_options = getattr(config, "tr_extra_options", [])
     for option_name in tr_extra_options:
-        if use_schema:
-            _register_field(app, option_name, schema={"type": "string"})
-        else:
-            _register_field(app, option_name)
+        _register_field(app, option_name, schema={"type": "string"})
 
     # Extra need types
     # For details about usage read

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -1,5 +1,4 @@
 # fmt: off
-import inspect
 import os
 
 from docutils.parsers.rst import directives
@@ -9,6 +8,7 @@ from sphinx.util import logging
 
 # from docutils import nodes
 from sphinx_needs.api import add_dynamic_function, add_need_type
+from sphinx_needs.exceptions import NeedsApiConfigWarning
 
 from sphinxcontrib.test_reports.directives.test_case import TestCase, TestCaseDirective
 from sphinxcontrib.test_reports.directives.test_env import EnvReport, EnvReportDirective
@@ -52,36 +52,34 @@ FIELD_DESCRIPTIONS = {
 }
 
 try:
+    # sphinx-needs >= 8.5: fields are registered through add_field.
     from sphinx_needs.api import add_field as _add_field
 
     def _register_field(app, name, schema=None):
         description = FIELD_DESCRIPTIONS.get(name, name)
         try:
             _add_field(name, description, schema=schema)
-        except Exception:
-            # Field already registered (e.g. via needs_fields or needs_extra_options
-            # in conf.py). Skip to avoid duplicate registration errors.
-            log = logging.getLogger(__name__)
-            log.debug(f"Field '{name}' already registered, skipping")
+        except NeedsApiConfigWarning:
+            # Already registered, e.g. via needs_fields or needs_extra_options
+            # in conf.py. Anything else is a real error and must surface.
+            logging.getLogger(__name__).debug(
+                f"Field '{name}' already registered, skipping"
+            )
 
 except ImportError:
     from sphinx_needs.api import add_extra_option as _add_extra_option
 
-    _add_extra_option_supports_description = (
-        "description" in inspect.signature(_add_extra_option).parameters
-    )
-
     def _register_field(app, name, schema=None):
-        kwargs = {}
-        if _add_extra_option_supports_description:
-            kwargs["description"] = FIELD_DESCRIPTIONS.get(name, name)
-        if schema is not None:
-            kwargs["schema"] = schema
+        # add_extra_option takes description and schema from sphinx-needs
+        # 6.0.1 on, which is the package's floor.
         try:
-            _add_extra_option(app, name, **kwargs)
-        except Exception:
-            log = logging.getLogger(__name__)
-            log.debug(f"Field '{name}' already registered, skipping")
+            _add_extra_option(
+                app, name, description=FIELD_DESCRIPTIONS.get(name, name), schema=schema
+            )
+        except NeedsApiConfigWarning:
+            logging.getLogger(__name__).debug(
+                f"Field '{name}' already registered, skipping"
+            )
 
 
 def setup(app: Sphinx):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,6 @@ from pathlib import Path
 from tempfile import mkdtemp
 
 import pytest
-from packaging.version import Version
-from sphinx import __version__ as sphinx_version
-
-if Version(sphinx_version) < Version("7.2"):
-    from sphinx.testing.path import path
-
 
 pytest_plugins = "sphinx.testing.fixtures"
 
@@ -19,11 +13,7 @@ def copy_srcdir_to_tmpdir(srcdir, tmp):
     srcdir = Path(__file__).parent.absolute() / srcdir
     tmproot = tmp / Path(srcdir).name
     shutil.copytree(srcdir, tmproot)
-    return (
-        tmproot
-        if Version(sphinx_version) >= Version("7.2")
-        else path(tmproot.absolute())
-    )
+    return tmproot
 
 
 @pytest.fixture(scope="function")

--- a/tests/doc_test/basic_doc/conf.py
+++ b/tests/doc_test/basic_doc/conf.py
@@ -72,7 +72,7 @@ language = "en"
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("7.0.0"):
     needs_fields = {"more_info": {"nullable": True}}
 else:
     needs_extra_options = ["more_info"]

--- a/tests/doc_test/doc_test_ctest_file/conf.py
+++ b/tests/doc_test/doc_test_ctest_file/conf.py
@@ -78,7 +78,7 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("7.0.0"):
     needs_fields = {
         "asil": {"nullable": True},
         "uses_secure": {"nullable": True},

--- a/tests/doc_test/doc_test_file/conf.py
+++ b/tests/doc_test/doc_test_file/conf.py
@@ -78,7 +78,7 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("7.0.0"):
     needs_fields = {
         "asil": {"nullable": True},
         "uses_secure": {"nullable": True},

--- a/tests/doc_test/json_parser_custom/conf.py
+++ b/tests/doc_test/json_parser_custom/conf.py
@@ -35,7 +35,7 @@ sys.path.insert(0, os.path.abspath("../../sphinxcontrib"))
 
 extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
 
-if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("7.0.0"):
     needs_fields = {"priority": {"nullable": True}}
 else:
     needs_extra_options = ["priority"]

--- a/tests/doc_test/many_testsuites_doc/conf.py
+++ b/tests/doc_test/many_testsuites_doc/conf.py
@@ -40,7 +40,7 @@ tr_case_id_length = 10
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("7.0.0"):
     needs_fields = {"more_info": {"nullable": True}}
 else:
     needs_extra_options = ["more_info"]

--- a/tests/doc_test/needs_linking/conf.py
+++ b/tests/doc_test/needs_linking/conf.py
@@ -78,7 +78,7 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("7.0.0"):
     needs_fields = {
         "asil": {"nullable": True},
         "uses_secure": {"nullable": True},

--- a/tests/doc_test/properties_linking/conf.py
+++ b/tests/doc_test/properties_linking/conf.py
@@ -31,7 +31,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_theme = "alabaster"
 
 # Register "verifies" as both a sphinx-needs field and a tr_extra_option
-if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("7.0.0"):
     needs_fields = {
         "verifies": {"nullable": True},
         "priority": {"nullable": True},

--- a/tests/doc_test/testsuites_doc/conf.py
+++ b/tests/doc_test/testsuites_doc/conf.py
@@ -37,7 +37,7 @@ extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
-if Version(sphinx_needs.__version__) >= Version("8.0.0"):
+if Version(sphinx_needs.__version__) >= Version("7.0.0"):
     needs_fields = {"more_info": {"nullable": True}}
 else:
     needs_extra_options = ["more_info"]

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -19,18 +19,8 @@ import json
 from pathlib import Path
 
 import pytest
-import sphinx_needs
-from packaging.version import Version
-
-# The needs_schema_definitions / schema-validation feature was introduced in
-# sphinx-needs 6.0.0; skip on older versions that do not support it.
-SN_SUPPORTS_SCHEMAS = Version(sphinx_needs.__version__) >= Version("6.0.0")
 
 
-@pytest.mark.skipif(
-    not SN_SUPPORTS_SCHEMAS,
-    reason="needs_schema_definitions requires sphinx-needs>=6.0.0",
-)
 @pytest.mark.parametrize(
     "test_app",
     [{"buildername": "html", "srcdir": "doc_test/schema_strictness"}],
@@ -60,10 +50,6 @@ def test_strict_schema_ignores_unpopulated_test_report_fields(test_app):
     )
 
 
-@pytest.mark.skipif(
-    not SN_SUPPORTS_SCHEMAS,
-    reason="needs_schema_definitions requires sphinx-needs>=6.0.0",
-)
 @pytest.mark.parametrize(
     "test_app",
     [{"buildername": "html", "srcdir": "doc_test/schema_strictness_status"}],


### PR DESCRIPTION
Follows #147 (Python 3.11, merged). Split out so the version floors can be reviewed on their own;the declarative-config, plugin and converter PRs are rebased onto it and lose their remaining compatibility branches.

## Why

The package now requires Python 3.11. sphinx-needs raised its own floor to  ​3.10 with  ​6.0 (#1468 dropped 3.9) and requires Sphinx 7.4 from that release on. The versions this package still carried compatibility branches for — sphinx-needs 2.x to  ​5.x, Sphinx below  ​6.1 — are ones it no longer shares an interpreter range with in practice,and​ ​6.x is where field registration with a schema begins, which is what the extension relies on.



The exact floor is **6.0.1**:that is the first release whose `add_extra_option` takes `schema=` (sphinx-needs #1527). On 6.0.0 the call raised `TypeError`, which `_register_field` swallowed under a catch-all meant for "already registered" — so no field was registered and every directive failed with `InvalidNeedException`. The first CI run of this PR caught exactly that on the 6.0.0 cells.



## Changes

- `sphinx-needs>=6.0.1` and `sphinx>=7.4` (the floor sphinx-needs 6 implies anyway)
- nox and CI matrices: sphinx-needs 6.0.1 /​  ​6.3.0 /​  ​7.0.0 /​  ​8.0.0 × Sphinx  ​7.4.7 /​  ​8.1.3 (the Sphinx 5.0 cells could not have installed sphinx-needs 6)
- `sphinx_needs_update` registers fields with a schema unconditionally;the no-schema branch is gone
- `_register_field` catches only `NeedsApiConfigWarning` (a duplicate registration) instead of every exception,and no longer inspects `add_extra_option`'s signature
- the Sphinx version switches around `logging`, `status_iterator` and the test fixtures' path type are gone
- the `needs_schema_definitions` tests no longer skip
- the test fixtures' confs now switch to `needs_fields` at sphinx-needs 7.0.0 instead of 8..0.0:7.0.0 is where `needs_fields` was introduced and `needs_extra_options` deprecated (sphinx-needs #1611), so on  ​7.x the old option emits a `[needs.deprecated]` warning, which `test_test_file_needs_extra_options_no_warning` caught. Schema-based registration works since  ​6.0.1, so this only changes the 7.x path — no behaviour change for  ​6.x or​ ​ 8.x.



No behaviour change for any supported version. 110 tests pass on each of: sphinx-needs  ​6.​0.1 / Sphinx  ​7.4.7,​  ​7.0.0 / Sphinx  ​7.4.7,and​  ​7.0.0 / Sphinx  ​8.1.3;also verified on  ​8.5.0 / Sphinx  ​9.1.