### PR TITLE
build: drop dead `packaging` runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,13 @@ classifiers = [
 ]
 keywords = ["sphinx", "documentation", "test-reports"]
 requires-python = ">=3.11"
-dependencies = ["sphinx>=7.4", "lxml", "sphinx-needs>=6.0.1", "packaging>=20.0"]
+dependencies = ["sphinx>=7.4", "lxml", "sphinx-needs>=6.0.1"]
 
 [project.optional-dependencies]
 test = [
   "beautifulsoup4",
   "nox>=2025.2.9",
+  "packaging",
   "pytest-xdist",
   "pytest>=7.0",
   "pytest-cov",
@@ -36,6 +37,7 @@ test = [
   "sphinxcontrib-plantuml",
 ]
 docs = [
+  "packaging",
   "pillow",
   "sphinx-design",
   "sphinx-immaterial",


### PR DESCRIPTION
Closes #152. Follow-up from @chrisjsewell's [review of #150](https://github.com/useblocks/sphinx-test-reports/pull/150#pullrequestreview-5130337244).

## What

`packaging` was declared as a runtime dependency, but PR #150 removed the last import of it under `sphinxcontrib/`. It is still genuinely used outside the package, so it moves to the extras that cover those consumers rather than being deleted outright:

| Consumer | Installed via | Extra it now lives in |
| --- | --- | --- |
| `docs/conf.py` | RTD (`.readthedocs.yaml`) and the `linkcheck` nox session | `docs` |
| 9 × `tests/doc_test/*/conf.py` | the `tests` nox session | `test` |

All of them use it for the same thing — the `Version(sphinx_needs.__version__) >= Version("7.0.0")` config gate.

The `>=20.0` floor is dropped rather than carried over: `packaging.version.Version` predates it by years, Sphinx already pins a much higher floor, and the surrounding extras entries only carry bounds where one actually matters.

## Verification

- `grep -r packaging sphinxcontrib/` → no matches (the issue's stated criterion).
- AST scan over all 18 modules under `sphinxcontrib/` for `import packaging` / `from packaging …` → **zero** hits, so this is not a grep artifact.
- Installed metadata after the change lists `packaging` only as `packaging ; extra == "docs"` and `packaging ; extra == "test"` — no longer a runtime requirement.
- `pytest -n auto tests/` → **169 passed**, unchanged from baseline (Python 3.12, Sphinx 8.1.3, sphinx-needs 8.0.0, from a fresh `.[test]` install).
- `sphinx -b html docs docs/_build/html` from a fresh `.[docs]` install → `build succeeded.`, no warnings.
- `pre-commit run --all-files` → all 7 hooks pass, `taplo-format` included.
- `uv sync --group dev && uv run mypy` → `Success: no issues found in 6 source files`.

No lockfile in the repo, so nothing to regenerate.
