### PR TITLE
build: make Sphinx and sphinx-needs the `sphinx` extra — bare package and `[pytest]` install without the toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,26 @@ jobs:
       - name: Run the plugin's tests on the oldest supported pytest
         run: nox --non-interactive --session "plugin_floor(python='${{ matrix.python-version }}', pytest_version='${{ matrix.pytest-version }}')" -- --full-trace
 
+  toolchain-free:
+    # The converter runs without Sphinx; this installs the bare package and
+    # runs its tests where Sphinx is absent, the only thing that guarantees it.
+    name: "Test without Sphinx (python: ${{ matrix.python-version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Nox
+        run: |
+          python -m pip install nox
+      - name: Run Tests
+        run: nox --non-interactive --session "toolchain_free-${{ matrix.python-version }}" -- --full-trace
+
   pre-commit:
     name: pre-commit
     runs-on: ubuntu-latest
@@ -68,8 +88,10 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: uv sync
+        # The toolchain is an extra: without it, mypy cannot follow the
+        # extension's Sphinx and docutils imports.
         run: |
-          uv sync --group dev
+          uv sync --group dev --extra sphinx
 
       - name: Run mypy
         run: |
@@ -99,6 +121,7 @@ jobs:
     needs:
       - tests
       - plugin-floor
+      - toolchain-free
       - pre-commit
       - mypy
       - linkcheck

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,9 @@ jobs:
         run: nox --non-interactive --session "plugin_floor(python='${{ matrix.python-version }}', pytest_version='${{ matrix.pytest-version }}')" -- --full-trace
 
   toolchain-free:
-    # The converter runs without Sphinx; this installs the bare package and
-    # runs its tests where Sphinx is absent, the only thing that guarantees it.
+    # The converter and the pytest plugin run without Sphinx; this installs the
+    # package with the `pytest` extra alone and runs their tests where Sphinx is
+    # absent, the only thing that guarantees it.
     name: "Test without Sphinx (python: ${{ matrix.python-version }})"
     runs-on: ubuntu-latest
     strategy:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,14 +12,17 @@ Unreleased
   documentation project becomes ``pip install "sphinx-test-reports[sphinx]"``.
   The bare package brings only ``lxml``, the dependency of the ``test-reports``
   command, which runs in test runners and build actions that have no
-  documentation toolchain. An extra is opt-in, so the extension now checks the
+  documentation toolchain; the pytest plugin, the ``pytest`` extra, runs there
+  too. An extra is opt-in, so the extension now checks the
   installed toolchain against the versions the extra declares when Sphinx
   loads it: a missing or older Sphinx or Sphinx-Needs stops the build with a
   message naming the install line, instead of a traceback from inside a
   directive.
-* Testing: A CI job installs the bare package and runs the converter's tests
-  without Sphinx, so a toolchain import creeping into the command's import
-  chain -- or Sphinx creeping back into the dependency list -- fails the build.
+* Testing: CI installs the package with the ``pytest`` extra alone and runs the
+  converter's and the pytest plugin's tests without Sphinx -- on the newest
+  pytest and on the oldest the plugin supports -- so a toolchain import
+  creeping into either import chain, or Sphinx creeping back into a dependency
+  list, fails the build.
 * Feature: Support the googletest XML dialect: ``status="notrun"`` is reported
   as ``disabled`` instead of ``passed``, all ``<failure>``/``<skipped>`` parts
   of a test case are kept instead of only the first, ``RecordProperty`` values
@@ -61,7 +64,9 @@ Unreleased
   helper, for cases skipped at setup and under pytest-xdist too. Which
   properties exist, their XML names and which take lists is the
   ``test_reports_properties`` pytest ini option; S-CORE's model, which the
-  plugin was ported from, is the documented example. See :ref:`pytest_plugin`.
+  plugin was ported from, is the documented example. The plugin is the
+  ``pytest`` extra: ``pip install "sphinx-test-reports[pytest]"`` installs it
+  and pytest, without the documentation toolchain. See :ref:`pytest_plugin`.
 * Bugfix: ``tr_file_option``, ``tr_source_file_option`` and
   ``tr_source_line_option`` may no longer name a fixed field such as ``case``
   or ``result``, in ``conf.py`` or in the declarative file. The build

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,19 @@ Unreleased
 ----------
 :Released: under development
 
+* Breaking: ``pip install sphinx-test-reports`` no longer installs Sphinx and
+  Sphinx-Needs. They are the new ``sphinx`` extra, so the install line of a
+  documentation project becomes ``pip install "sphinx-test-reports[sphinx]"``.
+  The bare package brings only ``lxml``, the dependency of the ``test-reports``
+  command, which runs in test runners and build actions that have no
+  documentation toolchain. An extra is opt-in, so the extension now checks the
+  installed toolchain against the versions the extra declares when Sphinx
+  loads it: a missing or older Sphinx or Sphinx-Needs stops the build with a
+  message naming the install line, instead of a traceback from inside a
+  directive.
+* Testing: A CI job installs the bare package and runs the converter's tests
+  without Sphinx, so a toolchain import creeping into the command's import
+  chain -- or Sphinx creeping back into the dependency list -- fails the build.
 * Feature: Support the googletest XML dialect: ``status="notrun"`` is reported
   as ``disabled`` instead of ``passed``, all ``<failure>``/``<skipped>`` parts
   of a test case are kept instead of only the first, ``RecordProperty`` values
@@ -61,7 +74,8 @@ Unreleased
   file -- a wrong type, a rename onto a fixed field, a disagreeing need type
   -- as its crash report rather than as a one-line message; the message is in
   the report. A typo in ``[test_reports.build.needs]`` is reported the same
-  way.
+  way, and so is a missing or outdated toolchain refused when the extension
+  loads.
 * Support: Python 3.10 is no longer supported. It reached the end of upstream
   support, and dropping it lets the package read TOML with ``tomllib`` from the
   standard library instead of carrying a backport.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -13,7 +13,10 @@ be cached by a build system, and the data is unavailable to anything else. The
 CLI splits the computation out; the documentation build only imports the result.
 
 The command imports no Sphinx code at all, so it can run as a build action in an
-environment that has no documentation toolchain installed.
+environment that has no documentation toolchain installed. Installed as
+``pip install sphinx-test-reports`` -- without the ``sphinx`` extra the
+:doc:`extension needs </install>` -- the package brings a single dependency,
+``lxml``.
 
 Converting a report
 -------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,26 +3,39 @@
 Installation
 ============
 
-The Sphinx extension needs the documentation toolchain -- Sphinx and
+The package has three consumers, and each installs a different part of it.
+
+A documentation project needs the Sphinx extension, and with it the
+documentation toolchain -- Sphinx and
 `Sphinx-Needs <https://sphinx-needs.readthedocs.io/en/latest/>`_ -- which is
 the ``sphinx`` extra of the package::
 
    pip install "sphinx-test-reports[sphinx]"
 
-.. versionchanged:: 1.5.0
-   ``pip install sphinx-test-reports`` -- without the extra -- no longer
-   installs Sphinx and Sphinx-Needs. The package also ships the
-   :ref:`test-reports command <cli>`, which turns test results into a
-   ``needs.json`` without a Sphinx build, and that is what the bare install is
-   for: a test runner or a build action that has no documentation toolchain.
-   A documentation project has to add the extra to its install line.
+A test runner that should write the XML shape the extension reads installs the
+:ref:`pytest plugin <pytest_plugin>` as the ``pytest`` extra, which adds pytest
+and nothing of the documentation toolchain::
 
-The extra also states the supported versions: Sphinx 7.4 and Sphinx-Needs
-6.0.1 or later. An extra is opt-in, so a project that keeps installing the
-bare package into an environment holding an older toolchain would never be
-told by ``pip``; the extension therefore checks the installed versions when
-Sphinx loads it and stops the build with a message naming the install line
-above.
+   pip install "sphinx-test-reports[pytest]"
+
+A build action that only runs the :ref:`test-reports command <cli>`, which
+turns test results into a ``needs.json`` without a Sphinx build, installs the
+bare package, whose single dependency is ``lxml``::
+
+   pip install sphinx-test-reports
+
+.. versionchanged:: 1.5.0
+   ``pip install sphinx-test-reports`` -- without an extra -- no longer
+   installs Sphinx and Sphinx-Needs. A documentation project has to add the
+   ``sphinx`` extra to its install line; a test runner or a build action that
+   has no documentation toolchain no longer gets one.
+
+The ``sphinx`` extra also states the supported versions: Sphinx 7.4 and
+Sphinx-Needs 6.0.1 or later. An extra is opt-in, so a project that keeps
+installing the bare package into an environment holding an older toolchain
+would never be told by ``pip``; the extension therefore checks the installed
+versions when Sphinx loads it and stops the build with a message naming the
+install line above.
 
 After that the extension must be added to the ``conf.py`` file::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,9 +3,28 @@
 Installation
 ============
 
-Install ``Sphinx-Test-Report`` via ``pip install sphinx-test-reports``.
+The Sphinx extension needs the documentation toolchain -- Sphinx and
+`Sphinx-Needs <https://sphinx-needs.readthedocs.io/en/latest/>`_ -- which is
+the ``sphinx`` extra of the package::
 
-After that the extension must to be added to the ``conf.py`` file::
+   pip install "sphinx-test-reports[sphinx]"
+
+.. versionchanged:: 1.5.0
+   ``pip install sphinx-test-reports`` -- without the extra -- no longer
+   installs Sphinx and Sphinx-Needs. The package also ships the
+   :ref:`test-reports command <cli>`, which turns test results into a
+   ``needs.json`` without a Sphinx build, and that is what the bare install is
+   for: a test runner or a build action that has no documentation toolchain.
+   A documentation project has to add the extra to its install line.
+
+The extra also states the supported versions: Sphinx 7.4 and Sphinx-Needs
+6.0.1 or later. An extra is opt-in, so a project that keeps installing the
+bare package into an environment holding an older toolchain would never be
+told by ``pip``; the extension therefore checks the installed versions when
+Sphinx loads it and stops the build with a message naming the install line
+above.
+
+After that the extension must be added to the ``conf.py`` file::
 
    extensions = ['sphinx_needs',
                  'sphinxcontrib.test_reports',
@@ -18,6 +37,6 @@ Therefore it must also be added to the ``extensions`` list!
 And same for `PlantUML <http://plantuml.com>`_, which is important to render flowcharts for filtered
 test-cases.
 
-More details can be find in the
+More details can be found in the
 `installation-guide <https://sphinx-needs.readthedocs.io/en/latest/installation.html>`_
 of ``Sphinx-Needs``.

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -21,6 +21,10 @@ is the worked example below.
 Enabling it
 -----------
 
+The plugin is the ``pytest`` extra of the package: ``pip install
+"sphinx-test-reports[pytest]"`` installs it without the documentation toolchain
+(see :doc:`/install`). Enable it in the pytest configuration:
+
 .. code-block:: ini
 
    # pytest.ini / pyproject.toml [tool.pytest.ini_options]

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,6 +34,44 @@ def plugin_floor(session, pytest_version):
     session.run("pytest", "tests/test_pytest_plugin.py")
 
 
+# The converter and its configuration run without the documentation toolchain,
+# and these are their tests. Everything else builds documentation.
+TOOLCHAIN_FREE_TESTS = [
+    "tests/test_cli_config.py",
+    "tests/test_cli_convert.py",
+    "tests/test_identity.py",
+    "tests/test_junit_parser.py",
+    "tests/test_junit_parser_gtest.py",
+    "tests/test_needs_export.py",
+    "tests/test_project_config.py",
+    "tests/test_toolchain.py",
+]
+
+# Exits non-zero, naming them, if any module of the toolchain is importable.
+TOOLCHAIN_IS_ABSENT = (
+    "import importlib.util, sys;"
+    "present = [m for m in ('sphinx', 'sphinx_needs', 'docutils')"
+    " if importlib.util.find_spec(m)];"
+    "sys.exit(f'toolchain installed: {present}' if present else 0)"
+)
+
+
+@session(python=PYTHON_VERSIONS)
+def toolchain_free(session):
+    """Run the converter's tests in an environment without Sphinx.
+
+    The package is installed with the dependencies it declares -- `lxml` --
+    plus pytest, so a toolchain import creeping into the converter's import
+    chain, or Sphinx creeping back into the dependency list, fails here. The
+    tests that need a documentation build carry the `toolchain` mark.
+    """
+    session.install(".", "pytest")
+    session.run("python", "-c", TOOLCHAIN_IS_ABSENT)
+    session.run(
+        "pytest", "-m", "not toolchain", *TOOLCHAIN_FREE_TESTS, *session.posargs
+    )
+
+
 @session(python="3.12")
 def linkcheck(session):
     session.install(".[docs]")

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,22 +20,9 @@ def tests(session, sphinx_needs, sphinx):
     run_tests(session, sphinx, sphinx_needs)
 
 
-#: The oldest pytest the plugin's tests run on, per Python: 7.0 is the plugin's
-#: own floor (the pytest extra), and 7.3.2 the first pytest that runs on
-#: Python 3.12 at all.
-PLUGIN_PYTEST_FLOORS = [("3.11", "7.0.1"), ("3.12", "7.3.2")]
-
-
-@session
-@nox.parametrize("python,pytest_version", PLUGIN_PYTEST_FLOORS)
-def plugin_floor(session, pytest_version):
-    """The pytest plugin's tests on the oldest pytest it supports."""
-    session.install(".[test]", f"pytest=={pytest_version}")
-    session.run("pytest", "tests/test_pytest_plugin.py")
-
-
-# The converter and its configuration run without the documentation toolchain,
-# and these are their tests. Everything else builds documentation.
+# The converter, its configuration and the pytest plugin run without the
+# documentation toolchain, and these are their tests. Everything else builds
+# documentation.
 TOOLCHAIN_FREE_TESTS = [
     "tests/test_cli_config.py",
     "tests/test_cli_convert.py",
@@ -44,6 +31,7 @@ TOOLCHAIN_FREE_TESTS = [
     "tests/test_junit_parser_gtest.py",
     "tests/test_needs_export.py",
     "tests/test_project_config.py",
+    "tests/test_pytest_plugin.py",
     "tests/test_toolchain.py",
 ]
 
@@ -58,18 +46,38 @@ TOOLCHAIN_IS_ABSENT = (
 
 @session(python=PYTHON_VERSIONS)
 def toolchain_free(session):
-    """Run the converter's tests in an environment without Sphinx.
+    """Run the converter's and the pytest plugin's tests without Sphinx.
 
-    The package is installed with the dependencies it declares -- `lxml` --
-    plus pytest, so a toolchain import creeping into the converter's import
-    chain, or Sphinx creeping back into the dependency list, fails here. The
-    tests that need a documentation build carry the `toolchain` mark.
+    The package is installed with the dependencies it declares -- `lxml`, and
+    pytest through the `pytest` extra -- so a toolchain import creeping into
+    either import chain, or Sphinx creeping back into a dependency list, fails
+    here. The tests that need a documentation build carry the `toolchain` mark.
     """
-    session.install(".", "pytest")
+    session.install(".[pytest]")
     session.run("python", "-c", TOOLCHAIN_IS_ABSENT)
     session.run(
         "pytest", "-m", "not toolchain", *TOOLCHAIN_FREE_TESTS, *session.posargs
     )
+
+
+#: The oldest pytest the plugin's tests run on, per Python: 7.0 is the plugin's
+#: own floor (the pytest extra), and 7.3.2 the first pytest that runs on
+#: Python 3.12 at all.
+PLUGIN_PYTEST_FLOORS = [("3.11", "7.0.1"), ("3.12", "7.3.2")]
+
+
+@session
+@nox.parametrize("python,pytest_version", PLUGIN_PYTEST_FLOORS)
+def plugin_floor(session, pytest_version):
+    """The plugin's tests on the oldest pytest it supports, without Sphinx.
+
+    Installed as a test runner installs it: the `pytest` extra, nothing of the
+    documentation toolchain. pytest-xdist is there for the tests that run the
+    plugin under it.
+    """
+    session.install(".[pytest]", "pytest-xdist", f"pytest=={pytest_version}")
+    session.run("python", "-c", TOOLCHAIN_IS_ABSENT)
+    session.run("pytest", "tests/test_pytest_plugin.py", *session.posargs)
 
 
 @session(python="3.12")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,14 @@ classifiers = [
 ]
 keywords = ["sphinx", "documentation", "test-reports"]
 requires-python = ">=3.11"
-dependencies = ["sphinx>=7.4", "lxml", "sphinx-needs>=6.0.1"]
+dependencies = ["lxml"]
 
 [project.optional-dependencies]
+# The Sphinx extension. The `test-reports` command runs without the
+# documentation toolchain, so it is an extra rather than a dependency; the lazy
+# `setup` in `__init__.py` enforces these floors when the extension is loaded,
+# since an extra is opt-in and pip never sees them otherwise.
+sphinx = ["sphinx>=7.4", "sphinx-needs>=6.0.1"]
 # The pytest plugin (sphinxcontrib.test_reports.pytest_plugin); pytest is not
 # a dependency of the extension or the converter. 7.0 is where everything the
 # plugin uses exists (pytest.Config/Item/Mark, Config.stash,
@@ -40,6 +45,8 @@ test = [
   "pytest-xdist",
   "pytest>=7.0",
   "pytest-cov",
+  "sphinx>=7.4",
+  "sphinx-needs>=6.0.1",
   "sphinx_design",
   "sphinxcontrib-plantuml",
 ]
@@ -71,6 +78,11 @@ test-reports = "sphinxcontrib.test_reports.cli:main"
 
 [tool.flit.module]
 name = "sphinxcontrib.test_reports"
+
+[tool.pytest.ini_options]
+markers = [
+  "toolchain: needs the documentation toolchain (Sphinx, sphinx-needs) installed; deselected by the toolchain_free nox session",
+]
 
 [project.urls]
 Homepage = "https://github.com/useblocks/sphinx-test-reports"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,9 @@ requires-python = ">=3.11"
 dependencies = ["lxml"]
 
 [project.optional-dependencies]
-# The Sphinx extension. The `test-reports` command runs without the
-# documentation toolchain, so it is an extra rather than a dependency; the lazy
+# The Sphinx extension. The `test-reports` command and the pytest plugin run
+# without the documentation toolchain, so it is an extra rather than a
+# dependency; the lazy
 # `setup` in `__init__.py` enforces these floors when the extension is loaded,
 # since an extra is opt-in and pip never sees them otherwise.
 sphinx = ["sphinx>=7.4", "sphinx-needs>=6.0.1"]

--- a/sphinxcontrib/test_reports/__init__.py
+++ b/sphinxcontrib/test_reports/__init__.py
@@ -1,37 +1,66 @@
 """Sphinx-Test-Reports.
 
 ``setup`` is resolved lazily (PEP 562) so that importing a submodule of this
-package does not import Sphinx: :mod:`sphinxcontrib.test_reports.projectconfig`
-is read by consumers that are not a documentation build, in environments where
-the documentation toolchain is not installed, and every import of it runs this
-file first. Sphinx still finds ``setup`` through normal attribute access when it
+package does not import Sphinx: the ``test-reports`` command and
+:mod:`sphinxcontrib.test_reports.projectconfig` are used where the
+documentation toolchain is not installed -- it is the ``sphinx`` extra of the
+package, not a dependency -- and every import of a submodule runs this file
+first. Sphinx still finds ``setup`` through normal attribute access when it
 loads this package as an extension.
+
+Resolving ``setup`` is also where the toolchain is checked. An extra is opt-in,
+so a project that installs the bare package into an environment already holding
+an older Sphinx or sphinx-needs never shows pip the extra's version floors;
+:mod:`sphinxcontrib.test_reports.toolchain` enforces them here instead, with
+the install line in the message.
 """
 
 __all__ = ["setup"]
 
 
 def __getattr__(name: str) -> object:
-    if name == "setup":
-        try:
-            from sphinxcontrib.test_reports.test_reports import setup
-        except ImportError as error:
-            # Sphinx wraps an ImportError from importing the *package* in a
-            # clean "Could not import extension" message, but fetches `setup`
-            # with getattr(), which only tolerates AttributeError. Resolving
-            # lazily would let a missing sphinx-needs escape as a raw
-            # traceback, so the message Sphinx would have produced is raised
-            # here instead -- when Sphinx is there to receive it. The wrapped
-            # exception goes in the second argument only: ExtensionError.__str__
-            # renders it as "(exception: ...)", so spelling it out in the
-            # message too would print it twice.
-            try:
-                from sphinx.errors import ExtensionError
-            except ImportError:
-                raise error from None
-            raise ExtensionError(
-                f"Could not import extension {__name__}", error
-            ) from error
+    if name != "setup":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-        return setup
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from sphinxcontrib.test_reports.toolchain import INSTALL_HINT, unmet_requirements
+
+    unmet = unmet_requirements()
+    if unmet:
+        # Before the import: an outdated sphinx-needs may well import and fail
+        # only later, inside a directive, with a traceback that does not say
+        # why. Sphinx fetches `setup` with getattr(), which only tolerates
+        # AttributeError, so the error reaches the user as it is raised here.
+        message = (
+            f"Could not load extension {__name__}: {'; '.join(unmet)}. "
+            f"Install the Sphinx extension's dependencies with: {INSTALL_HINT}"
+        )
+        try:
+            from sphinx.errors import ExtensionError
+        except ImportError:
+            raise ImportError(message) from None
+        raise ExtensionError(message)
+
+    try:
+        from sphinxcontrib.test_reports.test_reports import setup
+    except ImportError as error:
+        # Sphinx wraps an ImportError from importing the *package* in a clean
+        # "Could not import extension" message, but fetches `setup` with
+        # getattr(), which only tolerates AttributeError. Resolving lazily
+        # would let a missing sphinx-needs escape as a raw traceback, so the
+        # message Sphinx would have produced is raised here instead -- when
+        # Sphinx is there to receive it -- naming the extra that installs the
+        # toolchain, the likely cause. The wrapped exception goes in the second
+        # argument only: ExtensionError.__str__ renders it as
+        # "(exception: ...)", so spelling it out in the message too would print
+        # it twice.
+        try:
+            from sphinx.errors import ExtensionError
+        except ImportError:
+            raise error from None
+        raise ExtensionError(
+            f"Could not import extension {__name__}; the Sphinx extension's "
+            f"dependencies are an extra, install them with: {INSTALL_HINT}",
+            error,
+        ) from error
+
+    return setup

--- a/sphinxcontrib/test_reports/toolchain.py
+++ b/sphinxcontrib/test_reports/toolchain.py
@@ -1,0 +1,77 @@
+"""The documentation toolchain the Sphinx extension needs, checked at load time.
+
+Sphinx and sphinx-needs are the ``sphinx`` extra of this package rather than
+dependencies: the ``test-reports`` command runs where they are not installed.
+An extra is opt-in, so nothing shows pip the extra's version floors when a
+project installs the bare package into an environment that already holds an
+older toolchain -- the old versions stay, and the extension would fail later,
+inside a directive, with a traceback that does not say why.
+
+:func:`unmet_requirements` compares the installed toolchain against the floors
+the extra declares, read from this package's own metadata so that they live in
+``pyproject.toml`` alone. The lazy ``setup`` in the package ``__init__`` calls
+it before the extension is imported and raises Sphinx's ``ExtensionError``
+with the install line.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, requires, version
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from packaging.requirements import Requirement
+
+#: The distribution whose metadata declares the toolchain.
+DISTRIBUTION = "sphinx-test-reports"
+#: The extra holding the Sphinx extension's dependencies.
+EXTRA = "sphinx"
+#: The install line named by every message about a missing or outdated toolchain.
+INSTALL_HINT = f'pip install "{DISTRIBUTION}[{EXTRA}]"'
+
+
+def toolchain_requirements() -> list[Requirement]:
+    """The requirements the extra declares, read from the installed metadata.
+
+    Empty without metadata (the package imported from a source tree on
+    ``sys.path``) and without ``packaging``, which parses them: it is not a
+    dependency of this package but arrives with Sphinx (and with pytest), so it
+    is there wherever the extension is loaded.
+    """
+    try:
+        from packaging.requirements import Requirement
+    except ImportError:
+        return []
+    try:
+        declared = requires(DISTRIBUTION) or []
+    except PackageNotFoundError:
+        return []
+    requirements = [Requirement(spec) for spec in declared]
+    return [
+        requirement
+        for requirement in requirements
+        if requirement.marker is not None
+        and requirement.marker.evaluate({"extra": EXTRA})
+    ]
+
+
+def unmet_requirements() -> list[str]:
+    """One sentence per requirement of the extra the environment falls short of.
+
+    A requirement whose distribution is not installed at all is not reported:
+    the import that fails on it states the problem more precisely, and a
+    toolchain importable from a source tree without metadata must not be
+    refused on the strength of the metadata alone.
+    """
+    unmet: list[str] = []
+    for requirement in toolchain_requirements():
+        try:
+            installed = version(requirement.name)
+        except PackageNotFoundError:
+            continue
+        if not requirement.specifier.contains(installed, prereleases=True):
+            unmet.append(
+                f"{requirement.name} {installed} is installed, "
+                f"but {requirement.name}{requirement.specifier} is required"
+            )
+    return unmet

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,11 @@ from tempfile import mkdtemp
 import pytest
 
 # The documentation toolchain is an extra of the package, and the converter's
-# tests run where it is not installed (the `toolchain_free` nox session), so
-# Sphinx's fixtures are loaded only where Sphinx is. Tests that need a build
-# carry the `toolchain` mark and are deselected there. `pytester`, which the
-# pytest plugin's tests drive, ships with pytest itself.
+# and the pytest plugin's tests run where it is not installed (the
+# `toolchain_free` and `plugin_floor` nox sessions), so Sphinx's fixtures are
+# loaded only where Sphinx is. Tests that need a build carry the `toolchain`
+# mark and are deselected there. `pytester`, which the plugin's tests drive,
+# ships with pytest itself.
 pytest_plugins = (
     ["sphinx.testing.fixtures"] if importlib.util.find_spec("sphinx") else []
 ) + ["pytester"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,20 @@
 """Pytest conftest module containing common test configuration and fixtures."""
 
+import importlib.util
 import shutil
 from pathlib import Path
 from tempfile import mkdtemp
 
 import pytest
 
-pytest_plugins = ["sphinx.testing.fixtures", "pytester"]
+# The documentation toolchain is an extra of the package, and the converter's
+# tests run where it is not installed (the `toolchain_free` nox session), so
+# Sphinx's fixtures are loaded only where Sphinx is. Tests that need a build
+# carry the `toolchain` mark and are deselected there. `pytester`, which the
+# pytest plugin's tests drive, ships with pytest itself.
+pytest_plugins = (
+    ["sphinx.testing.fixtures"] if importlib.util.find_spec("sphinx") else []
+) + ["pytester"]
 
 
 def copy_srcdir_to_tmpdir(srcdir, tmp):

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -68,6 +68,7 @@ class TestNoSphinxImport:
 
 
 class TestEnvelope:
+    @pytest.mark.toolchain
     def test_output_passes_the_sphinx_needs_schema(self, tmp_path):
         """The output must validate against sphinx-needs' own needs.json schema."""
         from sphinx_needs import needsfile
@@ -616,6 +617,7 @@ class TestContentIsNotDuplicated:
         assert "not applicable on this platform" in content
 
 
+@pytest.mark.toolchain
 class TestImportIntoABuild:
     """The documented consumption path: ``needimport`` of the produced file.
 

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -15,7 +15,6 @@ from shutil import copytree
 
 import pytest
 
-from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 from sphinxcontrib.test_reports.projectconfig import (
     BRIDGE_KEYS,
     BUILD_TABLE,
@@ -459,6 +458,7 @@ class TestLoader:
         assert config["rootdir"] == str(tmp_path)
 
 
+@pytest.mark.toolchain
 class TestSphinxBridge:
     """The build reads the same section and honours the same precedence."""
 
@@ -507,6 +507,8 @@ class TestSphinxBridge:
         _write(tmp_path / "docs", "[test_reports]\nsuite_id_length = 'four'\n")
 
         from sphinx.application import Sphinx
+
+        from sphinxcontrib.test_reports.exceptions import InvalidConfigurationError
 
         docs = tmp_path / "docs"
         with pytest.raises(InvalidConfigurationError, match="suite_id_length"):
@@ -715,6 +717,7 @@ def _basic_doc(tmp_path, toml=None, conf_extra=""):
     return docs
 
 
+@pytest.mark.toolchain
 class TestBridgePrecedence:
     """``-D`` > TOML > conf.py, and the diagnostics for a file that is missing."""
 
@@ -822,6 +825,7 @@ def _documented_toml_example():
     return "\n".join(block) + "\n"
 
 
+@pytest.mark.toolchain
 class TestConfvalTypes:
     """The bridged values must pass Sphinx's own confval type check.
 
@@ -878,13 +882,15 @@ class TestSphinxFree:
         )
         assert result.returncode == 0, result.stderr
 
+    @pytest.mark.toolchain
     def test_a_missing_sphinx_needs_is_an_extension_error(self):
         # The lazy `setup` owns the message Sphinx would have produced for a
         # broken extension import, because Sphinx fetches `setup` with
         # getattr() and would otherwise show a raw traceback. Sphinx renders
         # the wrapped exception itself, so the message must not carry it a
-        # second time. Checked in a subprocess: sphinx_needs is importable
-        # here.
+        # second time -- but it names the extra that installs the toolchain,
+        # the likely cause since the toolchain stopped being a dependency.
+        # Checked in a subprocess: sphinx_needs is importable here.
         code = (
             "import sys\n"
             "sys.modules['sphinx_needs'] = None\n"  # `from sphinx_needs...` fails
@@ -907,3 +913,4 @@ class TestSphinxFree:
         )
         assert message.count("(exception:") == 1
         assert "sphinx_needs" in message
+        assert 'pip install "sphinx-test-reports[sphinx]"' in message

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -21,6 +21,7 @@ DECLARED = [
     "lxml",
     'sphinx>=7.4; extra == "sphinx"',
     'sphinx-needs>=6.0.1; extra == "sphinx"',
+    'pytest>=7.0; extra == "pytest"',
     'pytest>=7.0; extra == "test"',
 ]
 

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -1,0 +1,157 @@
+"""The documentation toolchain is an extra; the extension checks it at load time.
+
+``pip install sphinx-test-reports`` installs the converter's dependency only.
+The Sphinx extension needs Sphinx and sphinx-needs at the versions the
+``sphinx`` extra declares -- and an extra is opt-in, so a project that installs
+the bare package next to an older toolchain never shows pip those floors. The
+lazy ``setup`` compares the installed versions against the extra's declarations
+when Sphinx loads the extension, and names the install line in its message.
+"""
+
+import sys
+from importlib.metadata import PackageNotFoundError
+from io import StringIO
+
+import pytest
+
+import sphinxcontrib.test_reports as package
+from sphinxcontrib.test_reports import toolchain
+
+DECLARED = [
+    "lxml",
+    'sphinx>=7.4; extra == "sphinx"',
+    'sphinx-needs>=6.0.1; extra == "sphinx"',
+    'pytest>=7.0; extra == "test"',
+]
+
+AT_THE_FLOORS = {"sphinx": "7.4.7", "sphinx-needs": "6.0.1"}
+
+VIOLATION = "sphinx-needs 5.1.0 is installed, but sphinx-needs>=6.0.1 is required"
+
+
+def _environment(monkeypatch, installed, declared=DECLARED):
+    """Fake the metadata: what this package declares and what is installed."""
+
+    def requires(name):
+        assert name == toolchain.DISTRIBUTION
+        return declared
+
+    def version(name):
+        try:
+            return installed[name]
+        except KeyError:
+            raise PackageNotFoundError(name) from None
+
+    monkeypatch.setattr(toolchain, "requires", requires)
+    monkeypatch.setattr(toolchain, "version", version)
+
+
+class TestUnmetRequirements:
+    def test_a_toolchain_at_the_floors_is_accepted(self, monkeypatch):
+        _environment(monkeypatch, AT_THE_FLOORS)
+        assert toolchain.unmet_requirements() == []
+
+    def test_a_version_below_the_floor_is_named_with_the_floor(self, monkeypatch):
+        _environment(monkeypatch, {**AT_THE_FLOORS, "sphinx-needs": "5.1.0"})
+        assert toolchain.unmet_requirements() == [VIOLATION]
+
+    def test_every_violation_is_reported_in_declaration_order(self, monkeypatch):
+        _environment(monkeypatch, {"sphinx": "7.3.7", "sphinx-needs": "5.1.0"})
+        assert toolchain.unmet_requirements() == [
+            "sphinx 7.3.7 is installed, but sphinx>=7.4 is required",
+            VIOLATION,
+        ]
+
+    def test_a_missing_distribution_is_left_to_the_import(self, monkeypatch):
+        # The import that fails on a missing package states the problem more
+        # precisely -- and a toolchain importable from a source tree without
+        # metadata must not be refused on the strength of the metadata alone.
+        _environment(monkeypatch, {"sphinx": "7.4.7"})
+        assert toolchain.unmet_requirements() == []
+
+    def test_other_extras_and_the_core_dependency_are_not_checked(self, monkeypatch):
+        _environment(monkeypatch, {**AT_THE_FLOORS, "lxml": "0.1", "pytest": "1.0"})
+        assert toolchain.unmet_requirements() == []
+
+    def test_a_prerelease_above_the_floor_is_accepted(self, monkeypatch):
+        _environment(monkeypatch, {**AT_THE_FLOORS, "sphinx-needs": "9.0.0rc1"})
+        assert toolchain.unmet_requirements() == []
+
+    def test_without_our_own_metadata_there_is_nothing_to_check(self, monkeypatch):
+        # Run from a source tree on sys.path, the package has no metadata.
+        def requires(name):
+            raise PackageNotFoundError(name)
+
+        monkeypatch.setattr(toolchain, "requires", requires)
+        assert toolchain.unmet_requirements() == []
+
+    def test_without_packaging_the_check_is_skipped(self, monkeypatch):
+        # `packaging` is not a dependency of this package: it arrives with
+        # Sphinx (and with pytest). Where neither is installed, nothing loads
+        # the extension either -- so the check stands down instead of failing
+        # on its own import.
+        _environment(monkeypatch, {"sphinx": "7.3.7", "sphinx-needs": "5.1.0"})
+        monkeypatch.setitem(sys.modules, "packaging.requirements", None)
+        assert toolchain.unmet_requirements() == []
+
+    def test_the_installed_metadata_declares_the_toolchain_under_the_extra(self):
+        # Against the real metadata: the extra the check reads is the one
+        # pyproject.toml declares. Renaming it there would silently disarm the
+        # check, and this test.
+        names = sorted(
+            requirement.name for requirement in toolchain.toolchain_requirements()
+        )
+        assert names == ["sphinx", "sphinx-needs"]
+
+    def test_this_environment_meets_the_floors(self):
+        assert toolchain.unmet_requirements() == []
+
+
+@pytest.mark.toolchain
+class TestLazySetup:
+    """Sphinx resolves ``setup`` through getattr(); the check runs first."""
+
+    def test_a_sufficient_toolchain_resolves_setup(self):
+        from sphinxcontrib.test_reports.test_reports import setup
+
+        assert package.setup is setup
+
+    def test_a_toolchain_below_the_floors_is_an_extension_error(self, monkeypatch):
+        from sphinx.errors import ExtensionError
+
+        monkeypatch.setattr(toolchain, "unmet_requirements", lambda: [VIOLATION])
+        with pytest.raises(ExtensionError) as info:
+            _ = package.setup
+        message = str(info.value)
+        assert message.startswith("Could not load extension sphinxcontrib.test_reports")
+        assert VIOLATION in message
+        assert toolchain.INSTALL_HINT in message
+        # Nothing was imported, so there is no exception to wrap; the message
+        # must not end in an empty "(exception: ...)".
+        assert "(exception:" not in message
+
+    def test_sphinx_surfaces_the_error_when_loading_the_extension(
+        self, tmp_path, monkeypatch
+    ):
+        # Sphinx fetches `setup` with getattr(module, "setup", None), which
+        # only swallows AttributeError. The error must reach the user as the
+        # extension error it is, install line included -- not as "extension
+        # has no setup() function".
+        from sphinx.application import Sphinx
+        from sphinx.errors import ExtensionError
+
+        monkeypatch.setattr(toolchain, "unmet_requirements", lambda: [VIOLATION])
+        (tmp_path / "conf.py").write_text(
+            'extensions = ["sphinxcontrib.test_reports"]\n', encoding="utf-8"
+        )
+        (tmp_path / "index.rst").write_text("Index\n=====\n", encoding="utf-8")
+        with pytest.raises(ExtensionError, match=r"sphinx-test-reports\[sphinx\]"):
+            Sphinx(
+                srcdir=tmp_path,
+                confdir=tmp_path,
+                outdir=tmp_path / "_build",
+                doctreedir=tmp_path / "_doctrees",
+                buildername="html",
+                status=None,
+                warning=StringIO(),
+            )


### PR DESCRIPTION
Closes #155.

## What changes

`pip install sphinx-test-reports` now installs `lxml` alone. Sphinx and sphinx-needs move to a `sphinx` extra:

```toml
dependencies = ["lxml"]

[project.optional-dependencies]
sphinx = ["sphinx>=7.4", "sphinx-needs>=6.0.1"]
pytest = ["pytest>=7.0"]   # from #151, unchanged
```

So the install line of a documentation project becomes `pip install "sphinx-test-reports[sphinx]"`, and a test runner or build action that only wants `test-reports build needs` no longer pulls the toolchain. The same goes for the pytest plugin #151 added as the `pytest` extra: `pip install "sphinx-test-reports[pytest]"` now yields the plugin, pytest and `lxml`, nothing of the toolchain. `[test]` gains the two floors it used to inherit from the core list; `[docs]` already had them; the nox matrix pins both explicitly and is unaffected.

The install page lists the three install lines side by side (`sphinx` extra for a documentation project, `pytest` extra for a test runner, bare package for a build action running the command), and the plugin's page, which said how to enable the plugin but not how to install it, names the extra.

## The version-constraint gap

An extra is opt-in, so a project that keeps installing the bare package next to an already-installed older toolchain never shows pip the floors. The lazy `setup` in `__init__.py` now enforces them at load time, before the extension is imported (an outdated sphinx-needs may well import and only fail later, inside a directive):

```
Extension error:
Could not load extension sphinxcontrib.test_reports: sphinx-needs 5.1.0 is installed, but sphinx-needs>=6.0.1 is required. Install the Sphinx extension's dependencies with: pip install "sphinx-test-reports[sphinx]"
```

A toolchain that is missing altogether keeps the existing "Could not import extension" path, which now names the extra too:

```
Extension error:
Could not import extension sphinxcontrib.test_reports; the Sphinx extension's dependencies are an extra, install them with: pip install "sphinx-test-reports[sphinx]" (exception: No module named 'sphinx_needs')
```

One deviation from the sketch in the issue: instead of `app.require_sphinx((7, 4))` plus a hard-coded sphinx-needs floor, the new `toolchain` module reads the `sphinx` extra's requirements from the package's own metadata (`importlib.metadata.requires`) and compares each installed version against its specifier. The floors then live in `pyproject.toml` alone -- #150 just moved them, and a copy in code would need a lockstep test -- and a test guards that the extra the check reads is the one `pyproject.toml` declares. `packaging` does the parsing; it is imported lazily and the check stands down without it, since it arrives with Sphinx (and pytest) wherever the extension can be loaded. A distribution that is *not installed* is deliberately left to the import: the import states it more precisely, and a toolchain importable from a source tree without metadata must not be refused.

On Sphinx 9 the error appears inside Sphinx's crash report, as the existing "Known" changelog entry already notes for the configuration errors; the note now covers this case too.

## Guaranteeing the property in CI

A `toolchain_free` nox session (Python 3.11 and 3.12, new CI job, wired into `all_good`) installs the package with the dependencies it declares -- `pip install ".[pytest]"`, no `--no-deps`, so the declared lists themselves are what is tested -- asserts that neither `sphinx`, `sphinx_needs` nor `docutils` is importable, and runs the converter's and the pytest plugin's test modules with `-m "not toolchain"`. The tests that need a build carry the new `toolchain` mark (the issue suggested `needs_sphinx`; `sphinx` itself is taken by Sphinx's own testing fixtures). `tests/conftest.py` loads `sphinx.testing.fixtures` only where Sphinx is importable, and one top-level import of the package's Sphinx-dependent `exceptions` module in `test_project_config.py` became local to the marked test that uses it.

#151's `plugin_floor` session (the plugin's tests on the oldest pytest per Python) installed `.[test]`, which after this change brings the toolchain back in. It now installs `.[pytest]` plus pytest-xdist and runs the same toolchain-absent guard, so the floor run doubles as the isolation proof on old pytest. It also forwards nox's posargs, which CI passes (`--full-trace`) and it ignored.

The mypy CI job installs with `uv sync --group dev --extra sphinx`; without the extra it would no longer see Sphinx and docutils.

## Open questions from the issue, as resolved here

- **Extra name:** `sphinx`, as proposed. It matches the `[docs]`/`[test]` style and the `[pytest]` extra from #151.
- **1.5.0 or 2.0:** not decided here. The changelog carries a "Breaking:" entry spelling out the install-line change; `version` is untouched, so the release can decide.
- **Two-distribution split:** not done, per the suggested path.
- **`[pytest]` extra:** on master since #151; this PR is what makes it toolchain-free, and the second commit proves and documents that.

## Verification

- `pytest -n auto tests/`: 407 passed (13 new in `tests/test_toolchain.py`)
- `nox -s toolchain_free-3.11 toolchain_free-3.12`: 308 passed, 3 skipped (the pytest-xdist tests; xdist is not installed there), 24 `toolchain`-marked deselected, in a venv holding the package, `lxml` and pytest only; the toolchain-absent guard passes
- `nox -s "plugin_floor(python='3.11', pytest_version='7.0.1')" "plugin_floor(python='3.12', pytest_version='7.3.2')"`: 63 passed each, toolchain absent
- `mypy`: clean (the new module is strict-checked, not excluded)
- `pre-commit run --all-files`: clean
- `sphinx-build -W` of the docs: clean

## Notes for the reviewer

- Rebased onto #151 (`pyproject.toml`, `noxfile.py`, `ci.yaml`, `tests/conftest.py` conflicted; all resolved as a union of both sides). The first commit is the original change; the second is the plugin-isolation follow-up and can be reviewed, or dropped, on its own.
- `docs/install.rst` also fixes two pre-existing typos on the page it rewrites ("must to be", "can be find").
