### PR TITLE
feat(pytest): plugin writing the XML shape this extension reads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,28 @@ jobs:
       - name: Run Tests
         run: nox --non-interactive --session "tests-${{ matrix.python-version }}(sphinx='${{ matrix.sphinx-version }}', sphinx_needs='${{ matrix.sphinx_needs-version }}')" -- --full-trace
 
+  plugin-floor:
+    name: "Plugin (python: ${{ matrix.python-version }}, pytest: ${{ matrix.pytest-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - python-version: "3.11"
+            pytest-version: "7.0.1"
+          - python-version: "3.12"
+            pytest-version: "7.3.2"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Nox Dependencies
+        run: |
+          python -m pip install poetry nox nox-poetry
+      - name: Run the plugin's tests on the oldest supported pytest
+        run: nox --non-interactive --session "plugin_floor(python='${{ matrix.python-version }}', pytest_version='${{ matrix.pytest-version }}')" -- --full-trace
+
   pre-commit:
     name: pre-commit
     runs-on: ubuntu-latest
@@ -76,6 +98,7 @@ jobs:
 
     needs:
       - tests
+      - plugin-floor
       - pre-commit
       - mypy
       - linkcheck

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,10 +41,12 @@ Unreleased
   Sphinx build with the extension loaded. The declarations and the fields the
   extension registers come from one table, so the two cannot drift apart.
 * Feature: A pytest plugin (``-p sphinxcontrib.test_reports.pytest_plugin``)
-  writes the ``file``/``line`` attributes that give a test case its source
-  location, and requirement-link ``<properties>`` from an
-  ``add_test_properties`` decorator or an ``apply_test_metadata`` runtime
-  helper. Which properties exist, their XML names and which take lists is the
+  gives every test case the source location an editor shows -- pytest's
+  ``file``/``line`` counted from 1, Bazel's runfiles prefix cut, a runtime
+  override for file-driven tests -- and requirement-link ``<properties>`` from
+  an ``add_test_properties`` decorator or an ``apply_test_metadata`` runtime
+  helper, for cases skipped at setup and under pytest-xdist too. Which
+  properties exist, their XML names and which take lists is the
   ``test_reports_properties`` pytest ini option; S-CORE's model, which the
   plugin was ported from, is the documented example. See :ref:`pytest_plugin`.
 * Bugfix: ``tr_file_option``, ``tr_source_file_option`` and

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,7 +44,8 @@ Unreleased
   writes the ``file``/``line`` attributes that give a test case its source
   location, and requirement-link ``<properties>`` from an
   ``add_test_properties`` decorator or an ``apply_test_metadata`` runtime
-  helper, ported from S-CORE's docs-as-code. See :ref:`pytest_plugin`.
+  helper, ported from S-CORE's docs-as-code; ``register_property`` adds the
+  link fields of other metamodels. See :ref:`pytest_plugin`.
 * Bugfix: ``tr_file_option``, ``tr_source_file_option`` and
   ``tr_source_line_option`` may no longer name a fixed field such as ``case``
   or ``result``, in ``conf.py`` or in the declarative file. The build

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,8 +44,9 @@ Unreleased
   writes the ``file``/``line`` attributes that give a test case its source
   location, and requirement-link ``<properties>`` from an
   ``add_test_properties`` decorator or an ``apply_test_metadata`` runtime
-  helper, ported from S-CORE's docs-as-code; ``register_property`` adds the
-  link fields of other metamodels. See :ref:`pytest_plugin`.
+  helper. Which properties exist, their XML names and which take lists is the
+  ``test_reports_properties`` pytest ini option; S-CORE's model, which the
+  plugin was ported from, is the documented example. See :ref:`pytest_plugin`.
 * Bugfix: ``tr_file_option``, ``tr_source_file_option`` and
   ``tr_source_line_option`` may no longer name a fixed field such as ``case``
   or ``result``, in ``conf.py`` or in the declarative file. The build

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,11 @@ Unreleased
   consumer can read the type of a field from the artifact instead of from a
   Sphinx build with the extension loaded. The declarations and the fields the
   extension registers come from one table, so the two cannot drift apart.
+* Feature: A pytest plugin (``-p sphinxcontrib.test_reports.pytest_plugin``)
+  writes the ``file``/``line`` attributes that give a test case its source
+  location, and requirement-link ``<properties>`` from an
+  ``add_test_properties`` decorator or an ``apply_test_metadata`` runtime
+  helper, ported from S-CORE's docs-as-code. See :ref:`pytest_plugin`.
 * Bugfix: ``tr_file_option``, ``tr_source_file_option`` and
   ``tr_source_line_option`` may no longer name a fixed field such as ``case``
   or ``result``, in ``conf.py`` or in the declarative file. The build

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,6 +76,7 @@ Content
    directives/index
    configuration
    cli
+   pytest
    parsers
    filter
    functions

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -11,6 +11,10 @@ the deterministic ID of ``tr_deterministic_case_ids``), and nothing records the
 requirements a test verifies. ``Sphinx-Test-Reports`` ships a small pytest
 plugin that writes both.
 
+The plugin is generic: which properties exist, what they are called in the XML
+and whether they take a list is pytest configuration, not code. S-CORE's model
+is the worked example below.
+
 Enabling it
 -----------
 
@@ -43,8 +47,90 @@ clean usage error instead;
 silences them. pytest's own notice that ``record_xml_attribute`` is experimental
 is dropped by the plugin, whatever the warning policy.
 
+Declaring the properties
+------------------------
+
+The ``test_reports_properties`` ini option declares the properties a test may
+carry, one per line:
+
+.. code-block:: text
+
+   keyword [= XmlName] [, list]
+
+*keyword*
+   what a test author writes -- the argument of ``add_test_properties`` or the
+   key in the metadata of ``apply_test_metadata``.
+*XmlName*
+   the ``<property name="...">`` written to the report. Leave it out when it
+   equals the keyword.
+``list``
+   marks a multi-valued property: a list is written joined with ``", "`` -- the
+   shape ``tr_property_link_types`` splits again -- and a bare string counts as
+   one value. Without it the property takes exactly one value, and a list is a
+   ``TypeError`` rather than a silent join.
+
+A keyword that is not declared is written under its own name with a single
+value. A list under it is a ``TypeError`` whose message names the option, so a
+project cannot lose requirement IDs to a Python ``repr`` silently. A line
+outside the grammar stops the run at start-up with a usage error that quotes
+it.
+
+**Example: S-CORE.** The model of S-CORE's docs-as-code, whose ``score_pytest``
+plugin this one was ported from:
+
+.. code-block:: ini
+
+   # pytest.ini
+   [pytest]
+   addopts = -p sphinxcontrib.test_reports.pytest_plugin
+   junit_family = xunit1
+   test_reports_properties =
+       partially_verifies = PartiallyVerifies, list
+       fully_verifies = FullyVerifies, list
+       test_type = TestType
+       derivation_technique = DerivationTechnique
+
+.. code-block:: toml
+
+   # pyproject.toml
+   [tool.pytest.ini_options]
+   addopts = "-p sphinxcontrib.test_reports.pytest_plugin"
+   junit_family = "xunit1"
+   test_reports_properties = [
+       "partially_verifies = PartiallyVerifies, list",
+       "fully_verifies = FullyVerifies, list",
+       "test_type = TestType",
+       "derivation_technique = DerivationTechnique",
+   ]
+
+With it, tests written against ``score_pytest`` keep working when they import
+``add_test_properties`` and ``apply_test_metadata`` from here. The values of
+``test_type`` and ``derivation_technique`` are the identifiers of S-CORE's
+verification methods and derivation techniques, from its
+`verification concept <https://eclipse-score.github.io/process_description/main/process_areas/verification/verification_concept.html#verification-concept-types-methods>`_:
+
+.. list-table::
+   :header-rows: 1
+
+   * - ``TestType``
+     - ``DerivationTechnique``
+   * - ``control-flow-analysis``, ``data-flow-analysis``, ``fault-injection``,
+       ``inspection``, ``interface-test``, ``requirements-based``,
+       ``resource-usage``, ``static-code-analysis``,
+       ``structural-statement-coverage``, ``structural-branch-coverage``,
+       ``walkthrough``
+     - ``requirements-analysis``, ``design-analysis``, ``boundary-values``,
+       ``equivalence-classes``, ``fuzz-testing``, ``error-guessing``,
+       ``explorative-testing``
+
+They are documented here, not enforced by the plugin: S-CORE's own metamodel
+accepts any string for both fields, and a project with a different metamodel
+writes its own values.
+
 Linking a test to requirements
 ------------------------------
+
+With the S-CORE model declared:
 
 .. code-block:: python
 
@@ -69,32 +155,16 @@ writes, on that test's ``<testcase>``:
      <property name="DerivationTechnique" value="requirements-analysis"/>
    </properties>
 
-``fully_verifies`` writes ``FullyVerifies`` the same way. How a value is written
-is declared per property, not guessed from the value:
+The declared XML name doubles as keyword, so ``PartiallyVerifies=[...]`` is
+accepted too. Empty values are not written, and a decorator that would write
+nothing is an error at import time. The values are written when the test is
+set up, against the declared model; a wrong shape -- a list where one value is
+expected -- fails that test with the ``TypeError`` above.
 
-* ``partially_verifies`` and ``fully_verifies`` are multi-valued: a list is
-  joined with ``", "`` -- the shape ``tr_property_link_types`` splits again --
-  and a bare string is one ID (``partially_verifies="REQ_1"`` writes ``REQ_1``,
-  not five one-letter IDs).
-* ``test_type`` and ``derivation_technique`` are single-valued; a list is a
-  ``TypeError``, not a silent join.
-* Any further keyword argument is written under its own name with a single
-  value (``Owner="team-a"`` writes ``Owner``). A list under a keyword the plugin
-  does not know is a ``TypeError``: register the keyword first, see below.
-
-Empty values are not written, and a decorator that would write nothing is an
-error. The decorator also goes on a class, and decorators stack: a
-classification on the class and the requirement links on each method are merged
-into the method's ``<properties>``, the decorator closest to the function
-winning where two set the same property.
-
-The property names are the ones S-CORE's metamodel spells, and the values of
-``test_type`` and ``derivation_technique`` are the identifiers of its
-verification methods and derivation techniques (``TEST_TYPES`` and
-``DERIVATION_TECHNIQUES`` in the plugin module list them, following the
-`verification concept <https://eclipse-score.github.io/process_description/main/process_areas/verification/verification_concept.html#verification-concept-types-methods>`_).
-They are documented, not enforced: a project with a different metamodel writes
-its own values.
+The decorator also goes on a class, and decorators stack: a classification on
+the class and the requirement links on each method are merged into the method's
+``<properties>``, the decorator closest to the function winning where two set
+the same property.
 
 On the build side the properties arrive through the directives' property
 handling: ``tr_property_link_types`` turns a comma-separated property into a
@@ -114,25 +184,6 @@ link field, and the link field has to exist as a sphinx-needs link type --
 ``needs_extra_options`` entry in turn. A link field missing from
 ``needs_extra_links`` fails the build on the first test case that carries the
 property. The same names work for any other consumer of the report.
-
-Properties of your own metamodel
---------------------------------
-
-The four keywords above are S-CORE's. A project with other link fields registers
-them once, before the tests are collected -- ``conftest.py`` is the place:
-
-.. code-block:: python
-
-   # conftest.py
-   from sphinxcontrib.test_reports.pytest_plugin import register_property
-
-   register_property("satisfies", "Satisfies", multi=True)
-
-``@add_test_properties(satisfies=["REQ_1", "REQ_2"])`` then writes
-``<property name="Satisfies" value="REQ_1, REQ_2"/>``, ready for
-``tr_property_link_types = {"Satisfies": "satisfies"}`` on the build side.
-Without ``multi=True`` the property takes a single value, like ``test_type``.
-The XML name doubles as keyword, so ``PartiallyVerifies=[...]`` is accepted too.
 
 Metadata known only at run time
 -------------------------------
@@ -167,10 +218,10 @@ Origin
 ------
 
 The plugin is a port of the ``score_pytest`` attribute plugin of S-CORE's
-`docs-as-code <https://github.com/eclipse-score/docs-as-code>`_, producing the
-same XML, so tests written against that plugin keep working when they import
-``add_test_properties`` and ``apply_test_metadata`` from here. Two of its rules
-are not ported, because they are that project's process rules rather than
-properties of the data: the ``test_type`` and ``derivation_technique``
-vocabularies are documented (``TEST_TYPES``, ``DERIVATION_TECHNIQUES``) but not
-enforced, and a decorated test is not required to carry a docstring.
+`docs-as-code <https://github.com/eclipse-score/docs-as-code>`_. What that
+plugin hard-codes -- the four properties and their spelling -- is the
+``test_reports_properties`` example above here, so the XML comes out the same
+and other metamodels declare their own. Two of its rules are not ported,
+because they are that project's process rules rather than properties of the
+data: the ``test_type`` and ``derivation_technique`` vocabularies are documented
+but not enforced, and a decorated test is not required to carry a docstring.

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -4,12 +4,15 @@ pytest plugin
 =============
 .. versionadded:: 1.5.0
 
-A stock pytest run writes a JUnit XML that this extension can only partly use:
-no ``<testcase>`` carries the ``file``/``line`` attributes that give a test case
-its source location (``tr_source_file_option``/``tr_source_line_option``, and
-the deterministic ID of ``tr_deterministic_case_ids``), and nothing records the
-requirements a test verifies. ``Sphinx-Test-Reports`` ships a small pytest
-plugin that writes both.
+A stock pytest run writes a JUnit XML that this extension can only partly use.
+Under pytest's default ``junit_family = xunit2`` no ``<testcase>`` carries the
+``file``/``line`` attributes that give a test case its source location
+(``tr_source_file_option``/``tr_source_line_option``, and the deterministic ID
+of ``tr_deterministic_case_ids``). Under ``xunit1`` pytest writes them, but
+counts the line from 0, keeps Bazel's runfiles prefix, and has no way to point
+a case at the file that drove it. And nothing records the requirements a test
+verifies. ``Sphinx-Test-Reports`` ships a small pytest plugin that takes care
+of both.
 
 The plugin is generic: which properties exist, what they are called in the XML
 and whether they take a list is pytest configuration, not code. S-CORE's model
@@ -27,25 +30,22 @@ Enabling it
 then run with ``--junitxml=report.xml`` as usual. ``junit_family = xunit1`` is
 required: pytest writes ``<testcase>`` attributes only under that family (its
 ``legacy`` is an alias), and the plugin warns at start-up when a report is
-requested under ``xunit2``. Every test case now carries ``file`` and ``line`` --
-the path is relative to the pytest rootdir, and Bazel's ``_main/`` runfiles
-prefix is cut off.
+requested under ``xunit2``. Every test case now carries ``file`` and ``line``
+as an editor shows them: the line counted from 1, the path relative to the
+pytest rootdir with Bazel's ``_main/`` runfiles prefix cut off. Every case
+means every case -- one skipped or erroring during setup gets the same
+treatment, so a deterministic ID does not move with the outcome. The plugin
+works through hooks on the test reports, not fixtures, which is also why it
+holds under pytest-xdist: the location is written on the controller, where
+pytest keeps the XML writer, and the properties travel with the reports.
 
 Nothing else changes for tests that do not use the decorator below.
 
-.. note::
-
-   pytest builds the XML writer on the controller only, so under pytest-xdist
-   (``-n``) the workers cannot record the location: the test cases then carry
-   pytest's stock ``file``/``line`` (counted from 0), silently. The plugin warns
-   at start-up; write the report in a run without ``-n``.
-
-Both start-up notices are a ``TestReportsConfigWarning``. A project that turns
-warnings into errors (``filterwarnings = error``, ``-W error``) gets them as a
+The start-up notice is a ``TestReportsConfigWarning``. A project that turns
+warnings into errors (``filterwarnings = error``, ``-W error``) gets it as a
 clean usage error instead;
 ``ignore::sphinxcontrib.test_reports.pytest_plugin.TestReportsConfigWarning``
-silences them. pytest's own notice that ``record_xml_attribute`` is experimental
-is dropped by the plugin, whatever the warning policy.
+silences it.
 
 Declaring the properties
 ------------------------
@@ -71,9 +71,17 @@ carry, one per line:
 
 A keyword that is not declared is written under its own name with a single
 value. A list under it is a ``TypeError`` whose message names the option, so a
-project cannot lose requirement IDs to a Python ``repr`` silently. A line
-outside the grammar stops the run at start-up with a usage error that quotes
-it.
+project cannot lose requirement IDs to a Python ``repr`` silently. For the same
+reason every item of a list has to be a string: a nested list, ``bytes`` or any
+other object is a ``TypeError`` naming the item. Values are joined with a comma
+and split on it again on the build side, and there is no escaping, so a value
+of a ``list`` property must not contain a comma. A line outside the grammar, or
+two keywords declaring the same XML name, stops the run at start-up with a usage
+error that quotes the line.
+
+The option exists only while the plugin is loaded: an ini file that declares
+``test_reports_properties`` without the ``-p`` line above fails
+``--strict-config`` with an unknown option. The two belong together.
 
 **Example: S-CORE.** The model of S-CORE's docs-as-code, whose ``score_pytest``
 plugin this one was ported from:
@@ -156,10 +164,13 @@ writes, on that test's ``<testcase>``:
    </properties>
 
 The declared XML name doubles as keyword, so ``PartiallyVerifies=[...]`` is
-accepted too. Empty values are not written, and a decorator that would write
+accepted too; a keyword declared as such wins over an XML name of the same
+spelling. Empty values are not written, and a decorator that would write
 nothing is an error at import time. The values are written when the test is
 set up, against the declared model; a wrong shape -- a list where one value is
-expected -- fails that test with the ``TypeError`` above.
+expected -- makes that test error at setup with the ``TypeError`` above (its
+need then carries the result ``error``, not ``failure``). The properties keep
+the order of the keywords.
 
 The decorator also goes on a class, and decorators stack: a classification on
 the class and the requirement links on each method are merged into the method's
@@ -168,22 +179,26 @@ the same property.
 
 On the build side the properties arrive through the directives' property
 handling: ``tr_property_link_types`` turns a comma-separated property into a
-link field, and the link field has to exist as a sphinx-needs link type --
+link field, and the link field has to exist as a sphinx-needs link type;
+``tr_extra_options`` lists the properties that become plain fields, each of
+which has to exist as a need field --
 
 .. code-block:: python
 
-   # conf.py
-   needs_extra_links = [
-       {"option": "partially_verifies", "incoming": "partially verified by", "outgoing": "partially verifies"},
-       {"option": "fully_verifies", "incoming": "fully verified by", "outgoing": "fully verifies"},
-   ]
+   # conf.py, sphinx-needs 7 and later
+   needs_links = {
+       "partially_verifies": {"incoming": "partially verified by", "outgoing": "partially verifies"},
+       "fully_verifies": {"incoming": "fully verified by", "outgoing": "fully verifies"},
+   }
+   needs_fields = {"TestType": {"nullable": True}, "DerivationTechnique": {"nullable": True}}
    tr_property_link_types = {"PartiallyVerifies": "partially_verifies", "FullyVerifies": "fully_verifies"}
+   tr_extra_options = ["TestType", "DerivationTechnique"]
 
--- and ``tr_extra_options`` lists the properties that become plain fields
-(``TestType``, ``DerivationTechnique``, ...), each of which needs its
-``needs_extra_options`` entry in turn. A link field missing from
-``needs_extra_links`` fails the build on the first test case that carries the
-property. The same names work for any other consumer of the report.
+On sphinx-needs 6 the two registrations are ``needs_extra_links`` (a list of
+dicts with an ``option`` key) and ``needs_extra_options`` (a list of names);
+sphinx-needs 7 deprecated both in favour of the spelling above. A link field
+missing from ``needs_links`` fails the build on the first test case that carries
+the property. The same names work for any other consumer of the report.
 
 Metadata known only at run time
 -------------------------------
@@ -198,12 +213,11 @@ of at the test function:
    from sphinxcontrib.test_reports.pytest_plugin import apply_test_metadata
 
    @pytest.mark.parametrize("spec", SPECS)
-   def test_spec(spec, record_property, record_xml_attribute):
+   def test_spec(spec, record_property):
        metadata = read_metadata(spec)   # {"fully_verifies": [...], "test_type": ...}
        apply_test_metadata(
            record_property=record_property,
            metadata=metadata,
-           record_xml_attribute=record_xml_attribute,
            file=str(spec),
            line=metadata_line(spec),
        )
@@ -212,7 +226,10 @@ of at the test function:
 Call it before the first assertion, so a failing test still carries its
 metadata. Metadata without values -- a file with an empty metadata block --
 writes no properties and is not an error; ``file`` and ``line`` are applied
-regardless.
+regardless, and hold under pytest-xdist, since they travel with the test report
+to where the XML is written. ``file`` is cut like every other location. Calls
+written against ``score_pytest`` may keep passing ``record_xml_attribute``; it
+is accepted and not needed.
 
 Origin
 ------
@@ -220,8 +237,14 @@ Origin
 The plugin is a port of the ``score_pytest`` attribute plugin of S-CORE's
 `docs-as-code <https://github.com/eclipse-score/docs-as-code>`_. What that
 plugin hard-codes -- the four properties and their spelling -- is the
-``test_reports_properties`` example above here, so the XML comes out the same
-and other metamodels declare their own. Two of its rules are not ported,
-because they are that project's process rules rather than properties of the
-data: the ``test_type`` and ``derivation_technique`` vocabularies are documented
-but not enforced, and a decorated test is not required to carry a docstring.
+``test_reports_properties`` example above here, and other metamodels declare
+their own. With that example the XML comes out the same, with four exceptions:
+a case skipped or erroring at setup carries its location and properties here
+and pytest's stock values there; the properties keep the order of the keywords
+rather than a fixed one; the Bazel prefix is cut at a whole ``_main`` component
+only, not wherever the text ``_main/`` occurs; and a ``file`` handed to
+``apply_test_metadata`` is cut the same way rather than passed through. Two of
+that plugin's rules are not ported, because they are process rules of that
+project rather than properties of the data: the ``test_type`` and
+``derivation_technique`` vocabularies are documented but not enforced, and a
+decorated test is not required to carry a docstring.

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -54,10 +54,21 @@ writes, on that test's ``<testcase>``:
      <property name="DerivationTechnique" value="requirements-analysis"/>
    </properties>
 
-``fully_verifies`` writes ``FullyVerifies`` the same way. Any further keyword
-argument becomes a property under its own name, for metamodels with fields the
-plugin does not know (``Owner="team-a"`` writes ``Owner``). Empty values are not
-written, and a decorator that would write nothing is an error.
+``fully_verifies`` writes ``FullyVerifies`` the same way. How a value is written
+is declared per property, not guessed from the value:
+
+* ``partially_verifies`` and ``fully_verifies`` are multi-valued: a list is
+  joined with ``", "`` -- the shape ``tr_property_link_types`` splits again --
+  and a bare string is one ID (``partially_verifies="REQ_1"`` writes ``REQ_1``,
+  not five one-letter IDs).
+* ``test_type`` and ``derivation_technique`` are single-valued; a list is a
+  ``TypeError``, not a silent join.
+* Any further keyword argument is written under its own name with a single
+  value (``Owner="team-a"`` writes ``Owner``). A list under a keyword the plugin
+  does not know is a ``TypeError``: register the keyword first, see below.
+
+Empty values are not written, and a decorator that would write nothing is an
+error.
 
 The property names are the ones S-CORE's metamodel spells. On the build side
 they arrive through the directives' property handling: ``tr_property_link_types``
@@ -70,6 +81,25 @@ turns a comma-separated property into a link field --
 -- and ``tr_extra_options`` lists the properties that become plain fields
 (``TestType``, ``DerivationTechnique``, ...). The same names work for any other
 consumer of the report.
+
+Properties of your own metamodel
+--------------------------------
+
+The four keywords above are S-CORE's. A project with other link fields registers
+them once, before the tests are collected -- ``conftest.py`` is the place:
+
+.. code-block:: python
+
+   # conftest.py
+   from sphinxcontrib.test_reports.pytest_plugin import register_property
+
+   register_property("satisfies", "Satisfies", multi=True)
+
+``@add_test_properties(satisfies=["REQ_1", "REQ_2"])`` then writes
+``<property name="Satisfies" value="REQ_1, REQ_2"/>``, ready for
+``tr_property_link_types = {"Satisfies": "satisfies"}`` on the build side.
+Without ``multi=True`` the property takes a single value, like ``test_type``.
+The XML name doubles as keyword, so ``PartiallyVerifies=[...]`` is accepted too.
 
 Metadata known only at run time
 -------------------------------
@@ -96,7 +126,9 @@ of at the test function:
        ...  # the actual checks
 
 Call it before the first assertion, so a failing test still carries its
-metadata.
+metadata. Metadata without values -- a file with an empty metadata block --
+writes no properties and is not an error; ``file`` and ``line`` are applied
+regardless.
 
 Origin
 ------

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -68,7 +68,10 @@ is declared per property, not guessed from the value:
   does not know is a ``TypeError``: register the keyword first, see below.
 
 Empty values are not written, and a decorator that would write nothing is an
-error.
+error. The decorator also goes on a class, and decorators stack: a
+classification on the class and the requirement links on each method are merged
+into the method's ``<properties>``, the decorator closest to the function
+winning where two set the same property.
 
 The property names are the ones S-CORE's metamodel spells. On the build side
 they arrive through the directives' property handling: ``tr_property_link_types``

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -88,17 +88,32 @@ classification on the class and the requirement links on each method are merged
 into the method's ``<properties>``, the decorator closest to the function
 winning where two set the same property.
 
-The property names are the ones S-CORE's metamodel spells. On the build side
-they arrive through the directives' property handling: ``tr_property_link_types``
-turns a comma-separated property into a link field --
+The property names are the ones S-CORE's metamodel spells, and the values of
+``test_type`` and ``derivation_technique`` are the identifiers of its
+verification methods and derivation techniques (``TEST_TYPES`` and
+``DERIVATION_TECHNIQUES`` in the plugin module list them, following the
+`verification concept <https://eclipse-score.github.io/process_description/main/process_areas/verification/verification_concept.html#verification-concept-types-methods>`_).
+They are documented, not enforced: a project with a different metamodel writes
+its own values.
+
+On the build side the properties arrive through the directives' property
+handling: ``tr_property_link_types`` turns a comma-separated property into a
+link field, and the link field has to exist as a sphinx-needs link type --
 
 .. code-block:: python
 
+   # conf.py
+   needs_extra_links = [
+       {"option": "partially_verifies", "incoming": "partially verified by", "outgoing": "partially verifies"},
+       {"option": "fully_verifies", "incoming": "fully verified by", "outgoing": "fully verifies"},
+   ]
    tr_property_link_types = {"PartiallyVerifies": "partially_verifies", "FullyVerifies": "fully_verifies"}
 
 -- and ``tr_extra_options`` lists the properties that become plain fields
-(``TestType``, ``DerivationTechnique``, ...). The same names work for any other
-consumer of the report.
+(``TestType``, ``DerivationTechnique``, ...), each of which needs its
+``needs_extra_options`` entry in turn. A link field missing from
+``needs_extra_links`` fails the build on the first test case that carries the
+property. The same names work for any other consumer of the report.
 
 Properties of your own metamodel
 --------------------------------

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -21,12 +21,27 @@ Enabling it
    junit_family = xunit1
 
 then run with ``--junitxml=report.xml`` as usual. ``junit_family = xunit1`` is
-required: pytest writes ``<testcase>`` attributes only under that family, and the
-plugin warns at start-up when a report is requested under ``xunit2``. Every test
-case now carries ``file`` and ``line`` -- the path is relative to the pytest
-rootdir, and Bazel's ``_main/`` runfiles prefix is cut off.
+required: pytest writes ``<testcase>`` attributes only under that family (its
+``legacy`` is an alias), and the plugin warns at start-up when a report is
+requested under ``xunit2``. Every test case now carries ``file`` and ``line`` --
+the path is relative to the pytest rootdir, and Bazel's ``_main/`` runfiles
+prefix is cut off.
 
 Nothing else changes for tests that do not use the decorator below.
+
+.. note::
+
+   pytest builds the XML writer on the controller only, so under pytest-xdist
+   (``-n``) the workers cannot record the location: the test cases then carry
+   pytest's stock ``file``/``line`` (counted from 0), silently. The plugin warns
+   at start-up; write the report in a run without ``-n``.
+
+Both start-up notices are a ``TestReportsConfigWarning``. A project that turns
+warnings into errors (``filterwarnings = error``, ``-W error``) gets them as a
+clean usage error instead;
+``ignore::sphinxcontrib.test_reports.pytest_plugin.TestReportsConfigWarning``
+silences them. pytest's own notice that ``record_xml_attribute`` is experimental
+is dropped by the plugin, whatever the warning policy.
 
 Linking a test to requirements
 ------------------------------

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -177,6 +177,12 @@ the class and the requirement links on each method are merged into the method's
 ``<properties>``, the decorator closest to the function winning where two set
 the same property.
 
+A skipped test carries its properties too, so its requirement links are in the
+report next to ``result="skipped"``. The plugin records the link; what the link
+means is the project's rule to make. A traceability query that reads "verified"
+off a link has to look at ``result`` as well, or a test that never ran counts as
+verification.
+
 On the build side the properties arrive through the directives' property
 handling: ``tr_property_link_types`` turns a comma-separated property into a
 link field, and the link field has to exist as a sphinx-needs link type;
@@ -224,12 +230,25 @@ of at the test function:
        ...  # the actual checks
 
 Call it before the first assertion, so a failing test still carries its
-metadata. Metadata without values -- a file with an empty metadata block --
-writes no properties and is not an error; ``file`` and ``line`` are applied
-regardless, and hold under pytest-xdist, since they travel with the test report
-to where the XML is written. ``file`` is cut like every other location. Calls
-written against ``score_pytest`` may keep passing ``record_xml_attribute``; it
-is accepted and not needed.
+metadata. Metadata without values -- a file with an empty metadata block, a
+parser handing back ``""`` or ``[]`` for an absent field -- writes no properties
+and is not an error; ``file`` and ``line`` are applied regardless. ``file`` is
+cut like every other location.
+
+The override travels with the test report to where the XML is written, so it
+holds under pytest-xdist: as two ``user_properties`` entries named
+``sphinxcontrib.test_reports:file`` and ``sphinxcontrib.test_reports:line``,
+which the plugin takes out again before the properties are written. Those two
+names are reserved -- a property recorded under either is read as a location
+override, not written as a property.
+
+Calls written against ``score_pytest`` may keep passing ``record_xml_attribute``;
+the argument is accepted and ignored. Drop the fixture from the test's signature,
+though: requesting it is what makes pytest warn that the fixture is
+experimental, and under ``-W error`` or ``filterwarnings = error`` that request
+is a setup error. The plugin neither requests the fixture nor filters its
+notice any more, so whether a test keeps it, and how it treats the notice, is
+that test's own business.
 
 Origin
 ------

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -1,0 +1,111 @@
+.. _pytest_plugin:
+
+pytest plugin
+=============
+.. versionadded:: 1.5.0
+
+A stock pytest run writes a JUnit XML that this extension can only partly use:
+no ``<testcase>`` carries the ``file``/``line`` attributes that give a test case
+its source location (``tr_source_file_option``/``tr_source_line_option``, and
+the deterministic ID of ``tr_deterministic_case_ids``), and nothing records the
+requirements a test verifies. ``Sphinx-Test-Reports`` ships a small pytest
+plugin that writes both.
+
+Enabling it
+-----------
+
+.. code-block:: ini
+
+   # pytest.ini / pyproject.toml [tool.pytest.ini_options]
+   addopts = -p sphinxcontrib.test_reports.pytest_plugin
+   junit_family = xunit1
+
+then run with ``--junitxml=report.xml`` as usual. ``junit_family = xunit1`` is
+required: pytest writes ``<testcase>`` attributes only under that family, and the
+plugin warns at start-up when a report is requested under ``xunit2``. Every test
+case now carries ``file`` and ``line`` -- the path is relative to the pytest
+rootdir, and Bazel's ``_main/`` runfiles prefix is cut off.
+
+Nothing else changes for tests that do not use the decorator below.
+
+Linking a test to requirements
+------------------------------
+
+.. code-block:: python
+
+   from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
+
+   @add_test_properties(
+       partially_verifies=["REQ_1", "REQ_2"],
+       test_type="requirements-based",
+       derivation_technique="requirements-analysis",
+   )
+   def test_addition():
+       """Adding two numbers."""
+       assert 1 + 1 == 2
+
+writes, on that test's ``<testcase>``:
+
+.. code-block:: xml
+
+   <properties>
+     <property name="PartiallyVerifies" value="REQ_1, REQ_2"/>
+     <property name="TestType" value="requirements-based"/>
+     <property name="DerivationTechnique" value="requirements-analysis"/>
+   </properties>
+
+``fully_verifies`` writes ``FullyVerifies`` the same way. Any further keyword
+argument becomes a property under its own name, for metamodels with fields the
+plugin does not know (``Owner="team-a"`` writes ``Owner``). Empty values are not
+written, and a decorator that would write nothing is an error.
+
+The property names are the ones S-CORE's metamodel spells. On the build side
+they arrive through the directives' property handling: ``tr_property_link_types``
+turns a comma-separated property into a link field --
+
+.. code-block:: python
+
+   tr_property_link_types = {"PartiallyVerifies": "partially_verifies", "FullyVerifies": "fully_verifies"}
+
+-- and ``tr_extra_options`` lists the properties that become plain fields
+(``TestType``, ``DerivationTechnique``, ...). The same names work for any other
+consumer of the report.
+
+Metadata known only at run time
+-------------------------------
+
+A parameterised test whose metadata comes from the file it is driven by cannot
+use a decorator. :func:`apply_test_metadata` records the same properties from
+inside the test body, and can point the case at the file that drove it instead
+of at the test function:
+
+.. code-block:: python
+
+   from sphinxcontrib.test_reports.pytest_plugin import apply_test_metadata
+
+   @pytest.mark.parametrize("spec", SPECS)
+   def test_spec(spec, record_property, record_xml_attribute):
+       metadata = read_metadata(spec)   # {"fully_verifies": [...], "test_type": ...}
+       apply_test_metadata(
+           record_property=record_property,
+           metadata=metadata,
+           record_xml_attribute=record_xml_attribute,
+           file=str(spec),
+           line=metadata_line(spec),
+       )
+       ...  # the actual checks
+
+Call it before the first assertion, so a failing test still carries its
+metadata.
+
+Origin
+------
+
+The plugin is a port of the ``score_pytest`` attribute plugin of S-CORE's
+`docs-as-code <https://github.com/eclipse-score/docs-as-code>`_, producing the
+same XML, so tests written against that plugin keep working when they import
+``add_test_properties`` and ``apply_test_metadata`` from here. Two of its rules
+are not ported, because they are that project's process rules rather than
+properties of the data: the ``test_type`` and ``derivation_technique``
+vocabularies are documented (``TEST_TYPES``, ``DERIVATION_TECHNIQUES``) but not
+enforced, and a decorated test is not required to carry a docstring.

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,6 +20,20 @@ def tests(session, sphinx_needs, sphinx):
     run_tests(session, sphinx, sphinx_needs)
 
 
+#: The oldest pytest the plugin's tests run on, per Python: 7.0 is the plugin's
+#: own floor (the pytest extra), and 7.3.2 the first pytest that runs on
+#: Python 3.12 at all.
+PLUGIN_PYTEST_FLOORS = [("3.11", "7.0.1"), ("3.12", "7.3.2")]
+
+
+@session
+@nox.parametrize("python,pytest_version", PLUGIN_PYTEST_FLOORS)
+def plugin_floor(session, pytest_version):
+    """The pytest plugin's tests on the oldest pytest it supports."""
+    session.install(".[test]", f"pytest=={pytest_version}")
+    session.run("pytest", "tests/test_pytest_plugin.py")
+
+
 @session(python="3.12")
 def linkcheck(session):
     session.install(".[docs]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,12 @@ dependencies = ["sphinx>=7.4", "lxml", "sphinx-needs>=6.0.1"]
 
 [project.optional-dependencies]
 # The pytest plugin (sphinxcontrib.test_reports.pytest_plugin); pytest is not
-# a dependency of the extension or the converter. 7.4 is the first pytest that
-# runs on Python 3.12, so the floor holds on every interpreter this supports.
-pytest = ["pytest>=7.4"]
+# a dependency of the extension or the converter. 7.0 is where everything the
+# plugin uses exists (pytest.Config/Item/Mark, Config.stash,
+# issue_config_time_warning). pytest before 7.3.2 does not run on Python 3.12
+# at all -- that floor is pytest's own, not this one's; the nox session
+# plugin_floor runs the plugin's tests on the oldest pytest of each Python.
+pytest = ["pytest>=7.0"]
 test = [
   "beautifulsoup4",
   "nox>=2025.2.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ dev = [
   # Stubs for docutils, which ships none: without them every directive
   # option spec is untyped and `test_reports.py` cannot be checked.
   "types-docutils>=0.21",
+  # pytest: mypy type-checks the pytest plugin, so `uv sync --group dev` (the
+  # CI mypy job) has to be able to follow its imports.
+  "pytest>=7.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,9 @@ dependencies = ["sphinx>=7.4", "lxml", "sphinx-needs>=6.0.1"]
 
 [project.optional-dependencies]
 # The pytest plugin (sphinxcontrib.test_reports.pytest_plugin); pytest is not
-# a dependency of the extension or the converter.
-pytest = ["pytest>=7.0"]
+# a dependency of the extension or the converter. 7.4 is the first pytest that
+# runs on Python 3.12, so the floor holds on every interpreter this supports.
+pytest = ["pytest>=7.4"]
 test = [
   "beautifulsoup4",
   "nox>=2025.2.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,10 +114,6 @@ exclude = [
   "^sphinxcontrib/test_reports/functions",
   "^sphinxcontrib/test_reports/jsonparser\\.py$",
   "^sphinxcontrib/test_reports/junitparser\\.py$",
-  # pytest's marker API is Any-typed (MarkDecorator.__call__ on a
-  # Callable[..., object], whose `...` is itself an Any), which
-  # disallow_any_expr rejects for every decorator expression.
-  "^sphinxcontrib/test_reports/pytest_plugin\\.py$",
 ]
 # Disallow dynamic typing
 disallow_any_unimported = true
@@ -133,6 +129,7 @@ disallow_untyped_defs = true
 # disallow_incomplete_defs = true
 # check_untyped_defs = true
 # disallow_untyped_decorators = true
+
 
 # # None and optional handling
 # no_implicit_optional = true
@@ -164,3 +161,16 @@ module = [
   "sphinxcontrib.test_reports.cli",
 ]
 disallow_any_expr = false
+
+# The pytest plugin decorates arbitrary test functions (Callable[..., object],
+# whose `...` is an Any) and reads pytest's Any-typed config API; everything
+# else stays strict. Both module names: `packages` above yields the full one,
+# a file passed on the command line loses the `sphinxcontrib` prefix because
+# that directory is a namespace package.
+[[tool.mypy.overrides]]
+module = [
+  "sphinxcontrib.test_reports.pytest_plugin",
+  "test_reports.pytest_plugin",
+]
+disallow_any_expr = false
+disallow_any_explicit = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ requires-python = ">=3.11"
 dependencies = ["sphinx>=7.4", "lxml", "sphinx-needs>=6.0.1"]
 
 [project.optional-dependencies]
+# The pytest plugin (sphinxcontrib.test_reports.pytest_plugin); pytest is not
+# a dependency of the extension or the converter.
+pytest = ["pytest>=7.0"]
 test = [
   "beautifulsoup4",
   "nox>=2025.2.9",
@@ -111,6 +114,10 @@ exclude = [
   "^sphinxcontrib/test_reports/functions",
   "^sphinxcontrib/test_reports/jsonparser\\.py$",
   "^sphinxcontrib/test_reports/junitparser\\.py$",
+  # pytest's marker API is Any-typed (MarkDecorator.__call__ on a
+  # Callable[..., object], whose `...` is itself an Any), which
+  # disallow_any_expr rejects for every decorator expression.
+  "^sphinxcontrib/test_reports/pytest_plugin\\.py$",
 ]
 # Disallow dynamic typing
 disallow_any_unimported = true

--- a/sphinxcontrib/test_reports/pytest_plugin.py
+++ b/sphinxcontrib/test_reports/pytest_plugin.py
@@ -27,6 +27,7 @@ is only ever loaded by pytest.
 
 from __future__ import annotations
 
+import re
 import warnings
 from dataclasses import dataclass
 from typing import Callable, Mapping, Sequence
@@ -63,10 +64,12 @@ DERIVATION_TECHNIQUES = (
     "explorative-testing",
 )
 
-#: Bazel runs tests from a runfiles tree where the workspace appears as
-#: ``_main``; a location such as ``../_main/pkg/test_x.py`` names the source
-#: file ``pkg/test_x.py``.
-_RUNFILES_MARKER = "_main/"
+#: Bazel runs a test from a runfiles tree in which the workspace is the
+#: directory ``_main``: ``../_main/pkg/test_x.py`` names ``pkg/test_x.py``. Only
+#: a whole path component counts -- ``app_main/`` is somebody's directory -- and
+#: the last one wins, since under bzlmod the execroot's workspace directory is
+#: ``_main`` as well.
+_RUNFILES_PREFIX = re.compile(r"^(?:.*[\\/])?_main[\\/]")
 
 Recorder = Callable[[str, str], None]
 
@@ -268,12 +271,12 @@ def clean_source_path(path: str) -> str:
     """The workspace-relative source path of a test.
 
     pytest reports locations relative to its rootdir already; under Bazel the
-    rootdir sits inside a runfiles tree, so the path starts with ``../_main/``
-    and has to be cut down to the workspace path.
+    rootdir sits inside a runfiles tree, so the path leads through ``_main``,
+    the workspace directory of that tree -- as does an absolute path handed to
+    :func:`apply_test_metadata`. Everything up to and including the last
+    ``_main/`` component is cut.
     """
-    if _RUNFILES_MARKER in path:
-        return path.rsplit(_RUNFILES_MARKER, 1)[-1]
-    return path
+    return _RUNFILES_PREFIX.sub("", path, count=1)
 
 
 class TestReportsConfigWarning(pytest.PytestWarning):

--- a/sphinxcontrib/test_reports/pytest_plugin.py
+++ b/sphinxcontrib/test_reports/pytest_plugin.py
@@ -46,13 +46,24 @@ FULLY_VERIFIES = "FullyVerifies"
 TEST_TYPE = "TestType"
 DERIVATION_TECHNIQUE = "DerivationTechnique"
 
-#: The vocabularies S-CORE uses. Documented, not enforced: a project with a
-#: different metamodel is free to write other values.
+#: The vocabularies of S-CORE's verification concept ("Verification Methods"
+#: in its process description): the identifiers of the verification methods,
+#: for ``TestType``, and of the derivation techniques, for
+#: ``DerivationTechnique``. Documented, not enforced -- S-CORE's own metamodel
+#: accepts any string for both fields, and a project with a different metamodel
+#: is free to write other values.
 TEST_TYPES = (
+    "control-flow-analysis",
+    "data-flow-analysis",
     "fault-injection",
+    "inspection",
     "interface-test",
     "requirements-based",
     "resource-usage",
+    "static-code-analysis",
+    "structural-statement-coverage",
+    "structural-branch-coverage",
+    "walkthrough",
 )
 DERIVATION_TECHNIQUES = (
     "requirements-analysis",

--- a/sphinxcontrib/test_reports/pytest_plugin.py
+++ b/sphinxcontrib/test_reports/pytest_plugin.py
@@ -1,0 +1,278 @@
+"""pytest plugin: shape the JUnit XML the way this extension reads it.
+
+Enable it with ``-p sphinxcontrib.test_reports.pytest_plugin`` (or in
+``addopts``) and write the report with ``--junitxml`` under
+``junit_family = xunit1``. Two things then happen to every ``<testcase>``:
+
+* it carries ``file`` and ``line`` attributes -- the source location that the
+  directives put into ``tr_source_file_option``/``tr_source_line_option`` and
+  that a deterministic case ID is derived from. pytest only writes these under
+  ``xunit1``, and only through the ``record_xml_attribute`` fixture; nothing in
+  a stock run produces them;
+* the metadata given with :func:`add_test_properties` (or, for parameterised
+  tests, :func:`apply_test_metadata`) is written as ``<properties>``, which the
+  directives turn into need fields (``tr_extra_options``) and link fields
+  (``tr_property_link_types``) pointing at the requirements a test verifies.
+
+Ported from the ``score_pytest`` attribute plugin of S-CORE's docs-as-code, so
+the XML is shaped identically and tests written against that plugin keep
+working when they import from here instead. Two deliberate differences: the
+``TestType``/``DerivationTechnique`` vocabularies are documented, not enforced,
+and a test does not have to carry a docstring -- both are process rules of that
+project, not of this tool.
+
+This module imports pytest and nothing else from the package's Sphinx side; it
+is only ever loaded by pytest.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Mapping, Sequence
+
+import pytest
+
+#: Name of the marker :func:`add_test_properties` attaches. Registered in
+#: :func:`pytest_configure` so ``--strict-markers`` accepts it.
+MARKER = "test_properties"
+
+#: Property names written to the XML, matching S-CORE's metamodel spelling so
+#: a ``link_properties = { PartiallyVerifies = "partially_verifies" }`` in
+#: ``ubproject.toml`` maps them without translation.
+PARTIALLY_VERIFIES = "PartiallyVerifies"
+FULLY_VERIFIES = "FullyVerifies"
+TEST_TYPE = "TestType"
+DERIVATION_TECHNIQUE = "DerivationTechnique"
+
+#: The vocabularies S-CORE uses. Documented, not enforced: a project with a
+#: different metamodel is free to write other values.
+TEST_TYPES = (
+    "fault-injection",
+    "interface-test",
+    "requirements-based",
+    "resource-usage",
+)
+DERIVATION_TECHNIQUES = (
+    "requirements-analysis",
+    "design-analysis",
+    "boundary-values",
+    "equivalence-classes",
+    "fuzz-testing",
+    "error-guessing",
+    "explorative-testing",
+)
+
+#: Bazel runs tests from a runfiles tree where the workspace appears as
+#: ``_main``; a location such as ``../_main/pkg/test_x.py`` names the source
+#: file ``pkg/test_x.py``.
+_RUNFILES_MARKER = "_main/"
+
+Recorder = Callable[[str, str], None]
+
+
+def properties_mapping(
+    *,
+    partially_verifies: Sequence[str] | None = None,
+    fully_verifies: Sequence[str] | None = None,
+    test_type: str | None = None,
+    derivation_technique: str | None = None,
+    **properties: str,
+) -> dict[str, str]:
+    """The property mapping that ends up in the XML, empty values dropped.
+
+    Single source of truth for the decorator and the runtime helper. Lists are
+    joined with ``", "``, which is what ``tr_property_link_types``
+    splits on again.
+    """
+    mapping = {
+        PARTIALLY_VERIFIES: ", ".join(partially_verifies or ()),
+        FULLY_VERIFIES: ", ".join(fully_verifies or ()),
+        TEST_TYPE: test_type or "",
+        DERIVATION_TECHNIQUE: derivation_technique or "",
+        **properties,
+    }
+    cleaned = {name: value for name, value in mapping.items() if value}
+    if not cleaned:
+        raise ValueError(
+            "no test properties given: at least one of partially_verifies, "
+            "fully_verifies, test_type, derivation_technique or a custom "
+            "property is needed"
+        )
+    return cleaned
+
+
+def add_test_properties(
+    *,
+    partially_verifies: Sequence[str] | None = None,
+    fully_verifies: Sequence[str] | None = None,
+    test_type: str | None = None,
+    derivation_technique: str | None = None,
+    **properties: str,
+) -> Callable[[Callable[..., object]], Callable[..., object]]:
+    """Decorator recording requirement links and classification for a test.
+
+    ::
+
+        @add_test_properties(
+            partially_verifies=["REQ_1", "REQ_2"],
+            test_type="requirements-based",
+            derivation_technique="requirements-analysis",
+        )
+        def test_addition():
+            ...
+
+    Extra keyword arguments become properties under their own names, for
+    metamodels with fields this plugin does not know.
+    """
+    mapping = properties_mapping(
+        partially_verifies=partially_verifies,
+        fully_verifies=fully_verifies,
+        test_type=test_type,
+        derivation_technique=derivation_technique,
+        **properties,
+    )
+    marker = getattr(pytest.mark, MARKER)
+
+    def decorator(function: Callable[..., object]) -> Callable[..., object]:
+        decorated: Callable[..., object] = marker(mapping)(function)
+        return decorated
+
+    return decorator
+
+
+def apply_test_metadata(
+    *,
+    record_property: Recorder,
+    metadata: Mapping[str, Sequence[str] | str | None],
+    record_xml_attribute: Recorder | None = None,
+    file: str | None = None,
+    line: int | None = None,
+) -> None:
+    """Runtime equivalent of :func:`add_test_properties`.
+
+    For tests whose metadata is only known inside the test body -- typically a
+    parameterised test driven by files that carry their own metadata. Call it
+    *early*, before any assertion, so the properties are attached even when the
+    test then fails. *metadata* uses the decorator's argument names as keys.
+
+    With *record_xml_attribute*, *file* and *line* override the location the
+    plugin's fixture recorded, so a case can point at the file that drove it
+    rather than at the test function.
+    """
+    if not metadata:
+        return
+    properties = {
+        name: str(value)
+        for name, value in metadata.items()
+        if name
+        not in (
+            "partially_verifies",
+            "fully_verifies",
+            "test_type",
+            "derivation_technique",
+        )
+        and value
+    }
+    mapping = properties_mapping(
+        partially_verifies=_as_list(metadata.get("partially_verifies")),
+        fully_verifies=_as_list(metadata.get("fully_verifies")),
+        test_type=_as_str(metadata.get("test_type")),
+        derivation_technique=_as_str(metadata.get("derivation_technique")),
+        **properties,
+    )
+    for name, value in mapping.items():
+        record_property(name, value)
+
+    if record_xml_attribute is not None:
+        if file is not None:
+            record_xml_attribute("file", clean_source_path(file))
+        if line is not None:
+            record_xml_attribute("line", str(line))
+
+
+def _as_list(value: object) -> list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def _as_str(value: object) -> str | None:
+    return None if value is None else str(value)
+
+
+def clean_source_path(path: str) -> str:
+    """The workspace-relative source path of a test.
+
+    pytest reports locations relative to its rootdir already; under Bazel the
+    rootdir sits inside a runfiles tree, so the path starts with ``../_main/``
+    and has to be cut down to the workspace path.
+    """
+    if _RUNFILES_MARKER in path:
+        return path.rsplit(_RUNFILES_MARKER, 1)[-1]
+    return path
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        f"{MARKER}(properties): properties written to the JUnit XML of the "
+        "test; attached by sphinxcontrib.test_reports.pytest_plugin.add_test_properties",
+    )
+    # record_xml_attribute is marked experimental and says so once per test;
+    # this plugin exists to use it, so the notice is noise here.
+    config.addinivalue_line(
+        "filterwarnings",
+        "ignore:record_xml_attribute is an experimental feature:"
+        "pytest.PytestExperimentalApiWarning",
+    )
+    xmlpath: object = config.option.xmlpath
+    family: object = config.getini("junit_family")
+    if xmlpath and family != "xunit1":
+        config.issue_config_time_warning(
+            pytest.PytestConfigWarning(
+                "sphinxcontrib.test_reports.pytest_plugin: junit_family is "
+                f"{family!r}, but pytest writes the file/line attributes of a "
+                "<testcase> only under 'xunit1'. Set junit_family = xunit1, or the "
+                "test cases will have no source location."
+            ),
+            stacklevel=2,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _test_reports_xml_shape(
+    request: pytest.FixtureRequest,
+    record_property: Recorder,
+    record_xml_attribute: Recorder,
+) -> None:
+    """Record the source location and the marker's properties for every test.
+
+    Runs at setup, so a test that fails still carries both. The location is
+    the test function's -- for a decorated function, the line of its first
+    decorator, which is where pytest points too; :func:`apply_test_metadata`
+    may override it later.
+    """
+    node: pytest.Item = request.node
+    location: tuple[str, int | None, str] = node.location
+    path, line_number, _domain = location
+    record_xml_attribute("file", clean_source_path(path))
+    if line_number is not None:
+        # pytest's line numbers are 0-based; editors and the report count
+        # from 1.
+        record_xml_attribute("line", str(line_number + 1))
+
+    marker: pytest.Mark | None = node.get_closest_marker(MARKER)
+    if marker is None:
+        return
+    arguments: tuple[object, ...] = marker.args
+    if not arguments or not isinstance(arguments[0], Mapping):
+        raise pytest.UsageError(
+            f"marker '{MARKER}' on {node.name} carries no property mapping; "
+            "attach it with add_test_properties(...)"
+        )
+    properties: Mapping[object, object] = arguments[0]
+    for name, value in properties.items():
+        record_property(str(name), str(value))

--- a/sphinxcontrib/test_reports/pytest_plugin.py
+++ b/sphinxcontrib/test_reports/pytest_plugin.py
@@ -9,17 +9,23 @@ Enable it with ``-p sphinxcontrib.test_reports.pytest_plugin`` (or in
   that a deterministic case ID is derived from. pytest only writes these under
   ``xunit1``, and only through the ``record_xml_attribute`` fixture; nothing in
   a stock run produces them;
-* the metadata given with :func:`add_test_properties` (or, for parameterised
-  tests, :func:`apply_test_metadata`) is written as ``<properties>``, which the
+* the properties given with :func:`add_test_properties` (or, for parameterised
+  tests, :func:`apply_test_metadata`) are written as ``<properties>``, which the
   directives turn into need fields (``tr_extra_options``) and link fields
   (``tr_property_link_types``) pointing at the requirements a test verifies.
 
-Ported from the ``score_pytest`` attribute plugin of S-CORE's docs-as-code, so
-the XML is shaped identically and tests written against that plugin keep
-working when they import from here instead. Two deliberate differences: the
-``TestType``/``DerivationTechnique`` vocabularies are documented, not enforced,
-and a test does not have to carry a docstring -- both are process rules of that
-project, not of this tool.
+Which keywords the two helpers know, the ``<property>`` name each is written
+under and whether it takes a list is configuration, not code: the
+``test_reports_properties`` ini option, one line per property (see
+:func:`parse_properties`). The plugin ships no metamodel of its own; S-CORE's
+is a four-line example in the docs.
+
+Ported from the ``score_pytest`` attribute plugin of S-CORE's docs-as-code.
+With that example configured the XML is shaped identically, so tests written
+against that plugin keep working when they import from here instead. Two
+deliberate differences: the ``TestType``/``DerivationTechnique`` vocabularies
+are documented, not enforced, and a test does not have to carry a docstring --
+both are process rules of that project, not of this tool.
 
 This module imports pytest and nothing else from the package's Sphinx side; it
 is only ever loaded by pytest.
@@ -38,41 +44,17 @@ import pytest
 #: :func:`pytest_configure` so ``--strict-markers`` accepts it.
 MARKER = "test_properties"
 
-#: Property names written to the XML, matching S-CORE's metamodel spelling so
-#: a ``property_link_types = { PartiallyVerifies = "partially_verifies" }`` in
-#: ``ubproject.toml`` maps them without translation.
-PARTIALLY_VERIFIES = "PartiallyVerifies"
-FULLY_VERIFIES = "FullyVerifies"
-TEST_TYPE = "TestType"
-DERIVATION_TECHNIQUE = "DerivationTechnique"
+#: The ini option holding the property model, one line per property.
+OPTION = "test_reports_properties"
 
-#: The vocabularies of S-CORE's verification concept ("Verification Methods"
-#: in its process description): the identifiers of the verification methods,
-#: for ``TestType``, and of the derivation techniques, for
-#: ``DerivationTechnique``. Documented, not enforced -- S-CORE's own metamodel
-#: accepts any string for both fields, and a project with a different metamodel
-#: is free to write other values.
-TEST_TYPES = (
-    "control-flow-analysis",
-    "data-flow-analysis",
-    "fault-injection",
-    "inspection",
-    "interface-test",
-    "requirements-based",
-    "resource-usage",
-    "static-code-analysis",
-    "structural-statement-coverage",
-    "structural-branch-coverage",
-    "walkthrough",
-)
-DERIVATION_TECHNIQUES = (
-    "requirements-analysis",
-    "design-analysis",
-    "boundary-values",
-    "equivalence-classes",
-    "fuzz-testing",
-    "error-guessing",
-    "explorative-testing",
+#: How one line of :data:`OPTION` reads.
+GRAMMAR = "keyword [= XmlName] [, list]"
+
+#: One line of :data:`OPTION`: a keyword, an optional ``= XmlName`` and an
+#: optional ``, flag``; ``flag`` is checked afterwards so the message can name
+#: it.
+_LINE = re.compile(
+    r"^\s*(?P<keyword>[^\s=,]+)\s*(?:=\s*(?P<name>[^\s=,]+)\s*)?(?:,\s*(?P<flag>[^\s,]+)\s*)?$"
 )
 
 #: Bazel runs a test from a runfiles tree in which the workspace is the
@@ -102,63 +84,79 @@ class Property:
     multi: bool = False
 
 
-#: Keyword -> how it is written. S-CORE's four are pre-registered; a project
-#: adds its own with :func:`register_property`. A keyword not found here is
-#: written under its own name and takes a single value only.
-PROPERTIES: dict[str, Property] = {
-    "partially_verifies": Property(PARTIALLY_VERIFIES, multi=True),
-    "fully_verifies": Property(FULLY_VERIFIES, multi=True),
-    "test_type": Property(TEST_TYPE),
-    "derivation_technique": Property(DERIVATION_TECHNIQUE),
-}
+#: Keyword -> how it is written: the model of :data:`OPTION`, installed by
+#: :func:`pytest_configure`. A keyword not found here is written under its own
+#: name and takes a single value only.
+PROPERTIES: dict[str, Property] = {}
 
 
-def register_property(
-    keyword: str, name: str | None = None, *, multi: bool = False
-) -> Property:
-    """Teach :func:`add_test_properties` and :func:`apply_test_metadata` *keyword*.
+def parse_properties(lines: Sequence[str]) -> dict[str, Property]:
+    """The property model declared by the lines of :data:`OPTION`.
 
-    *name* is the ``<property>`` name written to the XML (default: the keyword
-    itself); a *multi*-valued property takes a sequence of values and writes
-    them ``", "``-joined, the shape ``tr_property_link_types`` reads. Call it
-    once, before the tests are collected -- a ``conftest.py`` is the place::
+    Each line reads ``keyword [= XmlName] [, list]``: *keyword* is what a test
+    writes, *XmlName* the ``<property>`` name it is written under (the keyword
+    itself when omitted), and ``list`` marks a multi-valued property. Blank
+    lines are skipped. S-CORE's model, for example::
 
-        register_property("satisfies", "Satisfies", multi=True)
+        test_reports_properties =
+            partially_verifies = PartiallyVerifies, list
+            fully_verifies = FullyVerifies, list
+            test_type = TestType
+            derivation_technique = DerivationTechnique
 
-    lets a test write ``@add_test_properties(satisfies=["REQ_1", "REQ_2"])``.
+    :raises ValueError: for a line outside the grammar, a flag other than
+        ``list``, or a keyword declared twice.
     """
-    registered = Property(name or keyword, multi=multi)
-    PROPERTIES[keyword] = registered
-    return registered
+    model: dict[str, Property] = {}
+    for line in lines:
+        if not line.strip():
+            continue
+        match = _LINE.match(line)
+        if match is None:
+            raise ValueError(
+                f"{OPTION}: cannot read {line.strip()!r}; a line is '{GRAMMAR}'"
+            )
+        keyword, name, flag = match.group("keyword", "name", "flag")
+        if flag not in (None, "list"):
+            raise ValueError(
+                f"{OPTION}: unknown flag {flag!r} in {line.strip()!r}; the only "
+                "flag is 'list'"
+            )
+        if keyword in model:
+            raise ValueError(f"{OPTION}: {keyword!r} is declared twice")
+        model[keyword] = Property(name or keyword, multi=flag == "list")
+    return model
 
 
 def _lookup(keyword: str) -> Property | None:
-    """The registered property for *keyword*, also when given by its XML name."""
-    registered = PROPERTIES.get(keyword)
-    if registered is not None:
-        return registered
+    """The configured property for *keyword*, also when given by its XML name."""
+    configured = PROPERTIES.get(keyword)
+    if configured is not None:
+        return configured
     return next((p for p in PROPERTIES.values() if p.name == keyword), None)
 
 
-def _serialise(keyword: str, registered: Property | None, value: object) -> str | None:
+def _serialise(keyword: str, configured: Property | None, value: object) -> str | None:
     """The text written for *value*, or ``None`` when there is nothing to write."""
     if value is None:
         return None
     if isinstance(value, (str, int, float)):
         return str(value) or None
     if isinstance(value, Sequence):
-        if registered is None:
+        if configured is None:
             raise TypeError(
-                f"{keyword!r} is not a registered property and takes a single "
-                f"value; register_property({keyword!r}, multi=True) lets it "
-                "write a list"
+                f"{keyword!r} is not a configured property and takes a single "
+                f"value; a line '{keyword}, list' in {OPTION} lets it write a list"
             )
-        if not registered.multi:
-            raise TypeError(f"{keyword!r} takes a single value, not a sequence")
+        if not configured.multi:
+            raise TypeError(
+                f"{keyword!r} takes a single value, not a sequence; declare it "
+                f"'{keyword} = {configured.name}, list' in {OPTION} for lists"
+            )
         return ", ".join(str(item) for item in value if item not in (None, "")) or None
     raise TypeError(
         f"{keyword!r} takes a string"
-        + (" or a list of strings" if registered and registered.multi else "")
+        + (" or a list of strings" if configured and configured.multi else "")
         + f", not {type(value).__name__}"
     )
 
@@ -167,57 +165,45 @@ def _normalise(properties: Mapping[str, object]) -> dict[str, str]:
     """The XML properties for keyword/value pairs; empty values dropped."""
     written: dict[str, str] = {}
     for keyword, value in properties.items():
-        registered = _lookup(keyword)
-        text = _serialise(keyword, registered, value)
+        configured = _lookup(keyword)
+        text = _serialise(keyword, configured, value)
         if text is not None:
-            written[registered.name if registered else keyword] = text
+            written[configured.name if configured else keyword] = text
     return written
 
 
-def properties_mapping(
-    *,
-    partially_verifies: Value = None,
-    fully_verifies: Value = None,
-    test_type: str | None = None,
-    derivation_technique: str | None = None,
-    **properties: Value,
-) -> dict[str, str]:
+def _empty(value: object) -> bool:
+    """Whether *value* would write nothing, whatever the model says."""
+    if value is None or value == "":
+        return True
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return all(_empty(item) for item in value)
+    return False
+
+
+def properties_mapping(**properties: Value) -> dict[str, str]:
     """The property mapping that ends up in the XML, empty values dropped.
 
     Single source of truth for the decorator and the runtime helper. How a
-    value is written is decided by :data:`PROPERTIES`, not by the keyword it
-    arrived under: the four named parameters are sugar over the same mechanism
-    that serves every registered keyword.
+    value is written is decided by the configured model (:data:`PROPERTIES`),
+    not by the keyword it arrived under.
+
+    :raises ValueError: when nothing would be written.
+    :raises TypeError: for a sequence under a single-valued or unconfigured
+        keyword, or a value of another kind.
     """
-    cleaned = _normalise(
-        {
-            "partially_verifies": partially_verifies,
-            "fully_verifies": fully_verifies,
-            "test_type": test_type,
-            "derivation_technique": derivation_technique,
-            **properties,
-        }
-    )
+    cleaned = _normalise(properties)
     if not cleaned:
-        raise ValueError(
-            "no test properties given: at least one of partially_verifies, "
-            "fully_verifies, test_type, derivation_technique or a registered "
-            "property is needed"
-        )
+        raise ValueError("no test properties given: every value is empty")
     return cleaned
 
 
 def add_test_properties(
-    *,
-    partially_verifies: Value = None,
-    fully_verifies: Value = None,
-    test_type: str | None = None,
-    derivation_technique: str | None = None,
     **properties: Value,
 ) -> Callable[[Callable[..., object]], Callable[..., object]]:
     """Decorator recording requirement links and classification for a test.
 
-    ::
+    With S-CORE's model configured (see the docs)::
 
         @add_test_properties(
             partially_verifies=["REQ_1", "REQ_2"],
@@ -227,21 +213,18 @@ def add_test_properties(
         def test_addition():
             ...
 
-    Further keyword arguments are written under their own names with a single
-    value each; :func:`register_property` gives a project's own link fields the
-    list handling of ``partially_verifies``.
+    The keywords are the ones ``test_reports_properties`` declares; any other
+    keyword is written under its own name with a single value. The values are
+    kept as given and written at test setup, when the model is known, so the
+    decorator itself does not depend on configuration having been read. A call
+    that would write nothing is refused here, at import time.
     """
-    mapping = properties_mapping(
-        partially_verifies=partially_verifies,
-        fully_verifies=fully_verifies,
-        test_type=test_type,
-        derivation_technique=derivation_technique,
-        **properties,
-    )
+    if all(_empty(value) for value in properties.values()):
+        raise ValueError("no test properties given: every value is empty")
     marker = getattr(pytest.mark, MARKER)
 
     def decorator(function: Callable[..., object]) -> Callable[..., object]:
-        decorated: Callable[..., object] = marker(mapping)(function)
+        decorated: Callable[..., object] = marker(dict(properties))(function)
         return decorated
 
     return decorator
@@ -260,9 +243,9 @@ def apply_test_metadata(
     For tests whose metadata is only known inside the test body -- typically a
     parameterised test driven by files that carry their own metadata. Call it
     *early*, before any assertion, so the properties are attached even when the
-    test then fails. *metadata* uses the decorator's argument names as keys;
-    metadata without a value -- absent, or with nothing but empty entries --
-    writes no properties and is not an error.
+    test then fails. *metadata* uses the decorator's keywords as keys; metadata
+    without a value -- absent, or with nothing but empty entries -- writes no
+    properties and is not an error.
 
     With *record_xml_attribute*, *file* and *line* override the location the
     plugin's fixture recorded, so a case can point at the file that drove it
@@ -326,12 +309,29 @@ def _notify(config: pytest.Config, message: str) -> None:
         raise pytest.UsageError(str(error)) from None
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addini(
+        OPTION,
+        type="linelist",
+        help=f"Properties add_test_properties() knows, one '{GRAMMAR}' per line; "
+        "the sphinx-test-reports docs, page 'pytest plugin', have the details.",
+    )
+
+
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
         f"{MARKER}(properties): properties written to the JUnit XML of the "
         "test; attached by sphinxcontrib.test_reports.pytest_plugin.add_test_properties",
     )
+    lines: Sequence[str] = config.getini(OPTION)
+    try:
+        model = parse_properties(lines)
+    except ValueError as error:
+        raise pytest.UsageError(str(error)) from None
+    PROPERTIES.clear()
+    PROPERTIES.update(model)
+
     family = _report_family(config)
     if family is None:
         return
@@ -352,6 +352,10 @@ def pytest_configure(config: pytest.Config) -> None:
             "(counted from 0, runfiles prefix intact) instead of the plugin's. "
             "Write the report without -n.",
         )
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    PROPERTIES.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -391,8 +395,10 @@ def _test_reports_xml_shape(request: pytest.FixtureRequest) -> None:
 def _marked_properties(node: pytest.Item) -> dict[str, str]:
     """The properties of every ``test_properties`` marker on *node*, merged.
 
-    A marker on the class or the module counts as much as one on the function;
-    where two set the same property, the one closest to the function wins.
+    Each marker carries the keywords as the decorator received them; they are
+    written here, against the configured model. A marker on the class or the
+    module counts as much as one on the function; where two set the same
+    property, the one closest to the function wins.
     """
     merged: dict[str, str] = {}
     for marker in node.iter_markers(MARKER):  # closest first
@@ -402,7 +408,9 @@ def _marked_properties(node: pytest.Item) -> dict[str, str]:
                 f"marker '{MARKER}' on {node.name} carries no property mapping; "
                 "attach it with add_test_properties(...)"
             )
-        properties: Mapping[object, object] = arguments[0]
-        for name, value in properties.items():
-            merged.setdefault(str(name), str(value))
+        given: Mapping[object, object] = arguments[0]
+        for name, value in _normalise(
+            {str(keyword): value for keyword, value in given.items()}
+        ).items():
+            merged.setdefault(name, value)
     return merged

--- a/sphinxcontrib/test_reports/pytest_plugin.py
+++ b/sphinxcontrib/test_reports/pytest_plugin.py
@@ -27,6 +27,7 @@ is only ever loaded by pytest.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Callable, Mapping, Sequence
 
 import pytest
@@ -36,7 +37,7 @@ import pytest
 MARKER = "test_properties"
 
 #: Property names written to the XML, matching S-CORE's metamodel spelling so
-#: a ``link_properties = { PartiallyVerifies = "partially_verifies" }`` in
+#: a ``property_link_types = { PartiallyVerifies = "partially_verifies" }`` in
 #: ``ubproject.toml`` maps them without translation.
 PARTIALLY_VERIFIES = "PartiallyVerifies"
 FULLY_VERIFIES = "FullyVerifies"
@@ -68,33 +69,124 @@ _RUNFILES_MARKER = "_main/"
 
 Recorder = Callable[[str, str], None]
 
+#: What a property keyword accepts: one value, or -- for a multi-valued
+#: property -- a sequence of values. ``None`` and empty values are not written.
+Value = str | Sequence[str] | None
+
+
+@dataclass(frozen=True)
+class Property:
+    """How one keyword of :func:`add_test_properties` reaches the XML."""
+
+    #: The ``<property name="...">`` written.
+    name: str
+    #: Multi-valued: a sequence of values is joined with ``", "``, which
+    #: ``tr_property_link_types`` splits again on the build side; a bare string
+    #: counts as one value. A single-valued property takes one value, and a
+    #: sequence is an error rather than a silent join.
+    multi: bool = False
+
+
+#: Keyword -> how it is written. S-CORE's four are pre-registered; a project
+#: adds its own with :func:`register_property`. A keyword not found here is
+#: written under its own name and takes a single value only.
+PROPERTIES: dict[str, Property] = {
+    "partially_verifies": Property(PARTIALLY_VERIFIES, multi=True),
+    "fully_verifies": Property(FULLY_VERIFIES, multi=True),
+    "test_type": Property(TEST_TYPE),
+    "derivation_technique": Property(DERIVATION_TECHNIQUE),
+}
+
+
+def register_property(
+    keyword: str, name: str | None = None, *, multi: bool = False
+) -> Property:
+    """Teach :func:`add_test_properties` and :func:`apply_test_metadata` *keyword*.
+
+    *name* is the ``<property>`` name written to the XML (default: the keyword
+    itself); a *multi*-valued property takes a sequence of values and writes
+    them ``", "``-joined, the shape ``tr_property_link_types`` reads. Call it
+    once, before the tests are collected -- a ``conftest.py`` is the place::
+
+        register_property("satisfies", "Satisfies", multi=True)
+
+    lets a test write ``@add_test_properties(satisfies=["REQ_1", "REQ_2"])``.
+    """
+    registered = Property(name or keyword, multi=multi)
+    PROPERTIES[keyword] = registered
+    return registered
+
+
+def _lookup(keyword: str) -> Property | None:
+    """The registered property for *keyword*, also when given by its XML name."""
+    registered = PROPERTIES.get(keyword)
+    if registered is not None:
+        return registered
+    return next((p for p in PROPERTIES.values() if p.name == keyword), None)
+
+
+def _serialise(keyword: str, registered: Property | None, value: object) -> str | None:
+    """The text written for *value*, or ``None`` when there is nothing to write."""
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float)):
+        return str(value) or None
+    if isinstance(value, Sequence):
+        if registered is None:
+            raise TypeError(
+                f"{keyword!r} is not a registered property and takes a single "
+                f"value; register_property({keyword!r}, multi=True) lets it "
+                "write a list"
+            )
+        if not registered.multi:
+            raise TypeError(f"{keyword!r} takes a single value, not a sequence")
+        return ", ".join(str(item) for item in value if item not in (None, "")) or None
+    raise TypeError(
+        f"{keyword!r} takes a string"
+        + (" or a list of strings" if registered and registered.multi else "")
+        + f", not {type(value).__name__}"
+    )
+
+
+def _normalise(properties: Mapping[str, object]) -> dict[str, str]:
+    """The XML properties for keyword/value pairs; empty values dropped."""
+    written: dict[str, str] = {}
+    for keyword, value in properties.items():
+        registered = _lookup(keyword)
+        text = _serialise(keyword, registered, value)
+        if text is not None:
+            written[registered.name if registered else keyword] = text
+    return written
+
 
 def properties_mapping(
     *,
-    partially_verifies: Sequence[str] | None = None,
-    fully_verifies: Sequence[str] | None = None,
+    partially_verifies: Value = None,
+    fully_verifies: Value = None,
     test_type: str | None = None,
     derivation_technique: str | None = None,
-    **properties: str,
+    **properties: Value,
 ) -> dict[str, str]:
     """The property mapping that ends up in the XML, empty values dropped.
 
-    Single source of truth for the decorator and the runtime helper. Lists are
-    joined with ``", "``, which is what ``tr_property_link_types``
-    splits on again.
+    Single source of truth for the decorator and the runtime helper. How a
+    value is written is decided by :data:`PROPERTIES`, not by the keyword it
+    arrived under: the four named parameters are sugar over the same mechanism
+    that serves every registered keyword.
     """
-    mapping = {
-        PARTIALLY_VERIFIES: ", ".join(partially_verifies or ()),
-        FULLY_VERIFIES: ", ".join(fully_verifies or ()),
-        TEST_TYPE: test_type or "",
-        DERIVATION_TECHNIQUE: derivation_technique or "",
-        **properties,
-    }
-    cleaned = {name: value for name, value in mapping.items() if value}
+    cleaned = _normalise(
+        {
+            "partially_verifies": partially_verifies,
+            "fully_verifies": fully_verifies,
+            "test_type": test_type,
+            "derivation_technique": derivation_technique,
+            **properties,
+        }
+    )
     if not cleaned:
         raise ValueError(
             "no test properties given: at least one of partially_verifies, "
-            "fully_verifies, test_type, derivation_technique or a custom "
+            "fully_verifies, test_type, derivation_technique or a registered "
             "property is needed"
         )
     return cleaned
@@ -102,11 +194,11 @@ def properties_mapping(
 
 def add_test_properties(
     *,
-    partially_verifies: Sequence[str] | None = None,
-    fully_verifies: Sequence[str] | None = None,
+    partially_verifies: Value = None,
+    fully_verifies: Value = None,
     test_type: str | None = None,
     derivation_technique: str | None = None,
-    **properties: str,
+    **properties: Value,
 ) -> Callable[[Callable[..., object]], Callable[..., object]]:
     """Decorator recording requirement links and classification for a test.
 
@@ -120,8 +212,9 @@ def add_test_properties(
         def test_addition():
             ...
 
-    Extra keyword arguments become properties under their own names, for
-    metamodels with fields this plugin does not know.
+    Further keyword arguments are written under their own names with a single
+    value each; :func:`register_property` gives a project's own link fields the
+    list handling of ``partially_verifies``.
     """
     mapping = properties_mapping(
         partially_verifies=partially_verifies,
@@ -142,7 +235,7 @@ def add_test_properties(
 def apply_test_metadata(
     *,
     record_property: Recorder,
-    metadata: Mapping[str, Sequence[str] | str | None],
+    metadata: Mapping[str, object],
     record_xml_attribute: Recorder | None = None,
     file: str | None = None,
     line: int | None = None,
@@ -152,34 +245,15 @@ def apply_test_metadata(
     For tests whose metadata is only known inside the test body -- typically a
     parameterised test driven by files that carry their own metadata. Call it
     *early*, before any assertion, so the properties are attached even when the
-    test then fails. *metadata* uses the decorator's argument names as keys.
+    test then fails. *metadata* uses the decorator's argument names as keys;
+    metadata without a value -- absent, or with nothing but empty entries --
+    writes no properties and is not an error.
 
     With *record_xml_attribute*, *file* and *line* override the location the
     plugin's fixture recorded, so a case can point at the file that drove it
     rather than at the test function.
     """
-    if not metadata:
-        return
-    properties = {
-        name: str(value)
-        for name, value in metadata.items()
-        if name
-        not in (
-            "partially_verifies",
-            "fully_verifies",
-            "test_type",
-            "derivation_technique",
-        )
-        and value
-    }
-    mapping = properties_mapping(
-        partially_verifies=_as_list(metadata.get("partially_verifies")),
-        fully_verifies=_as_list(metadata.get("fully_verifies")),
-        test_type=_as_str(metadata.get("test_type")),
-        derivation_technique=_as_str(metadata.get("derivation_technique")),
-        **properties,
-    )
-    for name, value in mapping.items():
+    for name, value in _normalise(metadata).items():
         record_property(name, value)
 
     if record_xml_attribute is not None:
@@ -187,20 +261,6 @@ def apply_test_metadata(
             record_xml_attribute("file", clean_source_path(file))
         if line is not None:
             record_xml_attribute("line", str(line))
-
-
-def _as_list(value: object) -> list[str] | None:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, Sequence):
-        return [str(item) for item in value]
-    return [str(value)]
-
-
-def _as_str(value: object) -> str | None:
-    return None if value is None else str(value)
 
 
 def clean_source_path(path: str) -> str:

--- a/sphinxcontrib/test_reports/pytest_plugin.py
+++ b/sphinxcontrib/test_reports/pytest_plugin.py
@@ -324,15 +324,25 @@ def _test_reports_xml_shape(
         # from 1.
         record_xml_attribute("line", str(line_number + 1))
 
-    marker: pytest.Mark | None = node.get_closest_marker(MARKER)
-    if marker is None:
-        return
-    arguments: tuple[object, ...] = marker.args
-    if not arguments or not isinstance(arguments[0], Mapping):
-        raise pytest.UsageError(
-            f"marker '{MARKER}' on {node.name} carries no property mapping; "
-            "attach it with add_test_properties(...)"
-        )
-    properties: Mapping[object, object] = arguments[0]
-    for name, value in properties.items():
-        record_property(str(name), str(value))
+    for name, value in _marked_properties(node).items():
+        record_property(name, value)
+
+
+def _marked_properties(node: pytest.Item) -> dict[str, str]:
+    """The properties of every ``test_properties`` marker on *node*, merged.
+
+    A marker on the class or the module counts as much as one on the function;
+    where two set the same property, the one closest to the function wins.
+    """
+    merged: dict[str, str] = {}
+    for marker in node.iter_markers(MARKER):  # closest first
+        arguments: tuple[object, ...] = marker.args
+        if not arguments or not isinstance(arguments[0], Mapping):
+            raise pytest.UsageError(
+                f"marker '{MARKER}' on {node.name} carries no property mapping; "
+                "attach it with add_test_properties(...)"
+            )
+        properties: Mapping[object, object] = arguments[0]
+        for name, value in properties.items():
+            merged.setdefault(str(name), str(value))
+    return merged

--- a/sphinxcontrib/test_reports/pytest_plugin.py
+++ b/sphinxcontrib/test_reports/pytest_plugin.py
@@ -195,16 +195,8 @@ def _serialise(keyword: str, configured: Property | None, value: object) -> str 
     if isinstance(value, (bytes, bytearray)):
         raise TypeError(f"{keyword!r} takes a string, not {type(value).__name__}")
     if isinstance(value, Sequence):
-        if configured is None:
-            raise TypeError(
-                f"{keyword!r} is not a configured property and takes a single "
-                f"value; a line '{keyword}, list' in {OPTION} lets it write a list"
-            )
-        if not configured.multi:
-            raise TypeError(
-                f"{keyword!r} takes a single value, not a sequence; declare it "
-                f"'{keyword} = {configured.name}, list' in {OPTION} for lists"
-            )
+        # Empty items first: a parser handing back [] for an absent field has
+        # nothing to write under any keyword, so no arity applies.
         items: list[str] = []
         for index, item in enumerate(value):
             if item is None or item == "":
@@ -215,7 +207,19 @@ def _serialise(keyword: str, configured: Property | None, value: object) -> str 
                     "str; every item of a list is one value"
                 )
             items.append(item)
-        return ", ".join(items) or None
+        if not items:
+            return None
+        if configured is None:
+            raise TypeError(
+                f"{keyword!r} is not a configured property and takes a single "
+                f"value; a line '{keyword}, list' in {OPTION} lets it write a list"
+            )
+        if not configured.multi:
+            raise TypeError(
+                f"{keyword!r} takes a single value, not a sequence; declare it "
+                f"'{keyword} = {configured.name}, list' in {OPTION} for lists"
+            )
+        return ", ".join(items)
     raise TypeError(
         f"{keyword!r} takes a string"
         + (" or a list of strings" if configured and configured.multi else "")
@@ -316,9 +320,14 @@ def apply_test_metadata(
 
     *file* and *line* override the location the plugin recorded, so a case can
     point at the file that drove it rather than at the test function. The
-    override travels with the test report and is applied where the XML is
-    written, so it holds under pytest-xdist as well. *record_xml_attribute* is
-    accepted for calls written against ``score_pytest`` and not used.
+    override travels with the test report as two ``user_properties`` entries,
+    ``sphinxcontrib.test_reports:file`` and ``sphinxcontrib.test_reports:line``,
+    and is applied where the XML is written, so it holds under pytest-xdist as
+    well; the plugin takes the two entries out before the properties are
+    written, so a property recorded under either name is read as an override.
+    *record_xml_attribute* is accepted for calls written against
+    ``score_pytest`` and ignored -- and requesting that fixture is what draws
+    pytest's experimental-feature notice, so drop it from the signature.
     """
     for name, value in _normalise(metadata).items():
         record_property(name, value)
@@ -386,6 +395,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
+    # First thing: pytest_unconfigure pops whatever happens here, so a session
+    # that fails to configure (a bad ini line) must have pushed already.
+    _OUTER_MODELS.append(dict(PROPERTIES))
     config.addinivalue_line(
         "markers",
         f"{MARKER}(properties): properties written to the JUnit XML of the "
@@ -396,13 +408,14 @@ def pytest_configure(config: pytest.Config) -> None:
         model = parse_properties(lines)
     except ValueError as error:
         raise pytest.UsageError(str(error)) from None
-    _OUTER_MODELS.append(dict(PROPERTIES))
     PROPERTIES.clear()
     PROPERTIES.update(model)
     config.pluginmanager.register(_XmlShape(config), name=_HOOKS)
 
     family = _report_family(config)
-    if family is not None and family != "xunit1":
+    # Once per run: an xdist worker has the same options, and its own notice
+    # would only repeat the controller's.
+    if family is not None and family != "xunit1" and not hasattr(config, "workerinput"):
         _notify(
             config,
             f"junit_family is {family!r}, but pytest writes the file/line "
@@ -439,8 +452,12 @@ def pytest_runtest_makereport(
     outcome = yield
     if problem is not None:
         report = outcome.get_result()
+        message = f"{type(problem).__name__}: {problem}"
+        # Appended, not replacing: a fixture that failed in the same setup
+        # stays visible, so both problems show at once.
+        existing = report.longreprtext
+        report.longrepr = f"{existing}\n\n{message}" if existing else message
         report.outcome = "failed"
-        report.longrepr = f"{type(problem).__name__}: {problem}"
 
 
 class _XmlShape:

--- a/sphinxcontrib/test_reports/pytest_plugin.py
+++ b/sphinxcontrib/test_reports/pytest_plugin.py
@@ -4,11 +4,14 @@ Enable it with ``-p sphinxcontrib.test_reports.pytest_plugin`` (or in
 ``addopts``) and write the report with ``--junitxml`` under
 ``junit_family = xunit1``. Two things then happen to every ``<testcase>``:
 
-* it carries ``file`` and ``line`` attributes -- the source location that the
-  directives put into ``tr_source_file_option``/``tr_source_line_option`` and
-  that a deterministic case ID is derived from. pytest only writes these under
-  ``xunit1``, and only through the ``record_xml_attribute`` fixture; nothing in
-  a stock run produces them;
+* its ``file``/``line`` attributes -- the source location that the directives
+  put into ``tr_source_file_option``/``tr_source_line_option`` and that a
+  deterministic case ID is derived from -- are the ones an editor shows. pytest
+  writes the two under ``xunit1`` on its own, but counts the line from 0, keeps
+  Bazel's runfiles prefix and has no way to point a case at the file that drove
+  it; the plugin corrects the first two and adds the third
+  (:func:`apply_test_metadata`). Under the default ``xunit2`` pytest drops both
+  attributes, which is why ``xunit1`` is required;
 * the properties given with :func:`add_test_properties` (or, for parameterised
   tests, :func:`apply_test_metadata`) are written as ``<properties>``, which the
   directives turn into need fields (``tr_extra_options``) and link fields
@@ -20,12 +23,21 @@ under and whether it takes a list is configuration, not code: the
 :func:`parse_properties`). The plugin ships no metamodel of its own; S-CORE's
 is a four-line example in the docs.
 
+Both things happen through hooks on the test reports, not through fixtures, so
+a case that is skipped or errors during setup is shaped like one that ran, and
+under pytest-xdist the location is written on the controller, where pytest
+keeps the XML writer.
+
 Ported from the ``score_pytest`` attribute plugin of S-CORE's docs-as-code.
-With that example configured the XML is shaped identically, so tests written
-against that plugin keep working when they import from here instead. Two
-deliberate differences: the ``TestType``/``DerivationTechnique`` vocabularies
-are documented, not enforced, and a test does not have to carry a docstring --
-both are process rules of that project, not of this tool.
+With that example configured the XML comes out the same, with four exceptions:
+a case skipped or erroring at setup carries its location and properties here
+and pytest's stock values there; the properties keep the order of the keywords
+rather than a fixed one; the Bazel prefix is cut at a whole ``_main`` component
+only; and a file handed to :func:`apply_test_metadata` is cut the same way
+rather than passed through. Two of that plugin's rules are not ported: the
+``TestType``/``DerivationTechnique`` vocabularies are documented, not enforced,
+and a test does not have to carry a docstring -- both are process rules of that
+project, not of this tool.
 
 This module imports pytest and nothing else from the package's Sphinx side; it
 is only ever loaded by pytest.
@@ -34,11 +46,14 @@ is only ever loaded by pytest.
 from __future__ import annotations
 
 import re
-import warnings
 from dataclasses import dataclass
-from typing import Callable, Mapping, Sequence
+from typing import TYPE_CHECKING, Callable, Generator, Mapping, Sequence
 
+import pluggy
 import pytest
+
+if TYPE_CHECKING:
+    from _pytest.junitxml import LogXML
 
 #: Name of the marker :func:`add_test_properties` attaches. Registered in
 #: :func:`pytest_configure` so ``--strict-markers`` accepts it.
@@ -64,6 +79,19 @@ _LINE = re.compile(
 #: ``_main`` as well.
 _RUNFILES_PREFIX = re.compile(r"^(?:.*[\\/])?_main[\\/]")
 
+#: The location override of :func:`apply_test_metadata` travels with the test
+#: report as two entries of its ``user_properties`` under these names, and is
+#: taken out again before pytest writes the properties -- on the process that
+#: holds the XML writer, which under pytest-xdist is the controller, not the
+#: worker the test ran on. Maps the entry name to the attribute it sets.
+_OVERRIDES = {
+    "sphinxcontrib.test_reports:file": "file",
+    "sphinxcontrib.test_reports:line": "line",
+}
+
+#: Registration name of the per-session hook object, :class:`_XmlShape`.
+_HOOKS = "sphinxcontrib.test_reports.xml_shape"
+
 Recorder = Callable[[str, str], None]
 
 #: What a property keyword accepts: one value, or -- for a multi-valued
@@ -77,7 +105,7 @@ class Property:
 
     #: The ``<property name="...">`` written.
     name: str
-    #: Multi-valued: a sequence of values is joined with ``", "``, which
+    #: Multi-valued: a sequence of strings is joined with ``", "``, which
     #: ``tr_property_link_types`` splits again on the build side; a bare string
     #: counts as one value. A single-valued property takes one value, and a
     #: sequence is an error rather than a silent join.
@@ -85,9 +113,13 @@ class Property:
 
 
 #: Keyword -> how it is written: the model of :data:`OPTION`, installed by
-#: :func:`pytest_configure`. A keyword not found here is written under its own
-#: name and takes a single value only.
+#: :func:`pytest_configure` for the duration of the session (an inner session
+#: gets its own and hands the outer one back). A keyword not found here is
+#: written under its own name and takes a single value only.
 PROPERTIES: dict[str, Property] = {}
+
+#: The models of the sessions an in-process inner session interrupted.
+_OUTER_MODELS: list[dict[str, Property]] = []
 
 
 def parse_properties(lines: Sequence[str]) -> dict[str, Property]:
@@ -105,7 +137,7 @@ def parse_properties(lines: Sequence[str]) -> dict[str, Property]:
             derivation_technique = DerivationTechnique
 
     :raises ValueError: for a line outside the grammar, a flag other than
-        ``list``, or a keyword declared twice.
+        ``list``, a keyword declared twice, or two keywords sharing an XML name.
     """
     model: dict[str, Property] = {}
     for line in lines:
@@ -124,12 +156,22 @@ def parse_properties(lines: Sequence[str]) -> dict[str, Property]:
             )
         if keyword in model:
             raise ValueError(f"{OPTION}: {keyword!r} is declared twice")
-        model[keyword] = Property(name or keyword, multi=flag == "list")
+        name = name or keyword
+        if any(existing.name == name for existing in model.values()):
+            raise ValueError(
+                f"{OPTION}: {name!r} is the XML name of two keywords; one "
+                "property, one line"
+            )
+        model[keyword] = Property(name, multi=flag == "list")
     return model
 
 
 def _lookup(keyword: str) -> Property | None:
-    """The configured property for *keyword*, also when given by its XML name."""
+    """The configured property for *keyword*.
+
+    A declared keyword first; failing that, a property whose XML name is
+    spelled like *keyword*, so the XML name doubles as keyword.
+    """
     configured = PROPERTIES.get(keyword)
     if configured is not None:
         return configured
@@ -137,11 +179,21 @@ def _lookup(keyword: str) -> Property | None:
 
 
 def _serialise(keyword: str, configured: Property | None, value: object) -> str | None:
-    """The text written for *value*, or ``None`` when there is nothing to write."""
+    """The text written for *value*, or ``None`` when there is nothing to write.
+
+    Strict about shape, because the build side splits a link property on
+    commas and turns every piece into a need ID: what is not a string, or a
+    list of strings under a ``list`` property, is a ``TypeError`` rather than
+    a ``repr`` that becomes bogus IDs.
+    """
     if value is None:
         return None
-    if isinstance(value, (str, int, float)):
-        return str(value) or None
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, (bytes, bytearray)):
+        raise TypeError(f"{keyword!r} takes a string, not {type(value).__name__}")
     if isinstance(value, Sequence):
         if configured is None:
             raise TypeError(
@@ -153,7 +205,17 @@ def _serialise(keyword: str, configured: Property | None, value: object) -> str 
                 f"{keyword!r} takes a single value, not a sequence; declare it "
                 f"'{keyword} = {configured.name}, list' in {OPTION} for lists"
             )
-        return ", ".join(str(item) for item in value if item not in (None, "")) or None
+        items: list[str] = []
+        for index, item in enumerate(value):
+            if item is None or item == "":
+                continue
+            if not isinstance(item, str):
+                raise TypeError(
+                    f"item {index} of {keyword!r} is {type(item).__name__}, not "
+                    "str; every item of a list is one value"
+                )
+            items.append(item)
+        return ", ".join(items) or None
     raise TypeError(
         f"{keyword!r} takes a string"
         + (" or a list of strings" if configured and configured.multi else "")
@@ -173,11 +235,16 @@ def _normalise(properties: Mapping[str, object]) -> dict[str, str]:
 
 
 def _empty(value: object) -> bool:
-    """Whether *value* would write nothing, whatever the model says."""
+    """Whether :func:`_serialise` would write nothing for a well-formed *value*.
+
+    ``None``, ``""`` and a sequence holding nothing else are empty. Anything
+    else is not -- a list holding a list is not empty, it is wrong, and
+    :func:`_serialise` says so.
+    """
     if value is None or value == "":
         return True
-    if isinstance(value, Sequence) and not isinstance(value, str):
-        return all(_empty(item) for item in value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return all(item is None or item == "" for item in value)
     return False
 
 
@@ -190,7 +257,7 @@ def properties_mapping(**properties: Value) -> dict[str, str]:
 
     :raises ValueError: when nothing would be written.
     :raises TypeError: for a sequence under a single-valued or unconfigured
-        keyword, or a value of another kind.
+        keyword, a list item that is not a string, or a value of another kind.
     """
     cleaned = _normalise(properties)
     if not cleaned:
@@ -215,9 +282,9 @@ def add_test_properties(
 
     The keywords are the ones ``test_reports_properties`` declares; any other
     keyword is written under its own name with a single value. The values are
-    kept as given and written at test setup, when the model is known, so the
-    decorator itself does not depend on configuration having been read. A call
-    that would write nothing is refused here, at import time.
+    kept as given and written when the test is set up, against the model known
+    then, so the decorator itself does not depend on configuration having been
+    read. A call that would write nothing is refused here, at import time.
     """
     if all(_empty(value) for value in properties.values()):
         raise ValueError("no test properties given: every value is empty")
@@ -247,18 +314,18 @@ def apply_test_metadata(
     without a value -- absent, or with nothing but empty entries -- writes no
     properties and is not an error.
 
-    With *record_xml_attribute*, *file* and *line* override the location the
-    plugin's fixture recorded, so a case can point at the file that drove it
-    rather than at the test function.
+    *file* and *line* override the location the plugin recorded, so a case can
+    point at the file that drove it rather than at the test function. The
+    override travels with the test report and is applied where the XML is
+    written, so it holds under pytest-xdist as well. *record_xml_attribute* is
+    accepted for calls written against ``score_pytest`` and not used.
     """
     for name, value in _normalise(metadata).items():
         record_property(name, value)
-
-    if record_xml_attribute is not None:
-        if file is not None:
-            record_xml_attribute("file", clean_source_path(file))
-        if line is not None:
-            record_xml_attribute("line", str(line))
+    if file is not None:
+        record_property("sphinxcontrib.test_reports:file", clean_source_path(file))
+    if line is not None:
+        record_property("sphinxcontrib.test_reports:line", str(line))
 
 
 def clean_source_path(path: str) -> str:
@@ -329,67 +396,108 @@ def pytest_configure(config: pytest.Config) -> None:
         model = parse_properties(lines)
     except ValueError as error:
         raise pytest.UsageError(str(error)) from None
+    _OUTER_MODELS.append(dict(PROPERTIES))
     PROPERTIES.clear()
     PROPERTIES.update(model)
+    config.pluginmanager.register(_XmlShape(config), name=_HOOKS)
 
     family = _report_family(config)
-    if family is None:
-        return
-    if family != "xunit1":
+    if family is not None and family != "xunit1":
         _notify(
             config,
             f"junit_family is {family!r}, but pytest writes the file/line "
             "attributes of a <testcase> only under 'xunit1'. Set junit_family = "
             "xunit1, or the test cases will have no source location.",
         )
-    if getattr(config.option, "dist", "no") != "no" and not hasattr(
-        config, "workerinput"
-    ):
-        _notify(
-            config,
-            "pytest-xdist runs the tests on workers, where record_xml_attribute "
-            "is a no-op: the test cases will carry pytest's stock file/line "
-            "(counted from 0, runfiles prefix intact) instead of the plugin's. "
-            "Write the report without -n.",
-        )
 
 
 def pytest_unconfigure(config: pytest.Config) -> None:
+    config.pluginmanager.unregister(name=_HOOKS)
     PROPERTIES.clear()
+    if _OUTER_MODELS:
+        PROPERTIES.update(_OUTER_MODELS.pop())
 
 
-@pytest.fixture(autouse=True)
-def _test_reports_xml_shape(request: pytest.FixtureRequest) -> None:
-    """Record the source location and the markers' properties for every test.
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(
+    item: pytest.Item, call: pytest.CallInfo[None]
+) -> Generator[None, pluggy.Result[pytest.TestReport], None]:
+    """Attach the markers' properties to the item before its setup report is made.
 
-    Runs at setup, so a test that fails still carries both. The location is
-    the test function's -- for a decorated function, the line of its first
-    decorator, which is where pytest points too; :func:`apply_test_metadata`
-    may override it later.
+    A hook rather than a fixture, so a case that is skipped or errors during
+    setup carries them too. The report copies the item's ``user_properties``,
+    which is how they reach the XML writer -- across the wire under xdist. A
+    value of the wrong shape turns the setup report into an error for that
+    case, with the message.
     """
-    node: pytest.Item = request.node
-    if _report_family(request.config) == "xunit1":
-        # record_xml_attribute announces itself as experimental once per test;
-        # this plugin exists to use it, so the notice is dropped here, in
-        # process, where no warning policy of the project turns it into an
-        # error. Under any other family pytest would drop the attributes again
-        # and warn per test; the start-up notice covers that once.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", pytest.PytestExperimentalApiWarning)
-            record_xml_attribute: Recorder = request.getfixturevalue(
-                "record_xml_attribute"
-            )
-        path, line_number, _domain = node.location
-        record_xml_attribute("file", clean_source_path(path))
-        if line_number is not None:
-            # pytest's line numbers are 0-based; editors and the report count
-            # from 1.
-            record_xml_attribute("line", str(line_number + 1))
+    problem: Exception | None = None
+    if call.when == "setup":
+        try:
+            item.user_properties.extend(_marked_properties(item).items())
+        except (TypeError, pytest.UsageError) as error:
+            problem = error
+    outcome = yield
+    if problem is not None:
+        report = outcome.get_result()
+        report.outcome = "failed"
+        report.longrepr = f"{type(problem).__name__}: {problem}"
 
-    # What the record_property fixture does -- but that fixture belongs to the
-    # junitxml plugin (gone under -p no:junitxml) and warns per test under
-    # xunit2, which the start-up notice already covers.
-    node.user_properties.extend(_marked_properties(node).items())
+
+class _XmlShape:
+    """The per-session hooks that shape pytest's XML writer's output.
+
+    Registered by :func:`pytest_configure` so that they hold the session's
+    config. They act on the process that owns the XML writer: in a plain run
+    this one, under pytest-xdist the controller, where the workers' reports
+    arrive.
+    """
+
+    def __init__(self, config: pytest.Config) -> None:
+        self.config = config
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:
+        # tryfirst: before pytest's junitxml handler reads the report's
+        # user_properties, the override entries have to be gone from them.
+        # A worker forwards its reports untouched; the controller does this.
+        if hasattr(self.config, "workerinput"):
+            return
+        overrides = [
+            (name, value)
+            for name, value in report.user_properties
+            if name in _OVERRIDES
+        ]
+        if overrides:
+            report.user_properties[:] = [
+                entry for entry in report.user_properties if entry[0] not in _OVERRIDES
+            ]
+        xml = _xml_writer(self.config)
+        if xml is None or _report_family(self.config) != "xunit1":
+            return
+        reporter = xml.node_reporter(report)
+        if report.when == "setup":
+            path, line_number, _domain = report.location
+            reporter.add_attribute("file", clean_source_path(path))
+            if line_number is not None:
+                # pytest's line numbers are 0-based; editors and the report
+                # count from 1.
+                reporter.add_attribute("line", str(line_number + 1))
+        for name, value in overrides:
+            reporter.add_attribute(_OVERRIDES[name], str(value))
+
+
+def _xml_writer(config: pytest.Config) -> LogXML | None:
+    """pytest's XML writer of this run: ``None`` without ``--junitxml``, under
+    ``-p no:junitxml``, and on an xdist worker, where pytest does not build it.
+
+    The writer is what the ``record_xml_attribute`` fixture talks to as well;
+    it lives behind a private key, so its absence is handled, not assumed.
+    """
+    try:
+        from _pytest.junitxml import xml_key
+    except ImportError:  # pragma: no cover -- pytest moved its junitxml plugin
+        return None
+    return config.stash.get(xml_key, None)
 
 
 def _marked_properties(node: pytest.Item) -> dict[str, str]:

--- a/sphinxcontrib/test_reports/pytest_plugin.py
+++ b/sphinxcontrib/test_reports/pytest_plugin.py
@@ -27,6 +27,7 @@ is only ever loaded by pytest.
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import Callable, Mapping, Sequence
 
@@ -275,40 +276,73 @@ def clean_source_path(path: str) -> str:
     return path
 
 
+class TestReportsConfigWarning(pytest.PytestWarning):
+    """A run configured such that the plugin cannot write the full XML shape.
+
+    Issued once at start-up. Where the project turns warnings into errors
+    (``filterwarnings = error``, ``-W error``) it becomes a clean usage error
+    rather than a traceback;
+    ``ignore::sphinxcontrib.test_reports.pytest_plugin.TestReportsConfigWarning``
+    silences it.
+    """
+
+
+def _report_family(config: pytest.Config) -> str | None:
+    """The ``junit_family`` of the report this run writes, ``None`` without one.
+
+    ``legacy`` is pytest's alias of ``xunit1``. The option does not exist under
+    ``-p no:junitxml``.
+    """
+    if not getattr(config.option, "xmlpath", None):
+        return None
+    family = str(config.getini("junit_family"))
+    return "xunit1" if family == "legacy" else family
+
+
+def _notify(config: pytest.Config, message: str) -> None:
+    """Issue *message* as :class:`TestReportsConfigWarning` at configure time."""
+    warning = TestReportsConfigWarning(
+        f"sphinxcontrib.test_reports.pytest_plugin: {message}"
+    )
+    try:
+        config.issue_config_time_warning(warning, stacklevel=3)
+    except TestReportsConfigWarning as error:
+        # The project's filters make warnings errors; raised out of
+        # pytest_configure this would be an INTERNALERROR traceback.
+        raise pytest.UsageError(str(error)) from None
+
+
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
         f"{MARKER}(properties): properties written to the JUnit XML of the "
         "test; attached by sphinxcontrib.test_reports.pytest_plugin.add_test_properties",
     )
-    # record_xml_attribute is marked experimental and says so once per test;
-    # this plugin exists to use it, so the notice is noise here.
-    config.addinivalue_line(
-        "filterwarnings",
-        "ignore:record_xml_attribute is an experimental feature:"
-        "pytest.PytestExperimentalApiWarning",
-    )
-    xmlpath: object = config.option.xmlpath
-    family: object = config.getini("junit_family")
-    if xmlpath and family != "xunit1":
-        config.issue_config_time_warning(
-            pytest.PytestConfigWarning(
-                "sphinxcontrib.test_reports.pytest_plugin: junit_family is "
-                f"{family!r}, but pytest writes the file/line attributes of a "
-                "<testcase> only under 'xunit1'. Set junit_family = xunit1, or the "
-                "test cases will have no source location."
-            ),
-            stacklevel=2,
+    family = _report_family(config)
+    if family is None:
+        return
+    if family != "xunit1":
+        _notify(
+            config,
+            f"junit_family is {family!r}, but pytest writes the file/line "
+            "attributes of a <testcase> only under 'xunit1'. Set junit_family = "
+            "xunit1, or the test cases will have no source location.",
+        )
+    if getattr(config.option, "dist", "no") != "no" and not hasattr(
+        config, "workerinput"
+    ):
+        _notify(
+            config,
+            "pytest-xdist runs the tests on workers, where record_xml_attribute "
+            "is a no-op: the test cases will carry pytest's stock file/line "
+            "(counted from 0, runfiles prefix intact) instead of the plugin's. "
+            "Write the report without -n.",
         )
 
 
 @pytest.fixture(autouse=True)
-def _test_reports_xml_shape(
-    request: pytest.FixtureRequest,
-    record_property: Recorder,
-    record_xml_attribute: Recorder,
-) -> None:
-    """Record the source location and the marker's properties for every test.
+def _test_reports_xml_shape(request: pytest.FixtureRequest) -> None:
+    """Record the source location and the markers' properties for every test.
 
     Runs at setup, so a test that fails still carries both. The location is
     the test function's -- for a decorated function, the line of its first
@@ -316,16 +350,28 @@ def _test_reports_xml_shape(
     may override it later.
     """
     node: pytest.Item = request.node
-    location: tuple[str, int | None, str] = node.location
-    path, line_number, _domain = location
-    record_xml_attribute("file", clean_source_path(path))
-    if line_number is not None:
-        # pytest's line numbers are 0-based; editors and the report count
-        # from 1.
-        record_xml_attribute("line", str(line_number + 1))
+    if _report_family(request.config) == "xunit1":
+        # record_xml_attribute announces itself as experimental once per test;
+        # this plugin exists to use it, so the notice is dropped here, in
+        # process, where no warning policy of the project turns it into an
+        # error. Under any other family pytest would drop the attributes again
+        # and warn per test; the start-up notice covers that once.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", pytest.PytestExperimentalApiWarning)
+            record_xml_attribute: Recorder = request.getfixturevalue(
+                "record_xml_attribute"
+            )
+        path, line_number, _domain = node.location
+        record_xml_attribute("file", clean_source_path(path))
+        if line_number is not None:
+            # pytest's line numbers are 0-based; editors and the report count
+            # from 1.
+            record_xml_attribute("line", str(line_number + 1))
 
-    for name, value in _marked_properties(node).items():
-        record_property(name, value)
+    # What the record_property fixture does -- but that fixture belongs to the
+    # junitxml plugin (gone under -p no:junitxml) and warns per test under
+    # xunit2, which the start-up notice already covers.
+    node.user_properties.extend(_marked_properties(node).items())
 
 
 def _marked_properties(node: pytest.Item) -> dict[str, str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from tempfile import mkdtemp
 
 import pytest
 
-pytest_plugins = "sphinx.testing.fixtures"
+pytest_plugins = ["sphinx.testing.fixtures", "pytester"]
 
 
 def copy_srcdir_to_tmpdir(srcdir, tmp):

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -10,9 +10,12 @@ import xml.etree.ElementTree as ET
 
 import pytest
 
+from sphinxcontrib.test_reports import pytest_plugin
 from sphinxcontrib.test_reports.pytest_plugin import (
+    apply_test_metadata,
     clean_source_path,
     properties_mapping,
+    register_property,
 )
 
 PLUGIN = "sphinxcontrib.test_reports.pytest_plugin"
@@ -163,3 +166,68 @@ class TestHelpers:
             [sys.executable, "-c", script], capture_output=True, text=True, check=True
         )
         assert result.stdout.strip() == ""
+
+
+class TestPropertyValues:
+    """How a keyword's value reaches the XML: declared per property, not guessed."""
+
+    def test_a_bare_string_is_one_requirement_id(self):
+        # str is a Sequence[str]; it must not be exploded character by character.
+        assert properties_mapping(partially_verifies="REQ_1") == {
+            "PartiallyVerifies": "REQ_1"
+        }
+
+    def test_a_list_for_a_single_valued_property_is_an_error(self):
+        with pytest.raises(TypeError, match="test_type.*single value"):
+            properties_mapping(test_type=["a", "b"])
+
+    def test_a_custom_keyword_takes_a_single_value(self):
+        assert properties_mapping(Owner="team-a") == {"Owner": "team-a"}
+
+    def test_a_list_under_an_unregistered_keyword_is_an_error(self):
+        # Previously written as the Python repr "['REQ_1', 'REQ_2']".
+        with pytest.raises(TypeError, match="Satisfies.*register_property"):
+            properties_mapping(Satisfies=["REQ_1", "REQ_2"])
+
+    def test_a_registered_keyword_joins_its_list(self, monkeypatch):
+        monkeypatch.setattr(pytest_plugin, "PROPERTIES", dict(pytest_plugin.PROPERTIES))
+        register_property("satisfies", "Satisfies", multi=True)
+        assert properties_mapping(satisfies=["REQ_1", "REQ_2"]) == {
+            "Satisfies": "REQ_1, REQ_2"
+        }
+        assert properties_mapping(satisfies="REQ_1") == {"Satisfies": "REQ_1"}
+
+    def test_the_xml_name_of_a_registered_property_works_as_keyword(self):
+        assert properties_mapping(PartiallyVerifies=["REQ_1", "REQ_2"]) == {
+            "PartiallyVerifies": "REQ_1, REQ_2"
+        }
+
+    def test_numbers_are_written_as_text(self):
+        assert properties_mapping(Priority=3) == {"Priority": "3"}
+
+    def test_an_unordered_collection_is_an_error(self):
+        # str(set) would be written otherwise, and a set has no stable order.
+        with pytest.raises(TypeError, match="partially_verifies"):
+            properties_mapping(partially_verifies={"REQ_1", "REQ_2"})
+
+
+class TestRuntimeMetadata:
+    def test_all_empty_metadata_records_nothing(self):
+        # A spec file with an empty metadata block must not fail the test.
+        recorded = []
+        apply_test_metadata(
+            record_property=lambda name, value: recorded.append((name, value)),
+            metadata={"fully_verifies": [], "test_type": ""},
+        )
+        assert recorded == []
+
+    def test_the_location_is_applied_without_metadata(self):
+        attributes = {}
+        apply_test_metadata(
+            record_property=lambda name, value: None,
+            metadata={},
+            record_xml_attribute=attributes.__setitem__,
+            file="../_main/specs/a.rst",
+            line=7,
+        )
+        assert attributes == {"file": "specs/a.rst", "line": "7"}

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -372,6 +372,28 @@ class TestPropertyModel:
         # Not configured: written under its own name, as a single value.
         assert written["derivation_technique"] == "requirements-analysis"
 
+    def test_a_decorator_may_run_before_configuration_is_read(self, pytester):
+        # A conftest.py that imports a helper module runs during pytest's
+        # pre-parse, before pytest_configure installs the model. The decorator
+        # keeps the keywords as given, so that shape neither crashes collection
+        # nor loses the properties, which are written at setup.
+        pytester.makepyfile(
+            helpers=(
+                "from sphinxcontrib.test_reports.pytest_plugin import add_test_properties\n"
+                "\n"
+                '@add_test_properties(partially_verifies=["REQ_1"], test_type="interface-test")\n'
+                "def test_from_helper():\n"
+                "    assert True\n"
+            )
+        )
+        pytester.makeconftest("import helpers  # decorates at pre-parse time\n")
+        result, root = _run(pytester, "from helpers import test_from_helper\n")
+        result.assert_outcomes(passed=1)
+        assert _properties(_cases(root)["test_from_helper"]) == {
+            "PartiallyVerifies": "REQ_1",
+            "TestType": "interface-test",
+        }
+
     def test_without_a_profile_a_list_is_an_error_naming_the_option(self, pytester):
         # Silently writing "['REQ_1', 'REQ_2']" is the bug this replaces.
         result, root = _run(pytester, DECORATED, profile="")

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -70,9 +70,15 @@ PLAIN_LINE = _line_of(DECORATED, "def test_plain")
 
 
 def _run(pytester, source, *extra, family="xunit1"):
+    """Run *source* with the plugin in a fresh pytest process and parse the XML.
+
+    A subprocess, not in-process: this module has the plugin imported already,
+    and pytest warns about a ``-p`` module it cannot assert-rewrite any more --
+    noise in the warning counts, an error under a strict warning policy.
+    """
     pytester.makepyfile(source)
     report = pytester.path / "report.xml"
-    result = pytester.runpytest(
+    result = pytester.runpytest_subprocess(
         "-p", PLUGIN, "--junitxml", str(report), "-o", f"junit_family={family}", *extra
     )
     return result, (ET.parse(report).getroot() if report.exists() else None)
@@ -278,3 +284,88 @@ class TestMarkerMerge:
             "FullyVerifies": "REQ_3",
             "TestType": "interface-test",
         }
+
+
+PLAIN = """
+def test_plain():
+    assert True
+"""
+
+MARKED_STRICT = """
+import pytest
+
+
+@pytest.mark.filterwarnings("error")
+def test_strict():
+    assert True
+"""
+
+
+class TestStartUp:
+    """The plugin's own notices, and pytest's about its fixtures, never take the
+    run down -- whatever the project's warning policy."""
+
+    def test_filterwarnings_error_in_the_ini_keeps_the_run_alive(self, pytester):
+        pytester.makeini("[pytest]\nfilterwarnings = error\n")
+        result, root = _run(pytester, DECORATED)
+        result.assert_outcomes(passed=2)
+        assert _cases(root)["test_plain"].get("line") == str(PLAIN_LINE)
+
+    def test_w_error_on_the_command_line_keeps_the_run_alive(self, pytester):
+        # An appended ini filter cannot silence the record_xml_attribute notice
+        # here: command-line filters take precedence over every ini line.
+        result, root = _run(pytester, DECORATED, "-W", "error")
+        result.assert_outcomes(passed=2)
+        assert _cases(root)["test_plain"].get("line") == str(PLAIN_LINE)
+
+    def test_a_strict_filterwarnings_mark_keeps_the_test_alive(self, pytester):
+        result, root = _run(pytester, MARKED_STRICT)
+        result.assert_outcomes(passed=1)
+        assert _cases(root)["test_strict"].get("file") is not None
+
+    def test_xunit2_under_filterwarnings_error_is_a_clean_usage_error(self, pytester):
+        # The project asked for warnings to be errors; the plugin's advice is
+        # one, delivered as a usage error rather than an INTERNALERROR trace.
+        pytester.makeini("[pytest]\nfilterwarnings = error\n")
+        result, _ = _run(pytester, PLAIN, family="xunit2")
+        assert result.ret == pytest.ExitCode.USAGE_ERROR
+        result.stderr.fnmatch_lines(["ERROR: *junit_family is 'xunit2'*xunit1*"])
+        assert "INTERNALERROR" not in result.stdout.str()
+
+    def test_the_notice_can_be_silenced_by_its_class(self, pytester):
+        pytester.makeini(
+            "[pytest]\nfilterwarnings =\n    error\n"
+            f"    ignore::{PLUGIN}.TestReportsConfigWarning\n"
+        )
+        result, _ = _run(pytester, PLAIN, family="xunit2")
+        result.assert_outcomes(passed=1, warnings=0)
+
+    def test_xunit2_gives_no_per_test_fixture_warnings(self, pytester):
+        # pytest drops the attributes under xunit2 anyway and would warn per test
+        # that record_xml_attribute is incompatible; the plugin says it once.
+        result, _ = _run(pytester, PLAIN, family="xunit2")
+        result.assert_outcomes(passed=1, warnings=1)
+        assert not [
+            line for line in result.stdout.lines if "is incompatible with" in line
+        ]
+
+    def test_legacy_is_an_alias_of_xunit1(self, pytester):
+        result, root = _run(pytester, DECORATED, family="legacy")
+        result.assert_outcomes(passed=2, warnings=0)
+        assert _cases(root)["test_plain"].get("line") == str(PLAIN_LINE)
+
+    def test_the_junitxml_plugin_may_be_disabled(self, pytester):
+        # config.option.xmlpath exists only while pytest's junitxml plugin is
+        # registered, and so do the record_* fixtures.
+        pytester.makepyfile(DECORATED)
+        result = pytester.runpytest_subprocess("-p", PLUGIN, "-p", "no:junitxml")
+        result.assert_outcomes(passed=2)
+
+    def test_xdist_is_warned_about(self, pytester):
+        # record_xml_attribute is a no-op on xdist workers: pytest builds the
+        # XML writer on the controller only, so the locations are lost silently.
+        pytest.importorskip("xdist")
+        result, root = _run(pytester, DECORATED, "-n", "1")
+        result.assert_outcomes(passed=2, warnings=1)
+        result.stdout.fnmatch_lines(["*TestReportsConfigWarning*pytest-xdist*"])
+        assert root is not None

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,165 @@
+"""The pytest plugin produces the XML shape this extension reads.
+
+Run through ``pytester``: a small test file is executed with the plugin enabled
+and the resulting JUnit XML inspected.
+"""
+
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from sphinxcontrib.test_reports.pytest_plugin import (
+    clean_source_path,
+    properties_mapping,
+)
+
+PLUGIN = "sphinxcontrib.test_reports.pytest_plugin"
+
+DECORATED = """
+from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
+
+@add_test_properties(
+    partially_verifies=["REQ_1", "REQ_2"],
+    test_type="requirements-based",
+    derivation_technique="requirements-analysis",
+    Owner="team-a",
+)
+def test_addition():
+    assert 1 + 1 == 2
+
+
+def test_plain():
+    assert True
+"""
+
+RUNTIME = """
+import pytest
+from sphinxcontrib.test_reports.pytest_plugin import apply_test_metadata
+
+@pytest.mark.parametrize("spec", ["a.rst", "b.rst"])
+def test_driven_by_a_file(spec, record_property, record_xml_attribute):
+    apply_test_metadata(
+        record_property=record_property,
+        metadata={"fully_verifies": ["REQ_9"], "test_type": "interface-test"},
+        record_xml_attribute=record_xml_attribute,
+        file=f"specs/{spec}",
+        line=7,
+    )
+    assert spec.endswith(".rst")
+"""
+
+
+def _line_of(source, needle):
+    """1-based line of *needle* in the file pytester writes (it strips the
+    leading blank line)."""
+    return next(
+        index
+        for index, line in enumerate(source.strip().splitlines(), start=1)
+        if line.startswith(needle)
+    )
+
+
+# pytest points a decorated function at its first decorator line.
+ADDITION_LINE = _line_of(DECORATED, "@add_test_properties(")
+PLAIN_LINE = _line_of(DECORATED, "def test_plain")
+
+
+def _run(pytester, source, *extra, family="xunit1"):
+    pytester.makepyfile(source)
+    report = pytester.path / "report.xml"
+    result = pytester.runpytest(
+        "-p", PLUGIN, "--junitxml", str(report), "-o", f"junit_family={family}", *extra
+    )
+    return result, (ET.parse(report).getroot() if report.exists() else None)
+
+
+def _cases(root):
+    return {case.get("name"): case for case in root.iter("testcase")}
+
+
+def _properties(case):
+    return {p.get("name"): p.get("value") for p in case.iter("property")}
+
+
+class TestXmlShape:
+    def test_every_case_carries_its_source_location(self, pytester):
+        result, root = _run(pytester, DECORATED)
+        result.assert_outcomes(passed=2)
+        cases = _cases(root)
+        for case in cases.values():
+            assert case.get("file") == "test_every_case_carries_its_source_location.py"
+        # pytest counts lines from 0; the attribute counts from 1 like editors.
+        # A decorated function is located at its first decorator.
+        assert cases["test_addition"].get("line") == str(ADDITION_LINE)
+        assert cases["test_plain"].get("line") == str(PLAIN_LINE)
+
+    def test_the_decorator_writes_properties(self, pytester):
+        _, root = _run(pytester, DECORATED)
+        assert _properties(_cases(root)["test_addition"]) == {
+            "PartiallyVerifies": "REQ_1, REQ_2",
+            "TestType": "requirements-based",
+            "DerivationTechnique": "requirements-analysis",
+            "Owner": "team-a",
+        }
+        assert _properties(_cases(root)["test_plain"]) == {}
+
+    def test_runtime_metadata_and_location_override(self, pytester):
+        result, root = _run(pytester, RUNTIME)
+        result.assert_outcomes(passed=2)
+        case = _cases(root)["test_driven_by_a_file[a.rst]"]
+        assert _properties(case) == {
+            "FullyVerifies": "REQ_9",
+            "TestType": "interface-test",
+        }
+        assert case.get("file") == "specs/a.rst"
+        assert case.get("line") == "7"
+
+    def test_the_marker_is_registered(self, pytester):
+        result, _ = _run(pytester, DECORATED, "--strict-markers")
+        result.assert_outcomes(passed=2)
+
+    def test_the_record_xml_attribute_notice_is_silenced(self, pytester):
+        # pytest flags record_xml_attribute as experimental once per test; the
+        # plugin exists to use it, so that notice must not reach the user.
+        result, _ = _run(pytester, DECORATED)
+        noisy = [
+            line
+            for line in result.stdout.lines
+            if "record_xml_attribute is an experimental feature" in line
+        ]
+        assert noisy == []
+
+    def test_xunit2_is_warned_about_at_configure_time(self, pytester):
+        result, root = _run(pytester, DECORATED, family="xunit2")
+        result.stdout.fnmatch_lines(["*junit_family is 'xunit2'*xunit1*"])
+        assert _cases(root)["test_plain"].get("file") is None
+
+
+class TestHelpers:
+    def test_bazel_runfiles_prefix_is_cut(self):
+        assert clean_source_path("../_main/pkg/test_x.py") == "pkg/test_x.py"
+        assert clean_source_path("pkg/test_x.py") == "pkg/test_x.py"
+
+    def test_empty_values_are_dropped(self):
+        assert properties_mapping(fully_verifies=["R"], test_type="") == {
+            "FullyVerifies": "R"
+        }
+
+    def test_nothing_to_record_is_an_error(self):
+        with pytest.raises(ValueError, match="no test properties"):
+            properties_mapping(partially_verifies=[])
+
+    def test_the_plugin_does_not_import_sphinx(self):
+        script = (
+            "import sys;"
+            f"import {PLUGIN};"
+            "leaked = sorted(m for m in sys.modules"
+            " if m == 'sphinx' or m.startswith(('sphinx.', 'sphinx_needs')));"
+            "print(','.join(leaked))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, check=True
+        )
+        assert result.stdout.strip() == ""

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -146,11 +146,37 @@ class TestXmlShape:
         assert _cases(root)["test_plain"].get("file") is None
 
 
-class TestHelpers:
-    def test_bazel_runfiles_prefix_is_cut(self):
+class TestSourcePath:
+    def test_the_runfiles_prefix_is_cut_at_a_path_component(self):
         assert clean_source_path("../_main/pkg/test_x.py") == "pkg/test_x.py"
+        assert clean_source_path("_main/pkg/test_x.py") == "pkg/test_x.py"
+        assert (
+            clean_source_path("/cache/bin/t.runfiles/_main/pkg/test_x.py")
+            == "pkg/test_x.py"
+        )
         assert clean_source_path("pkg/test_x.py") == "pkg/test_x.py"
 
+    def test_a_directory_merely_ending_in_main_is_kept(self):
+        # Two files under app_main/ and domain_main/ used to collapse onto the
+        # same path -- and, with tr_deterministic_case_ids, onto the same ID.
+        assert (
+            clean_source_path("services/app_main/tests/test_api.py")
+            == "services/app_main/tests/test_api.py"
+        )
+        assert clean_source_path("domain_main/test_api.py") == "domain_main/test_api.py"
+
+    def test_the_last_runfiles_component_wins(self):
+        # Under bzlmod the execroot's workspace directory is _main as well.
+        assert (
+            clean_source_path("execroot/_main/bazel-out/bin/t.runfiles/_main/pkg/t.py")
+            == "pkg/t.py"
+        )
+
+    def test_windows_separators_count_as_boundaries(self):
+        assert clean_source_path("..\\_main\\pkg\\test_x.py") == "pkg\\test_x.py"
+
+
+class TestHelpers:
     def test_empty_values_are_dropped(self):
         assert properties_mapping(fully_verifies=["R"], test_type="") == {
             "FullyVerifies": "R"

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -53,16 +53,81 @@ import pytest
 from sphinxcontrib.test_reports.pytest_plugin import apply_test_metadata
 
 @pytest.mark.parametrize("spec", ["a.rst", "b.rst"])
-def test_driven_by_a_file(spec, record_property, record_xml_attribute):
+def test_driven_by_a_file(spec, record_property):
     apply_test_metadata(
         record_property=record_property,
         metadata={"fully_verifies": ["REQ_9"], "test_type": "interface-test"},
-        record_xml_attribute=record_xml_attribute,
-        file=f"specs/{spec}",
+        file=f"../_main/specs/{spec}",
         line=7,
     )
     assert spec.endswith(".rst")
 """
+
+RUNTIME_COMPAT = """
+from sphinxcontrib.test_reports.pytest_plugin import apply_test_metadata
+
+def test_score_style(record_property, record_xml_attribute):
+    apply_test_metadata(
+        record_property=record_property,
+        metadata={"fully_verifies": ["REQ_9"]},
+        record_xml_attribute=record_xml_attribute,
+        file="specs/a.rst",
+        line=7,
+    )
+"""
+
+SKIPPED = """
+import pytest
+from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
+
+
+@pytest.fixture(scope="module")
+def broken():
+    raise RuntimeError("no database")
+
+
+@pytest.mark.skip(reason="not today")
+@add_test_properties(partially_verifies=["REQ_1"])
+def test_skipped():
+    assert False
+
+
+@pytest.mark.xfail(run=False, reason="never run")
+def test_not_run():
+    assert False
+
+
+@add_test_properties(fully_verifies=["REQ_2"])
+def test_setup_error(broken):
+    assert True
+
+
+def test_runs():
+    assert True
+"""
+
+NESTED = """
+import pytest
+from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
+
+
+@add_test_properties(partially_verifies=["REQ_1"])
+def test_before():
+    assert True
+
+
+def test_inner_session(tmp_path):
+    # A project testing its own pytest setup runs an inner session in process.
+    inner = tmp_path / "test_inner.py"
+    inner.write_text("def test_inner():\\n    assert True\\n")
+    (tmp_path / "pytest.ini").write_text("[pytest]\\n")
+    assert pytest.main(["-q", "-p", "no:cacheprovider", "-p", "PLUGIN", str(inner)]) == 0
+
+
+@add_test_properties(partially_verifies=["REQ_2"])
+def test_after():
+    assert True
+""".replace("PLUGIN", PLUGIN)
 
 PLAIN = """
 def test_plain():
@@ -121,6 +186,12 @@ def _line_of(source, needle):
 # pytest points a decorated function at its first decorator line.
 ADDITION_LINE = _line_of(DECORATED, "@add_test_properties(")
 PLAIN_LINE = _line_of(DECORATED, "def test_plain")
+SKIPPED_LINES = {
+    "test_skipped": _line_of(SKIPPED, "@pytest.mark.skip"),
+    "test_not_run": _line_of(SKIPPED, "@pytest.mark.xfail"),
+    "test_setup_error": _line_of(SKIPPED, "@add_test_properties(fully_verifies"),
+    "test_runs": _line_of(SKIPPED, "def test_runs"),
+}
 
 
 def _run(pytester, source, *extra, family="xunit1", profile=SCORE_PROFILE, ini=""):
@@ -189,6 +260,30 @@ class TestXmlShape:
         assert case.get("file") == "specs/a.rst"
         assert case.get("line") == "7"
 
+    def test_record_xml_attribute_is_still_accepted(self, pytester):
+        # score_pytest call sites pass it; it is not needed any more.
+        result, root = _run(pytester, RUNTIME_COMPAT)
+        result.assert_outcomes(passed=1, warnings=1)  # pytest's experimental notice
+        case = _cases(root)["test_score_style"]
+        assert (case.get("file"), case.get("line")) == ("specs/a.rst", "7")
+
+    def test_cases_skipped_or_erroring_at_setup_carry_the_same_shape(self, pytester):
+        # A function-scoped fixture never runs for these; the report has to be
+        # shaped by hooks, or one report mixes 1-based and 0-based lines and,
+        # under Bazel, cut and uncut paths -- which moves a deterministic ID.
+        result, root = _run(pytester, SKIPPED)
+        result.assert_outcomes(passed=1, skipped=1, xfailed=1, errors=1)
+        cases = _cases(root)
+        for name, line in SKIPPED_LINES.items():
+            assert cases[name].get("line") == str(line), name
+        assert _properties(cases["test_skipped"]) == {"PartiallyVerifies": "REQ_1"}
+        assert _properties(cases["test_setup_error"]) == {"FullyVerifies": "REQ_2"}
+
+    def test_an_inner_pytest_session_leaves_the_model_intact(self, pytester):
+        result, root = _run(pytester, NESTED)
+        result.assert_outcomes(passed=3)
+        assert _properties(_cases(root)["test_after"]) == {"PartiallyVerifies": "REQ_2"}
+
     def test_the_marker_is_registered(self, pytester):
         result, _ = _run(pytester, DECORATED, "--strict-markers")
         result.assert_outcomes(passed=2)
@@ -242,6 +337,11 @@ class TestPropertyModel:
     def test_a_keyword_given_twice_is_an_error(self):
         with pytest.raises(ValueError, match="twice"):
             parse_properties(["a = A", "a = B"])
+
+    def test_two_keywords_for_one_xml_name_is_an_error(self):
+        # _normalise would keep only the later value, silently.
+        with pytest.raises(ValueError, match="'B'"):
+            parse_properties(["a = B", "c = B"])
 
     def test_a_custom_profile_drives_the_xml(self, pytester):
         profile = "test_reports_properties =\n    satisfies = Satisfies, list\n    reviewers, list\n"
@@ -315,6 +415,35 @@ class TestPropertyValues:
     def test_numbers_are_written_as_text(self, score_model):
         assert properties_mapping(Priority=3) == {"Priority": "3"}
 
+    def test_bytes_are_an_error(self, score_model):
+        # bytes is a Sequence of ints: b"REQ_1" would join to "82, 69, 81, 95, 49".
+        with pytest.raises(TypeError, match="bytes"):
+            properties_mapping(fully_verifies=b"REQ_1")
+
+    def test_every_item_of_a_list_must_be_a_string(self, score_model):
+        # A list of lists is one indentation away in a spec file; it used to be
+        # written as its repr and split into bogus IDs on the build side.
+        with pytest.raises(TypeError, match="partially_verifies.*item.*list"):
+            properties_mapping(partially_verifies=[["REQ_1", "REQ_2"]])
+        with pytest.raises(TypeError, match="item.*int"):
+            properties_mapping(partially_verifies=[1, 2])
+
+    def test_an_empty_nested_list_is_not_written_as_brackets(self, score_model):
+        with pytest.raises(TypeError, match="item"):
+            properties_mapping(partially_verifies=[[]], fully_verifies=["R"])
+
+    # The decorator builds the marker here, outside a session that registers it.
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnknownMarkWarning")
+    def test_the_import_gate_and_the_writer_agree_on_emptiness(self, score_model):
+        # Only None, "" and sequences of those count as empty. Anything else
+        # passes the decorator and is then judged by the writer.
+        with pytest.raises(ValueError, match="no test properties"):
+            pytest_plugin.add_test_properties(partially_verifies=[""], test_type=None)
+        decorator = pytest_plugin.add_test_properties(partially_verifies=[[]])
+        assert callable(decorator)
+        with pytest.raises(TypeError):
+            properties_mapping(partially_verifies=[[]])
+
     def test_an_unordered_collection_is_an_error(self, score_model):
         # str(set) would be written otherwise, and a set has no stable order.
         with pytest.raises(TypeError, match="partially_verifies"):
@@ -346,16 +475,16 @@ class TestRuntimeMetadata:
         )
         assert recorded == []
 
-    def test_the_location_is_applied_without_metadata(self, score_model):
-        attributes = {}
-        apply_test_metadata(
-            record_property=lambda name, value: None,
-            metadata={},
-            record_xml_attribute=attributes.__setitem__,
-            file="../_main/specs/a.rst",
-            line=7,
+    def test_the_location_is_applied_without_metadata(self, pytester):
+        source = RUNTIME.replace(
+            'metadata={"fully_verifies": ["REQ_9"], "test_type": "interface-test"}',
+            "metadata={}",
         )
-        assert attributes == {"file": "specs/a.rst", "line": "7"}
+        result, root = _run(pytester, source)
+        result.assert_outcomes(passed=2)
+        case = _cases(root)["test_driven_by_a_file[a.rst]"]
+        assert _properties(case) == {}
+        assert (case.get("file"), case.get("line")) == ("specs/a.rst", "7")
 
 
 class TestMarkerMerge:
@@ -445,18 +574,24 @@ class TestStartUp:
         result = pytester.runpytest_subprocess("-p", PLUGIN, "-p", "no:junitxml")
         result.assert_outcomes(passed=2)
 
-    def test_xdist_is_warned_about(self, pytester):
-        # record_xml_attribute is a no-op on xdist workers: pytest builds the
-        # XML writer on the controller only, so the locations are lost silently.
+    def test_xdist_gets_the_full_shape(self, pytester):
+        # pytest builds the XML writer on the controller only, so nothing a
+        # worker records as an attribute survives; the location is written on
+        # the controller from the report instead, and the model reaches the
+        # workers for the properties.
         pytest.importorskip("xdist")
         result, root = _run(pytester, DECORATED, "-n", "1")
-        result.assert_outcomes(passed=2, warnings=1)
-        result.stdout.fnmatch_lines(["*TestReportsConfigWarning*pytest-xdist*"])
-        # The model reaches the workers: the properties are written there.
-        assert (
-            _properties(_cases(root)["test_addition"])["PartiallyVerifies"]
-            == "REQ_1, REQ_2"
-        )
+        result.assert_outcomes(passed=2, warnings=0)
+        case = _cases(root)["test_addition"]
+        assert case.get("line") == str(ADDITION_LINE)
+        assert _properties(case)["PartiallyVerifies"] == "REQ_1, REQ_2"
+
+    def test_xdist_gets_the_runtime_location_override(self, pytester):
+        pytest.importorskip("xdist")
+        result, root = _run(pytester, RUNTIME, "-n", "1")
+        result.assert_outcomes(passed=2)
+        case = _cases(root)["test_driven_by_a_file[a.rst]"]
+        assert (case.get("file"), case.get("line")) == ("specs/a.rst", "7")
 
 
 class TestSourcePath:
@@ -495,7 +630,8 @@ class TestHelpers:
             "import sys;"
             f"import {PLUGIN};"
             "leaked = sorted(m for m in sys.modules"
-            " if m == 'sphinx' or m.startswith(('sphinx.', 'sphinx_needs')));"
+            " if m in ('sphinx', 'docutils')"
+            " or m.startswith(('sphinx.', 'sphinx_needs', 'docutils.')));"
             "print(','.join(leaked))"
         )
         result = subprocess.run(

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -231,3 +231,50 @@ class TestRuntimeMetadata:
             line=7,
         )
         assert attributes == {"file": "specs/a.rst", "line": "7"}
+
+
+STACKED = """
+from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
+
+
+@add_test_properties(test_type="requirements-based", Owner="team-a")
+class TestThing:
+    @add_test_properties(partially_verifies=["REQ_1"])
+    def test_one(self):
+        assert True
+
+    @add_test_properties(partially_verifies=["REQ_2"], Owner="team-b")
+    def test_two(self):
+        assert True
+
+
+@add_test_properties(fully_verifies=["REQ_3"])
+@add_test_properties(test_type="interface-test")
+def test_stacked():
+    assert True
+"""
+
+
+class TestMarkerMerge:
+    def test_class_and_method_markers_are_merged(self, pytester):
+        # A classification on the class and links on each method is the natural
+        # way to use the decorator; get_closest_marker kept only the innermost.
+        result, root = _run(pytester, STACKED)
+        result.assert_outcomes(passed=3)
+        cases = _cases(root)
+        assert _properties(cases["test_one"]) == {
+            "PartiallyVerifies": "REQ_1",
+            "TestType": "requirements-based",
+            "Owner": "team-a",
+        }
+
+    def test_the_innermost_marker_wins_per_key(self, pytester):
+        _, root = _run(pytester, STACKED)
+        assert _properties(_cases(root)["test_two"])["Owner"] == "team-b"
+
+    def test_stacked_decorators_on_a_function_are_merged(self, pytester):
+        _, root = _run(pytester, STACKED)
+        assert _properties(_cases(root)["test_stacked"]) == {
+            "FullyVerifies": "REQ_3",
+            "TestType": "interface-test",
+        }

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,7 +1,8 @@
 """The pytest plugin produces the XML shape this extension reads.
 
 Run through ``pytester``: a small test file is executed with the plugin enabled
-and the resulting JUnit XML inspected.
+and the resulting JUnit XML inspected. The property model comes from the
+``test_reports_properties`` ini option; S-CORE's is the profile most tests use.
 """
 
 import subprocess
@@ -12,13 +13,23 @@ import pytest
 
 from sphinxcontrib.test_reports import pytest_plugin
 from sphinxcontrib.test_reports.pytest_plugin import (
+    Property,
     apply_test_metadata,
     clean_source_path,
+    parse_properties,
     properties_mapping,
-    register_property,
 )
 
 PLUGIN = "sphinxcontrib.test_reports.pytest_plugin"
+
+#: S-CORE's model, as the docs show it: the profile most of these tests run with.
+SCORE_PROFILE = """\
+test_reports_properties =
+    partially_verifies = PartiallyVerifies, list
+    fully_verifies = FullyVerifies, list
+    test_type = TestType
+    derivation_technique = DerivationTechnique
+"""
 
 DECORATED = """
 from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
@@ -53,6 +64,49 @@ def test_driven_by_a_file(spec, record_property, record_xml_attribute):
     assert spec.endswith(".rst")
 """
 
+PLAIN = """
+def test_plain():
+    assert True
+"""
+
+MARKED_STRICT = """
+import pytest
+
+
+@pytest.mark.filterwarnings("error")
+def test_strict():
+    assert True
+"""
+
+STACKED = """
+from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
+
+
+@add_test_properties(test_type="requirements-based", Owner="team-a")
+class TestThing:
+    @add_test_properties(partially_verifies=["REQ_1"])
+    def test_one(self):
+        assert True
+
+    @add_test_properties(partially_verifies=["REQ_2"], Owner="team-b")
+    def test_two(self):
+        assert True
+
+
+@add_test_properties(fully_verifies=["REQ_3"])
+@add_test_properties(test_type="interface-test")
+def test_stacked():
+    assert True
+"""
+
+CUSTOM = """
+from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
+
+@add_test_properties(satisfies=["REQ_1", "REQ_2"], reviewers=["ann", "bob"], Owner="x")
+def test_custom():
+    assert True
+"""
+
 
 def _line_of(source, needle):
     """1-based line of *needle* in the file pytester writes (it strips the
@@ -69,13 +123,16 @@ ADDITION_LINE = _line_of(DECORATED, "@add_test_properties(")
 PLAIN_LINE = _line_of(DECORATED, "def test_plain")
 
 
-def _run(pytester, source, *extra, family="xunit1"):
+def _run(pytester, source, *extra, family="xunit1", profile=SCORE_PROFILE, ini=""):
     """Run *source* with the plugin in a fresh pytest process and parse the XML.
 
-    A subprocess, not in-process: this module has the plugin imported already,
-    and pytest warns about a ``-p`` module it cannot assert-rewrite any more --
-    noise in the warning counts, an error under a strict warning policy.
+    *profile* is the ``test_reports_properties`` block of the ini file, *ini*
+    any further ini lines. A subprocess, not in-process: this module has the
+    plugin imported already, and pytest warns about a ``-p`` module it cannot
+    assert-rewrite any more -- noise in the warning counts, an error under a
+    strict warning policy.
     """
+    pytester.makeini("[pytest]\n" + profile + ini)
     pytester.makepyfile(source)
     report = pytester.path / "report.xml"
     result = pytester.runpytest_subprocess(
@@ -90,6 +147,13 @@ def _cases(root):
 
 def _properties(case):
     return {p.get("name"): p.get("value") for p in case.iter("property")}
+
+
+@pytest.fixture
+def score_model(monkeypatch):
+    """The S-CORE profile installed as the plugin's model, for direct calls."""
+    lines = [line.strip() for line in SCORE_PROFILE.splitlines()[1:]]
+    monkeypatch.setattr(pytest_plugin, "PROPERTIES", parse_properties(lines))
 
 
 class TestXmlShape:
@@ -146,6 +210,255 @@ class TestXmlShape:
         assert _cases(root)["test_plain"].get("file") is None
 
 
+class TestPropertyModel:
+    """The model is pytest configuration; the plugin ships no names of its own."""
+
+    def test_a_line_declares_keyword_name_and_arity(self):
+        assert parse_properties(
+            ["partially_verifies = PartiallyVerifies, list", "test_type = TestType"]
+        ) == {
+            "partially_verifies": Property("PartiallyVerifies", multi=True),
+            "test_type": Property("TestType"),
+        }
+
+    def test_the_name_defaults_to_the_keyword(self):
+        assert parse_properties(["reviewers, list", "Owner"]) == {
+            "reviewers": Property("reviewers", multi=True),
+            "Owner": Property("Owner"),
+        }
+
+    def test_blank_lines_are_skipped(self):
+        assert parse_properties(["", "  ", "Owner"]) == {"Owner": Property("Owner")}
+
+    @pytest.mark.parametrize(
+        "line",
+        ["a = b = c", "a, list, extra", "= Name", "a, set"],
+        ids=["two-equals", "two-flags", "no-keyword", "unknown-flag"],
+    )
+    def test_a_line_outside_the_grammar_is_an_error(self, line):
+        with pytest.raises(ValueError, match="test_reports_properties"):
+            parse_properties([line])
+
+    def test_a_keyword_given_twice_is_an_error(self):
+        with pytest.raises(ValueError, match="twice"):
+            parse_properties(["a = A", "a = B"])
+
+    def test_a_custom_profile_drives_the_xml(self, pytester):
+        profile = "test_reports_properties =\n    satisfies = Satisfies, list\n    reviewers, list\n"
+        result, root = _run(pytester, CUSTOM, profile=profile)
+        result.assert_outcomes(passed=1)
+        assert _properties(_cases(root)["test_custom"]) == {
+            "Satisfies": "REQ_1, REQ_2",
+            "reviewers": "ann, bob",
+            "Owner": "x",
+        }
+
+    def test_the_profile_may_come_from_pyproject(self, pytester):
+        pytester.makepyprojecttoml(
+            "[tool.pytest.ini_options]\n"
+            "test_reports_properties = [\n"
+            '    "partially_verifies = PartiallyVerifies, list",\n'
+            '    "test_type = TestType",\n'
+            "]\n"
+        )
+        pytester.makepyfile(DECORATED)
+        report = pytester.path / "report.xml"
+        result = pytester.runpytest_subprocess(
+            "-p", PLUGIN, "--junitxml", str(report), "-o", "junit_family=xunit1"
+        )
+        result.assert_outcomes(passed=2)
+        written = _properties(_cases(ET.parse(report).getroot())["test_addition"])
+        assert written["PartiallyVerifies"] == "REQ_1, REQ_2"
+        # Not configured: written under its own name, as a single value.
+        assert written["derivation_technique"] == "requirements-analysis"
+
+    def test_without_a_profile_a_list_is_an_error_naming_the_option(self, pytester):
+        # Silently writing "['REQ_1', 'REQ_2']" is the bug this replaces.
+        result, root = _run(pytester, DECORATED, profile="")
+        result.assert_outcomes(passed=1, errors=1)
+        result.stdout.fnmatch_lines(
+            ["*TypeError*'partially_verifies'*test_reports_properties*"]
+        )
+        assert _properties(_cases(root)["test_plain"]) == {}
+
+    def test_a_bad_line_is_a_usage_error_at_start_up(self, pytester):
+        result, _ = _run(pytester, PLAIN, profile="test_reports_properties = a, set\n")
+        assert result.ret == pytest.ExitCode.USAGE_ERROR
+        result.stderr.fnmatch_lines(["ERROR: test_reports_properties*'set'*"])
+
+
+class TestPropertyValues:
+    """How a keyword's value reaches the XML: declared per property, not guessed."""
+
+    def test_a_bare_string_is_one_requirement_id(self, score_model):
+        # str is a Sequence[str]; it must not be exploded character by character.
+        assert properties_mapping(partially_verifies="REQ_1") == {
+            "PartiallyVerifies": "REQ_1"
+        }
+
+    def test_a_list_for_a_single_valued_property_is_an_error(self, score_model):
+        with pytest.raises(TypeError, match="test_type.*single value"):
+            properties_mapping(test_type=["a", "b"])
+
+    def test_an_unconfigured_keyword_takes_a_single_value(self, score_model):
+        assert properties_mapping(Owner="team-a") == {"Owner": "team-a"}
+
+    def test_a_list_under_an_unconfigured_keyword_is_an_error(self, score_model):
+        with pytest.raises(TypeError, match="Satisfies.*test_reports_properties"):
+            properties_mapping(Satisfies=["REQ_1", "REQ_2"])
+
+    def test_the_xml_name_of_a_configured_property_works_as_keyword(self, score_model):
+        assert properties_mapping(PartiallyVerifies=["REQ_1", "REQ_2"]) == {
+            "PartiallyVerifies": "REQ_1, REQ_2"
+        }
+
+    def test_numbers_are_written_as_text(self, score_model):
+        assert properties_mapping(Priority=3) == {"Priority": "3"}
+
+    def test_an_unordered_collection_is_an_error(self, score_model):
+        # str(set) would be written otherwise, and a set has no stable order.
+        with pytest.raises(TypeError, match="partially_verifies"):
+            properties_mapping(partially_verifies={"REQ_1", "REQ_2"})
+
+    def test_empty_values_are_dropped(self, score_model):
+        assert properties_mapping(fully_verifies=["R"], test_type="") == {
+            "FullyVerifies": "R"
+        }
+
+    def test_nothing_to_record_is_an_error(self, score_model):
+        with pytest.raises(ValueError, match="no test properties"):
+            properties_mapping(partially_verifies=[])
+
+    def test_the_decorator_rejects_an_empty_call_without_a_model(self, monkeypatch):
+        # Import time, before any configuration is read: emptiness needs none.
+        monkeypatch.setattr(pytest_plugin, "PROPERTIES", {})
+        with pytest.raises(ValueError, match="no test properties"):
+            pytest_plugin.add_test_properties(partially_verifies=[], test_type="")
+
+
+class TestRuntimeMetadata:
+    def test_all_empty_metadata_records_nothing(self, score_model):
+        # A spec file with an empty metadata block must not fail the test.
+        recorded = []
+        apply_test_metadata(
+            record_property=lambda name, value: recorded.append((name, value)),
+            metadata={"fully_verifies": [], "test_type": ""},
+        )
+        assert recorded == []
+
+    def test_the_location_is_applied_without_metadata(self, score_model):
+        attributes = {}
+        apply_test_metadata(
+            record_property=lambda name, value: None,
+            metadata={},
+            record_xml_attribute=attributes.__setitem__,
+            file="../_main/specs/a.rst",
+            line=7,
+        )
+        assert attributes == {"file": "specs/a.rst", "line": "7"}
+
+
+class TestMarkerMerge:
+    def test_class_and_method_markers_are_merged(self, pytester):
+        # A classification on the class and links on each method is the natural
+        # way to use the decorator; get_closest_marker kept only the innermost.
+        result, root = _run(pytester, STACKED)
+        result.assert_outcomes(passed=3)
+        cases = _cases(root)
+        assert _properties(cases["test_one"]) == {
+            "PartiallyVerifies": "REQ_1",
+            "TestType": "requirements-based",
+            "Owner": "team-a",
+        }
+
+    def test_the_innermost_marker_wins_per_key(self, pytester):
+        _, root = _run(pytester, STACKED)
+        assert _properties(_cases(root)["test_two"])["Owner"] == "team-b"
+
+    def test_stacked_decorators_on_a_function_are_merged(self, pytester):
+        _, root = _run(pytester, STACKED)
+        assert _properties(_cases(root)["test_stacked"]) == {
+            "FullyVerifies": "REQ_3",
+            "TestType": "interface-test",
+        }
+
+
+class TestStartUp:
+    """The plugin's own notices, and pytest's about its fixtures, never take the
+    run down -- whatever the project's warning policy."""
+
+    def test_filterwarnings_error_in_the_ini_keeps_the_run_alive(self, pytester):
+        result, root = _run(pytester, DECORATED, ini="filterwarnings = error\n")
+        result.assert_outcomes(passed=2)
+        assert _cases(root)["test_plain"].get("line") == str(PLAIN_LINE)
+
+    def test_w_error_on_the_command_line_keeps_the_run_alive(self, pytester):
+        # An appended ini filter cannot silence the record_xml_attribute notice
+        # here: command-line filters take precedence over every ini line.
+        result, root = _run(pytester, DECORATED, "-W", "error")
+        result.assert_outcomes(passed=2)
+        assert _cases(root)["test_plain"].get("line") == str(PLAIN_LINE)
+
+    def test_a_strict_filterwarnings_mark_keeps_the_test_alive(self, pytester):
+        result, root = _run(pytester, MARKED_STRICT)
+        result.assert_outcomes(passed=1)
+        assert _cases(root)["test_strict"].get("file") is not None
+
+    def test_xunit2_under_filterwarnings_error_is_a_clean_usage_error(self, pytester):
+        # The project asked for warnings to be errors; the plugin's advice is
+        # one, delivered as a usage error rather than an INTERNALERROR trace.
+        result, _ = _run(
+            pytester, PLAIN, family="xunit2", ini="filterwarnings = error\n"
+        )
+        assert result.ret == pytest.ExitCode.USAGE_ERROR
+        result.stderr.fnmatch_lines(["ERROR: *junit_family is 'xunit2'*xunit1*"])
+        assert "INTERNALERROR" not in result.stdout.str()
+
+    def test_the_notice_can_be_silenced_by_its_class(self, pytester):
+        result, _ = _run(
+            pytester,
+            PLAIN,
+            family="xunit2",
+            ini=f"filterwarnings =\n    error\n    ignore::{PLUGIN}.TestReportsConfigWarning\n",
+        )
+        result.assert_outcomes(passed=1, warnings=0)
+
+    def test_xunit2_gives_no_per_test_fixture_warnings(self, pytester):
+        # pytest drops the attributes under xunit2 anyway and would warn per test
+        # that record_xml_attribute is incompatible; the plugin says it once.
+        result, _ = _run(pytester, PLAIN, family="xunit2")
+        result.assert_outcomes(passed=1, warnings=1)
+        assert not [
+            line for line in result.stdout.lines if "is incompatible with" in line
+        ]
+
+    def test_legacy_is_an_alias_of_xunit1(self, pytester):
+        result, root = _run(pytester, DECORATED, family="legacy")
+        result.assert_outcomes(passed=2, warnings=0)
+        assert _cases(root)["test_plain"].get("line") == str(PLAIN_LINE)
+
+    def test_the_junitxml_plugin_may_be_disabled(self, pytester):
+        # config.option.xmlpath exists only while pytest's junitxml plugin is
+        # registered, and so do the record_* fixtures.
+        pytester.makeini("[pytest]\n" + SCORE_PROFILE)
+        pytester.makepyfile(DECORATED)
+        result = pytester.runpytest_subprocess("-p", PLUGIN, "-p", "no:junitxml")
+        result.assert_outcomes(passed=2)
+
+    def test_xdist_is_warned_about(self, pytester):
+        # record_xml_attribute is a no-op on xdist workers: pytest builds the
+        # XML writer on the controller only, so the locations are lost silently.
+        pytest.importorskip("xdist")
+        result, root = _run(pytester, DECORATED, "-n", "1")
+        result.assert_outcomes(passed=2, warnings=1)
+        result.stdout.fnmatch_lines(["*TestReportsConfigWarning*pytest-xdist*"])
+        # The model reaches the workers: the properties are written there.
+        assert (
+            _properties(_cases(root)["test_addition"])["PartiallyVerifies"]
+            == "REQ_1, REQ_2"
+        )
+
+
 class TestSourcePath:
     def test_the_runfiles_prefix_is_cut_at_a_path_component(self):
         assert clean_source_path("../_main/pkg/test_x.py") == "pkg/test_x.py"
@@ -177,15 +490,6 @@ class TestSourcePath:
 
 
 class TestHelpers:
-    def test_empty_values_are_dropped(self):
-        assert properties_mapping(fully_verifies=["R"], test_type="") == {
-            "FullyVerifies": "R"
-        }
-
-    def test_nothing_to_record_is_an_error(self):
-        with pytest.raises(ValueError, match="no test properties"):
-            properties_mapping(partially_verifies=[])
-
     def test_the_plugin_does_not_import_sphinx(self):
         script = (
             "import sys;"
@@ -198,200 +502,3 @@ class TestHelpers:
             [sys.executable, "-c", script], capture_output=True, text=True, check=True
         )
         assert result.stdout.strip() == ""
-
-
-class TestPropertyValues:
-    """How a keyword's value reaches the XML: declared per property, not guessed."""
-
-    def test_a_bare_string_is_one_requirement_id(self):
-        # str is a Sequence[str]; it must not be exploded character by character.
-        assert properties_mapping(partially_verifies="REQ_1") == {
-            "PartiallyVerifies": "REQ_1"
-        }
-
-    def test_a_list_for_a_single_valued_property_is_an_error(self):
-        with pytest.raises(TypeError, match="test_type.*single value"):
-            properties_mapping(test_type=["a", "b"])
-
-    def test_a_custom_keyword_takes_a_single_value(self):
-        assert properties_mapping(Owner="team-a") == {"Owner": "team-a"}
-
-    def test_a_list_under_an_unregistered_keyword_is_an_error(self):
-        # Previously written as the Python repr "['REQ_1', 'REQ_2']".
-        with pytest.raises(TypeError, match="Satisfies.*register_property"):
-            properties_mapping(Satisfies=["REQ_1", "REQ_2"])
-
-    def test_a_registered_keyword_joins_its_list(self, monkeypatch):
-        monkeypatch.setattr(pytest_plugin, "PROPERTIES", dict(pytest_plugin.PROPERTIES))
-        register_property("satisfies", "Satisfies", multi=True)
-        assert properties_mapping(satisfies=["REQ_1", "REQ_2"]) == {
-            "Satisfies": "REQ_1, REQ_2"
-        }
-        assert properties_mapping(satisfies="REQ_1") == {"Satisfies": "REQ_1"}
-
-    def test_the_xml_name_of_a_registered_property_works_as_keyword(self):
-        assert properties_mapping(PartiallyVerifies=["REQ_1", "REQ_2"]) == {
-            "PartiallyVerifies": "REQ_1, REQ_2"
-        }
-
-    def test_numbers_are_written_as_text(self):
-        assert properties_mapping(Priority=3) == {"Priority": "3"}
-
-    def test_an_unordered_collection_is_an_error(self):
-        # str(set) would be written otherwise, and a set has no stable order.
-        with pytest.raises(TypeError, match="partially_verifies"):
-            properties_mapping(partially_verifies={"REQ_1", "REQ_2"})
-
-
-class TestRuntimeMetadata:
-    def test_all_empty_metadata_records_nothing(self):
-        # A spec file with an empty metadata block must not fail the test.
-        recorded = []
-        apply_test_metadata(
-            record_property=lambda name, value: recorded.append((name, value)),
-            metadata={"fully_verifies": [], "test_type": ""},
-        )
-        assert recorded == []
-
-    def test_the_location_is_applied_without_metadata(self):
-        attributes = {}
-        apply_test_metadata(
-            record_property=lambda name, value: None,
-            metadata={},
-            record_xml_attribute=attributes.__setitem__,
-            file="../_main/specs/a.rst",
-            line=7,
-        )
-        assert attributes == {"file": "specs/a.rst", "line": "7"}
-
-
-STACKED = """
-from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
-
-
-@add_test_properties(test_type="requirements-based", Owner="team-a")
-class TestThing:
-    @add_test_properties(partially_verifies=["REQ_1"])
-    def test_one(self):
-        assert True
-
-    @add_test_properties(partially_verifies=["REQ_2"], Owner="team-b")
-    def test_two(self):
-        assert True
-
-
-@add_test_properties(fully_verifies=["REQ_3"])
-@add_test_properties(test_type="interface-test")
-def test_stacked():
-    assert True
-"""
-
-
-class TestMarkerMerge:
-    def test_class_and_method_markers_are_merged(self, pytester):
-        # A classification on the class and links on each method is the natural
-        # way to use the decorator; get_closest_marker kept only the innermost.
-        result, root = _run(pytester, STACKED)
-        result.assert_outcomes(passed=3)
-        cases = _cases(root)
-        assert _properties(cases["test_one"]) == {
-            "PartiallyVerifies": "REQ_1",
-            "TestType": "requirements-based",
-            "Owner": "team-a",
-        }
-
-    def test_the_innermost_marker_wins_per_key(self, pytester):
-        _, root = _run(pytester, STACKED)
-        assert _properties(_cases(root)["test_two"])["Owner"] == "team-b"
-
-    def test_stacked_decorators_on_a_function_are_merged(self, pytester):
-        _, root = _run(pytester, STACKED)
-        assert _properties(_cases(root)["test_stacked"]) == {
-            "FullyVerifies": "REQ_3",
-            "TestType": "interface-test",
-        }
-
-
-PLAIN = """
-def test_plain():
-    assert True
-"""
-
-MARKED_STRICT = """
-import pytest
-
-
-@pytest.mark.filterwarnings("error")
-def test_strict():
-    assert True
-"""
-
-
-class TestStartUp:
-    """The plugin's own notices, and pytest's about its fixtures, never take the
-    run down -- whatever the project's warning policy."""
-
-    def test_filterwarnings_error_in_the_ini_keeps_the_run_alive(self, pytester):
-        pytester.makeini("[pytest]\nfilterwarnings = error\n")
-        result, root = _run(pytester, DECORATED)
-        result.assert_outcomes(passed=2)
-        assert _cases(root)["test_plain"].get("line") == str(PLAIN_LINE)
-
-    def test_w_error_on_the_command_line_keeps_the_run_alive(self, pytester):
-        # An appended ini filter cannot silence the record_xml_attribute notice
-        # here: command-line filters take precedence over every ini line.
-        result, root = _run(pytester, DECORATED, "-W", "error")
-        result.assert_outcomes(passed=2)
-        assert _cases(root)["test_plain"].get("line") == str(PLAIN_LINE)
-
-    def test_a_strict_filterwarnings_mark_keeps_the_test_alive(self, pytester):
-        result, root = _run(pytester, MARKED_STRICT)
-        result.assert_outcomes(passed=1)
-        assert _cases(root)["test_strict"].get("file") is not None
-
-    def test_xunit2_under_filterwarnings_error_is_a_clean_usage_error(self, pytester):
-        # The project asked for warnings to be errors; the plugin's advice is
-        # one, delivered as a usage error rather than an INTERNALERROR trace.
-        pytester.makeini("[pytest]\nfilterwarnings = error\n")
-        result, _ = _run(pytester, PLAIN, family="xunit2")
-        assert result.ret == pytest.ExitCode.USAGE_ERROR
-        result.stderr.fnmatch_lines(["ERROR: *junit_family is 'xunit2'*xunit1*"])
-        assert "INTERNALERROR" not in result.stdout.str()
-
-    def test_the_notice_can_be_silenced_by_its_class(self, pytester):
-        pytester.makeini(
-            "[pytest]\nfilterwarnings =\n    error\n"
-            f"    ignore::{PLUGIN}.TestReportsConfigWarning\n"
-        )
-        result, _ = _run(pytester, PLAIN, family="xunit2")
-        result.assert_outcomes(passed=1, warnings=0)
-
-    def test_xunit2_gives_no_per_test_fixture_warnings(self, pytester):
-        # pytest drops the attributes under xunit2 anyway and would warn per test
-        # that record_xml_attribute is incompatible; the plugin says it once.
-        result, _ = _run(pytester, PLAIN, family="xunit2")
-        result.assert_outcomes(passed=1, warnings=1)
-        assert not [
-            line for line in result.stdout.lines if "is incompatible with" in line
-        ]
-
-    def test_legacy_is_an_alias_of_xunit1(self, pytester):
-        result, root = _run(pytester, DECORATED, family="legacy")
-        result.assert_outcomes(passed=2, warnings=0)
-        assert _cases(root)["test_plain"].get("line") == str(PLAIN_LINE)
-
-    def test_the_junitxml_plugin_may_be_disabled(self, pytester):
-        # config.option.xmlpath exists only while pytest's junitxml plugin is
-        # registered, and so do the record_* fixtures.
-        pytester.makepyfile(DECORATED)
-        result = pytester.runpytest_subprocess("-p", PLUGIN, "-p", "no:junitxml")
-        result.assert_outcomes(passed=2)
-
-    def test_xdist_is_warned_about(self, pytester):
-        # record_xml_attribute is a no-op on xdist workers: pytest builds the
-        # XML writer on the controller only, so the locations are lost silently.
-        pytest.importorskip("xdist")
-        result, root = _run(pytester, DECORATED, "-n", "1")
-        result.assert_outcomes(passed=2, warnings=1)
-        result.stdout.fnmatch_lines(["*TestReportsConfigWarning*pytest-xdist*"])
-        assert root is not None

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -261,11 +261,22 @@ class TestXmlShape:
         assert case.get("line") == "7"
 
     def test_record_xml_attribute_is_still_accepted(self, pytester):
-        # score_pytest call sites pass it; it is not needed any more.
+        # score_pytest call sites pass it; it is not needed any more. Requesting
+        # pytest's fixture is what draws its experimental-feature notice.
         result, root = _run(pytester, RUNTIME_COMPAT)
-        result.assert_outcomes(passed=1, warnings=1)  # pytest's experimental notice
+        result.assert_outcomes(passed=1, warnings=1)
         case = _cases(root)["test_score_style"]
         assert (case.get("file"), case.get("line")) == ("specs/a.rst", "7")
+
+    def test_the_fixture_request_is_the_callers_under_a_strict_policy(self, pytester):
+        # The plugin neither requests that fixture nor silences its notice any
+        # more, so under -W error the request in the test's own signature is
+        # the error -- the docs say to drop it from the signature.
+        result, _ = _run(pytester, RUNTIME_COMPAT, "-W", "error")
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(
+            ["*record_xml_attribute is an experimental feature*"]
+        )
 
     def test_cases_skipped_or_erroring_at_setup_carry_the_same_shape(self, pytester):
         # A function-scoped fixture never runs for these; the report has to be
@@ -281,6 +292,18 @@ class TestXmlShape:
 
     def test_an_inner_pytest_session_leaves_the_model_intact(self, pytester):
         result, root = _run(pytester, NESTED)
+        result.assert_outcomes(passed=3)
+        assert _properties(_cases(root)["test_after"]) == {"PartiallyVerifies": "REQ_2"}
+
+    def test_an_inner_session_that_fails_to_configure_leaves_it_intact(self, pytester):
+        # Its pytest_configure raises on the bad ini line; pytest_unconfigure
+        # still runs and must pop what that session pushed, not the outer entry.
+        broken = NESTED.replace(
+            'write_text("[pytest]\\n")',
+            'write_text("[pytest]\\ntest_reports_properties = a, set\\n")',
+        ).replace("str(inner)]) == 0", "str(inner)]) == 4")
+        assert broken != NESTED
+        result, root = _run(pytester, broken)
         result.assert_outcomes(passed=3)
         assert _properties(_cases(root)["test_after"]) == {"PartiallyVerifies": "REQ_2"}
 
@@ -450,6 +473,18 @@ class TestPropertyValues:
         with pytest.raises(TypeError, match="item.*int"):
             properties_mapping(partially_verifies=[1, 2])
 
+    def test_an_empty_list_under_any_keyword_writes_nothing(self, score_model):
+        # A parser returning [] for an absent field is the documented pattern;
+        # the arity check must not fire before the items are looked at.
+        assert properties_mapping(test_type=[], fully_verifies=["R"]) == {
+            "FullyVerifies": "R"
+        }
+        assert properties_mapping(Owner=[None, ""], fully_verifies=["R"]) == {
+            "FullyVerifies": "R"
+        }
+        with pytest.raises(TypeError, match="test_type.*single value"):
+            properties_mapping(test_type=["a"])
+
     def test_an_empty_nested_list_is_not_written_as_brackets(self, score_model):
         with pytest.raises(TypeError, match="item"):
             properties_mapping(partially_verifies=[[]], fully_verifies=["R"])
@@ -489,11 +524,16 @@ class TestPropertyValues:
 
 class TestRuntimeMetadata:
     def test_all_empty_metadata_records_nothing(self, score_model):
-        # A spec file with an empty metadata block must not fail the test.
+        # A spec file with an empty metadata block must not fail the test --
+        # whether the parser hands back "" or [] for an absent field.
         recorded = []
         apply_test_metadata(
             record_property=lambda name, value: recorded.append((name, value)),
-            metadata={"fully_verifies": [], "test_type": ""},
+            metadata={"fully_verifies": [], "test_type": "", "Owner": []},
+        )
+        apply_test_metadata(
+            record_property=lambda name, value: recorded.append((name, value)),
+            metadata={"test_type": [], "derivation_technique": [None]},
         )
         assert recorded == []
 
@@ -507,6 +547,40 @@ class TestRuntimeMetadata:
         case = _cases(root)["test_driven_by_a_file[a.rst]"]
         assert _properties(case) == {}
         assert (case.get("file"), case.get("line")) == ("specs/a.rst", "7")
+
+
+BAD_SHAPE_AND_BROKEN_FIXTURE = """
+import pytest
+from sphinxcontrib.test_reports.pytest_plugin import add_test_properties
+
+
+@pytest.fixture
+def broken():
+    raise RuntimeError("no database")
+
+
+@add_test_properties(test_type=["a", "b"])
+def test_both(broken):
+    assert True
+"""
+
+
+class TestBadShape:
+    def test_a_bad_shape_errors_the_case_at_setup(self, pytester):
+        result, root = _run(
+            pytester,
+            "from sphinxcontrib.test_reports.pytest_plugin import add_test_properties\n\n@add_test_properties(test_type=['a', 'b'])\ndef test_shape():\n    assert True\n",
+        )
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(["*TypeError*'test_type' takes a single value*"])
+
+    def test_a_bad_shape_is_appended_to_a_fixture_error(self, pytester):
+        # Replacing the fixture's error would hide it until the shape is fixed.
+        result, _ = _run(pytester, BAD_SHAPE_AND_BROKEN_FIXTURE)
+        result.assert_outcomes(errors=1)
+        result.stdout.fnmatch_lines(
+            ["*RuntimeError: no database*", "*TypeError*'test_type'*"]
+        )
 
 
 class TestMarkerMerge:
@@ -607,6 +681,11 @@ class TestStartUp:
         case = _cases(root)["test_addition"]
         assert case.get("line") == str(ADDITION_LINE)
         assert _properties(case)["PartiallyVerifies"] == "REQ_1, REQ_2"
+
+    def test_xdist_issues_the_xunit2_notice_once(self, pytester):
+        pytest.importorskip("xdist")
+        result, _ = _run(pytester, PLAIN, "-n", "1", family="xunit2")
+        result.assert_outcomes(passed=1, warnings=1)
 
     def test_xdist_gets_the_runtime_location_override(self, pytester):
         pytest.importorskip("xdist")


### PR DESCRIPTION
Based on master. Independent of the needs.json converter (#148, merged); rebased on top of it.

## Why

A stock pytest run writes a JUnit XML this extension can only partly use. Under pytest's default `junit_family = xunit2`, no `<testcase>` carries the `file`/`line` attributes that give a test case its source location (`tr_source_file_option`/`tr_source_line_option`, and the deterministic ID of `tr_deterministic_case_ids`). Under `xunit1` pytest writes them, but counts the line from 0, keeps Bazel's runfiles prefix, and has no way to point a case at the file that drove it. And nothing records the requirements a test verifies.

## What

`-p sphinxcontrib.test_reports.pytest_plugin`, with `junit_family = xunit1` (warned about otherwise), does two things to every `<testcase>`, through hooks on the test reports rather than fixtures, so a case skipped or erroring during setup gets the same treatment and pytest-xdist works:

- the source location becomes the one an editor shows: line counted from 1, path relative to the rootdir with Bazel's `_main/` runfiles prefix cut at a whole path component;
- the properties of an `add_test_properties(...)` decorator (or, for file-driven parameterised tests, the `apply_test_metadata(...)` runtime helper, which can also point the case at the driving file) are written as `<properties>`.

Which properties exist is configuration, not code. The `test_reports_properties` ini option declares them, one `keyword [= XmlName] [, list]` per line: the keyword a test writes, the `<property>` name it is written under, and whether it takes a list (joined with `", "`, which `tr_property_link_types` splits again). A keyword not declared is written under its own name with a single value; a list under it, a list item that is not a string, or bytes, is a `TypeError` naming the option, so nothing is lost to a Python `repr` silently. The plugin ships no metamodel of its own.

S-CORE's model is the worked example in the docs:

```ini
[pytest]
addopts = -p sphinxcontrib.test_reports.pytest_plugin
junit_family = xunit1
test_reports_properties =
    partially_verifies = PartiallyVerifies, list
    fully_verifies = FullyVerifies, list
    test_type = TestType
    derivation_technique = DerivationTechnique
```

Ported from S-CORE docs-as-code's `score_pytest` attribute plugin: same two entry-point names, and with that example the XML comes out the same, so tests written against that plugin keep working when they import from here. Four deliberate differences in the XML: a case skipped or erroring at setup carries its location and properties here and pytest's stock values there; the properties keep the order of the keywords; the Bazel prefix is cut at a whole `_main` component only; and a `file` handed to `apply_test_metadata` is cut the same way. Two of that plugin's rules are not ported, as process rules of that project rather than properties of the data: the `TestType`/`DerivationTechnique` vocabularies are documented, not enforced, and a decorated test needs no docstring.

The package `__init__` resolves `setup` lazily (PEP 562, #145), so loading the plugin into a pytest process imports neither Sphinx nor docutils; a test asserts it. A per-module mypy override lifts only the two `Any` checks the pytest API needs. A `pytest` extra (`pytest>=7.0`, where everything the plugin uses exists) pulls pytest in; it is not a dependency of the extension. pytest before 7.3.2 does not run on Python 3.12 by itself, so a `plugin_floor` nox session, wired into CI, runs the plugin's tests on the oldest pytest of each Python: 7.0.1 on 3.11, 7.3.2 on 3.12.

## Tests

`tests/test_pytest_plugin.py`, 63 tests through `pytester`, each inner pytest a fresh subprocess: locations (a decorated function is located at its first decorator, as pytest does; skipped and setup-erroring cases included), the properties written from ini and pyproject declarations, the option grammar and its errors, the value rules, marker merging across class and function, the runtime helper's location override, nested in-process sessions (one failing to configure), a decorator applied before `pytest_configure`, a bad shape next to a fixture error, `--strict-markers`, the `xunit2` start-up notice under strict warning policies, `-p no:junitxml`, `legacy`, an xdist run, the Bazel path cut, and that importing the plugin imports no Sphinx. Verified on pytest 7.0.1 and 7.4.4 (Python 3.11), 7.3.2, 7.4.4 and 8.4.2 (3.12) and 9.1.1 (3.14).
