### PR TITLE
ci: test against sphinx-needs 8.5.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.11", "3.12"]
         sphinx-version: ["7.4.7", "8.1.3"]
-        sphinx_needs-version: ["6.0.1", "6.3.0", "7.0.0", "8.0.0"]
+        sphinx_needs-version: ["6.0.1", "6.3.0", "7.0.0", "8.0.0", "8.5.0"]
     steps:
       - uses: actions/checkout@v2
       - name: Set Up Python ${{ matrix.python-version }}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,9 @@ Unreleased
   6.0.1 is the first release whose ``add_extra_option`` takes a schema, which
   this extension registers its fields with; sphinx-needs 6 itself requires
   Sphinx 7.4. The compatibility branches for older releases are gone.
+* Testing: Run the test suite against sphinx-needs 8.5.0. The matrix
+  previously topped out at 8.0.0, so the release a fresh install resolves to
+  was untested.
 
 .. _`release:1.4.0`:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ from nox import session
 
 PYTHON_VERSIONS = ["3.11", "3.12"]
 SPHINX_VERSIONS = ["7.4.7", "8.1.3"]
-SPHINX_NEEDS_VERSIONS = ["6.0.1", "6.3.0", "7.0.0", "8.0.0"]
+SPHINX_NEEDS_VERSIONS = ["6.0.1", "6.3.0", "7.0.0", "8.0.0", "8.5.0"]
 
 
 def run_tests(session, sphinx, sphinx_needs):

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -61,7 +61,7 @@ FIELD_DESCRIPTIONS = {
 }
 
 try:
-    # sphinx-needs >= 8.5: fields are registered through add_field.
+    # sphinx-needs >= 7.0: fields are registered through add_field.
     from sphinx_needs.api import add_field as _add_field
 
     def _register_field(app, name, schema=None):


### PR DESCRIPTION
Closes #153.

## What

Adds `8.5.0` as a fifth `sphinx_needs-version` cell to the CI matrix and to
the `SPHINX_NEEDS_VERSIONS` list in `noxfile.py` that mirrors it. Four new
jobs (python 3.11/3.12 × sphinx 7.4.7/8.1.3), taking the `tests` matrix from
16 to 20.

## Why — and a correction to the issue's premise

The issue asks for this on the grounds that the `add_field` registration
branch in `sphinx_needs_update()` is reachable only from sphinx-needs ≥ 8.5
and therefore untested. **That premise does not hold.** Checking the API
across the matrix range:

| sphinx-needs | `sphinx_needs.api.add_field` |
|---|---|
| 6.0.1 | absent |
| 6.3.0 | absent |
| 7.0.0 | **present** |
| 8.0.0 | present |
| 8.5.0 | present |

`add_field` was introduced in **7.0.0**, alongside `needs_fields` and the
deprecation of `needs_extra_options` — the same 7.0.0 change the [PR #150
review](https://github.com/useblocks/sphinx-test-reports/pull/150#pullrequestreview-5130337244)
identified as the correct threshold for the test fixtures' switch. The
existing 7.0.0 and 8.0.0 cells were already exercising that branch; the
`# sphinx-needs >= 8.5` comment above the import said otherwise and is the
likely source of the mix-up. This PR corrects it to `>= 7.0`.

The cell is still worth adding, for a different reason: the matrix topped out
at 8.0.0, while 8.5.0 is the current release and the one a fresh
`pip install sphinx-test-reports` resolves to today. That version was
untested. It now is.

## Changes

- `.github/workflows/ci.yaml`, `noxfile.py`: add `8.5.0` to the sphinx-needs
  matrix
- `sphinxcontrib/test_reports/test_reports.py`: correct the `>= 8.5` comment
  to `>= 7.0` (comment only, no behaviour change)
- `docs/changelog.rst`: `Testing:` entry under Unreleased

## Verification

All four new cells run locally against sphinx-needs 8.5.0:

```
[py3.11 sphinx=7.4.7 sn=8.5.0] -> 169 passed
[py3.11 sphinx=8.1.3 sn=8.5.0] -> 169 passed
[py3.12 sphinx=7.4.7 sn=8.5.0] -> 169 passed
[py3.12 sphinx=8.1.3 sn=8.5.0] -> 169 passed
```

`pre-commit run --all-files` and `mypy` are clean. CI on this PR is the real
check.

8.5.0 fits the rest of the matrix without constraint changes: it requires
`python >=3.10` and `sphinx >=7.4,<10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
