### PR TITLE
🚀 Release v2.0.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,48 @@ Unreleased
 ----------
 :Released: under development
 
+.. _`release:2.0.0`:
+
+2.0.0
+-----
+:Released: 11.09.2026
+
+A major release. ``pip install sphinx-test-reports`` no longer installs Sphinx
+and Sphinx-Needs, Python 3.10 is no longer supported, Sphinx-Needs 6.0.1 and
+Sphinx 7.4 are the oldest supported versions, and a failed test case's
+``result`` is spelled ``failed`` rather than ``failure``. What the bare package
+gains in return is a life outside a documentation build: a ``test-reports``
+command that turns test-result XML into a ``needs.json`` without running
+Sphinx, and a pytest plugin that writes the XML shape this extension reads. A
+project can also be described once, declaratively, in the ``[test_reports]``
+section of ``ubproject.toml`` instead of being restated in ``conf.py``.
+
+Upgrading a documentation project means adding the extra to its install line:
+``pip install "sphinx-test-reports[sphinx]"``. Beyond that, only a project that
+names the old ``failure`` result has to change anything: a filter on the value,
+a custom ``tr_report_template`` copied from the shipped one, and custom CSS on
+the ``tr_failure`` class.
+
+* Breaking: ``pip install sphinx-test-reports`` no longer installs Sphinx and
+  Sphinx-Needs. They are the new ``sphinx`` extra, so the install line of a
+  documentation project becomes ``pip install "sphinx-test-reports[sphinx]"``.
+  The bare package brings only ``lxml``, the dependency of the ``test-reports``
+  command, which runs in test runners and build actions that have no
+  documentation toolchain; the pytest plugin, the ``pytest`` extra, runs there
+  too. An extra is opt-in, so the extension now checks the installed toolchain
+  against the versions the extra declares when Sphinx loads it: a missing or
+  older Sphinx or Sphinx-Needs stops the build with a message naming the
+  install line, instead of a traceback from inside a directive.
+  `#159 <https://github.com/useblocks/sphinx-test-reports/pull/159>`_
+* Breaking: Python 3.10 is no longer supported. It reached the end of upstream
+  support, and dropping it lets the package read TOML with ``tomllib`` from the
+  standard library instead of carrying a backport.
+  `#147 <https://github.com/useblocks/sphinx-test-reports/pull/147>`_
+* Breaking: sphinx-needs 6.0.1 and Sphinx 7.4 are the oldest supported
+  versions. 6.0.1 is the first release whose ``add_extra_option`` takes a
+  schema, which this extension registers its fields with; sphinx-needs 6 itself
+  requires Sphinx 7.4. The compatibility branches for older releases are gone.
+  `#150 <https://github.com/useblocks/sphinx-test-reports/pull/150>`_
 * Breaking: a failed test case now carries the ``result`` value ``failed``
   instead of ``failure``, so that every state is spelled the same way -- as a
   participle, like the ``passed``, ``skipped`` and ``disabled`` beside it, and
@@ -23,61 +65,14 @@ Unreleased
   carries rules for both, so the colours survive either way). The value is also
   what ``test-reports build needs`` writes into ``needs.json``, so a consumer
   of that file -- a schema, a metamodel validator -- has to be updated with it.
-* Improvement: both parsers now map their input onto that one vocabulary
-  instead of each passing its own through, so a JSON report written against
-  the JUnit dialect no longer produces a different ``result`` than the XML it
-  mirrors. A state this package does not know is still passed through
-  untouched, so a ``tr_json_mapping`` pointing at a report with a vocabulary
-  of its own keeps working.
-* Breaking: ``pip install sphinx-test-reports`` no longer installs Sphinx and
-  Sphinx-Needs. They are the new ``sphinx`` extra, so the install line of a
-  documentation project becomes ``pip install "sphinx-test-reports[sphinx]"``.
-  The bare package brings only ``lxml``, the dependency of the ``test-reports``
-  command, which runs in test runners and build actions that have no
-  documentation toolchain; the pytest plugin, the ``pytest`` extra, runs there
-  too. An extra is opt-in, so the extension now checks the
-  installed toolchain against the versions the extra declares when Sphinx
-  loads it: a missing or older Sphinx or Sphinx-Needs stops the build with a
-  message naming the install line, instead of a traceback from inside a
-  directive.
-* Testing: CI installs the package with the ``pytest`` extra alone and runs the
-  converter's and the pytest plugin's tests without Sphinx -- on the newest
-  pytest and on the oldest the plugin supports -- so a toolchain import
-  creeping into either import chain, or Sphinx creeping back into a dependency
-  list, fails the build.
-* Feature: Support the googletest XML dialect: ``status="notrun"`` is reported
-  as ``disabled`` instead of ``passed``, all ``<failure>``/``<skipped>`` parts
-  of a test case are kept instead of only the first, ``RecordProperty`` values
-  in attribute form are read (on ``<testcase>`` for googletest < 1.8.1 and on
-  ``<testsuite>`` for suite-level properties up to 1.15.x), and ``timestamp``,
-  ``value_param`` and ``type_param`` are parsed. ``<system-err>`` is captured.
-* Feature: The source location of a test case is available as Sphinx-Needs
-  fields, configurable via the new ``tr_source_file_option`` and
-  ``tr_source_line_option``.
-* Bugfix: ``tr_file_option`` is now honoured by the directives, not only by the
-  field registration. Renaming the field previously produced needs carrying an
-  unregistered field.
-* Feature: New ``tr_deterministic_case_ids`` option derives test-case IDs from
-  the source location instead of the need content, so an ID no longer changes
-  when a test starts failing differently.
-* Feature: Declarative configuration in the ``[test_reports]`` section of
-  ``ubproject.toml``, the file shared with the other useblocks tooling, so a
-  project is described once instead of being restated in ``conf.py``. The file
-  is searched for upwards from the ``confdir``, stopping at the repository
-  root;
-  the new ``tr_config_from_toml`` names or disables it. Precedence is ``-D`` >
-  ``ubproject.toml`` > ``conf.py`` > default. See :ref:`tr_config_from_toml`.
+  `#161 <https://github.com/useblocks/sphinx-test-reports/pull/161>`_
 * Feature: New ``test-reports build needs`` command line interface, converting
   test-result XML into a ``needs.json`` without running Sphinx, so the
   conversion can run as a cacheable build action and the documentation build
-  only imports the result. Its settings come from the ``[test_reports.build.needs]``
-  table of ``ubproject.toml``, with flags for per-invocation overrides. See
-  :ref:`cli`.
-* Feature: The produced ``needs.json`` declares every field it uses in a
-  ``needs_schema``, as Sphinx-Needs does for the files a build writes, so a
-  consumer can read the type of a field from the artifact instead of from a
-  Sphinx build with the extension loaded. The declarations and the fields the
-  extension registers come from one table, so the two cannot drift apart.
+  only imports the result. Its settings come from the
+  ``[test_reports.build.needs]`` table of ``ubproject.toml``, with flags for
+  per-invocation overrides. See :ref:`cli`.
+  `#148 <https://github.com/useblocks/sphinx-test-reports/pull/148>`_
 * Feature: A pytest plugin (``-p sphinxcontrib.test_reports.pytest_plugin``)
   gives every test case the source location an editor shows -- pytest's
   ``file``/``line`` counted from 1, Bazel's runfiles prefix cut, a runtime
@@ -89,30 +84,78 @@ Unreleased
   plugin was ported from, is the documented example. The plugin is the
   ``pytest`` extra: ``pip install "sphinx-test-reports[pytest]"`` installs it
   and pytest, without the documentation toolchain. See :ref:`pytest_plugin`.
+  `#151 <https://github.com/useblocks/sphinx-test-reports/pull/151>`_
+* Feature: Declarative configuration in the ``[test_reports]`` section of
+  ``ubproject.toml``, the file shared with the other useblocks tooling, so a
+  project is described once instead of being restated in ``conf.py``. The file
+  is searched for upwards from the ``confdir``, stopping at the repository
+  root; the new ``tr_config_from_toml`` names or disables it. Precedence is
+  ``-D`` > ``ubproject.toml`` > ``conf.py`` > default. See
+  :ref:`tr_config_from_toml`.
+  `#145 <https://github.com/useblocks/sphinx-test-reports/pull/145>`_
+* Feature: The produced ``needs.json`` declares every field it uses in a
+  ``needs_schema``, as Sphinx-Needs does for the files a build writes, so a
+  consumer can read the type of a field from the artifact instead of from a
+  Sphinx build with the extension loaded. The declarations and the fields the
+  extension registers come from one table, so the two cannot drift apart.
+  `#148 <https://github.com/useblocks/sphinx-test-reports/pull/148>`_
+* Feature: Support the googletest XML dialect: ``status="notrun"`` is reported
+  as ``disabled`` instead of ``passed``, all ``<failure>``/``<skipped>`` parts
+  of a test case are kept instead of only the first, ``RecordProperty`` values
+  in attribute form are read (on ``<testcase>`` for googletest < 1.8.1 and on
+  ``<testsuite>`` for suite-level properties up to 1.15.x), and ``timestamp``,
+  ``value_param`` and ``type_param`` are parsed. ``<system-err>`` is captured.
+  `#141 <https://github.com/useblocks/sphinx-test-reports/pull/141>`_
+* Feature: The source location of a test case is available as Sphinx-Needs
+  fields, configurable via the new ``tr_source_file_option`` and
+  ``tr_source_line_option``.
+  `#142 <https://github.com/useblocks/sphinx-test-reports/pull/142>`_
+* Feature: New ``tr_deterministic_case_ids`` option derives test-case IDs from
+  the source location instead of the need content, so an ID no longer changes
+  when a test starts failing differently.
+  `#143 <https://github.com/useblocks/sphinx-test-reports/pull/143>`_
+* Improvement: both parsers now map their input onto the one ``result``
+  vocabulary instead of each passing its own through, so a JSON report written
+  against the JUnit dialect no longer produces a different ``result`` than the
+  XML it mirrors. A state this package does not know is still passed through
+  untouched, so a ``tr_json_mapping`` pointing at a report with a vocabulary of
+  its own keeps working.
+  `#161 <https://github.com/useblocks/sphinx-test-reports/pull/161>`_
+* Bugfix: ``tr_file_option`` is now honoured by the directives, not only by the
+  field registration. Renaming the field previously produced needs carrying an
+  unregistered field.
+  `#142 <https://github.com/useblocks/sphinx-test-reports/pull/142>`_
 * Bugfix: ``tr_file_option``, ``tr_source_file_option`` and
   ``tr_source_line_option`` may no longer name a fixed field such as ``case``
   or ``result``, in ``conf.py`` or in the declarative file. The build
   previously stopped with a bare ``TypeError`` from inside a directive.
+  `#148 <https://github.com/useblocks/sphinx-test-reports/pull/148>`_
 * Support: ``result_text`` and ``remote_url`` are registered as need fields by
   the extension, so a ``needs.json`` the ``build needs`` command produced
   imports without dropping them. A project that registered ``remote_url``
   itself keeps its own registration.
+  `#148 <https://github.com/useblocks/sphinx-test-reports/pull/148>`_
+* Support: ``packaging`` is no longer a runtime dependency. The last import of
+  it under ``sphinxcontrib/`` is gone, so the ``docs`` and ``test`` extras,
+  whose ``conf.py`` files still use it, declare it instead.
+  `#154 <https://github.com/useblocks/sphinx-test-reports/pull/154>`_
+* Testing: CI installs the package with the ``pytest`` extra alone and runs the
+  converter's and the pytest plugin's tests without Sphinx -- on the newest
+  pytest and on the oldest the plugin supports -- so a toolchain import
+  creeping into either import chain, or Sphinx creeping back into a dependency
+  list, fails the build.
+  `#159 <https://github.com/useblocks/sphinx-test-reports/pull/159>`_
+* Testing: Run the test suite against sphinx-needs 8.5.0. The matrix
+  previously topped out at 8.0.0, so the release a fresh install resolves to
+  was untested.
+  `#158 <https://github.com/useblocks/sphinx-test-reports/pull/158>`_
 * Known: Sphinx 9 renders a configuration error raised from the declarative
   file -- a wrong type, a rename onto a fixed field, a disagreeing need type
   -- as its crash report rather than as a one-line message; the message is in
   the report. A typo in ``[test_reports.build.needs]`` is reported the same
   way, and so is a missing or outdated toolchain refused when the extension
   loads.
-* Support: Python 3.10 is no longer supported. It reached the end of upstream
-  support, and dropping it lets the package read TOML with ``tomllib`` from the
-  standard library instead of carrying a backport.
-* Support: sphinx-needs 6.0.1 and Sphinx 7.4 are the oldest supported versions.
-  6.0.1 is the first release whose ``add_extra_option`` takes a schema, which
-  this extension registers its fields with; sphinx-needs 6 itself requires
-  Sphinx 7.4. The compatibility branches for older releases are gone.
-* Testing: Run the test suite against sphinx-needs 8.5.0. The matrix
-  previously topped out at 8.0.0, so the release a fresh install resolves to
-  was untested.
+  `#148 <https://github.com/useblocks/sphinx-test-reports/pull/148>`_
 
 .. _`release:1.4.0`:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,7 +2,7 @@
 
 Command line interface
 ======================
-.. versionadded:: 1.5.0
+.. versionadded:: 2.0.0
 
 ``Sphinx-Test-Reports`` ships a ``test-reports`` command that converts
 test-result XML into a ``needs.json`` **without running Sphinx**.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,9 +32,9 @@ copyright = f"team useblocks, 2017-{now.year}"
 author = "team useblocks"
 
 # The short X.Y version
-version = "1.4"
+version = "2.0"
 # The full version, including alpha/beta/rc tags
-release = "1.4.0"
+release = "2.0.0"
 
 needs_id_regex = ".*"
 needs_css = "dark.css"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -130,7 +130,7 @@ Default: **file**
 
 tr_source_file_option
 ---------------------
-.. versionadded:: 1.5.0
+.. versionadded:: 2.0.0
 
 Name of the Sphinx-Needs field that carries the source file of a test case,
 taken from the ``file`` attribute of the JUnit/googletest ``<testcase>``
@@ -162,7 +162,7 @@ Default: **case_file**
 
 tr_source_line_option
 ---------------------
-.. versionadded:: 1.5.0
+.. versionadded:: 2.0.0
 
 Name of the Sphinx-Needs field that carries the source line of a test case,
 taken from the ``line`` attribute of the ``<testcase>`` element.
@@ -174,7 +174,7 @@ Default: **case_line**
 
 tr_deterministic_case_ids
 -------------------------
-.. versionadded:: 1.5.0
+.. versionadded:: 2.0.0
 
 Derive test-case IDs from the source location and the case name instead of
 hashing the need's type, title and content.
@@ -413,7 +413,7 @@ An example of a JSON file, which supports the below configuration, can be seen i
 
 Declarative configuration (ubproject.toml)
 ------------------------------------------
-.. versionadded:: 1.5.0
+.. versionadded:: 2.0.0
 
 All of the above can also be configured declaratively, in the
 ``[test_reports]`` section of your project's ``ubproject.toml`` -- the same
@@ -497,7 +497,7 @@ deterministic case IDs, next to locally created test-case needs, must set
 
 tr_config_from_toml
 ~~~~~~~~~~~~~~~~~~~
-.. versionadded:: 1.5.0
+.. versionadded:: 2.0.0
 
 Name of the declarative configuration file whose ``[test_reports]`` section is
 applied to the ``tr_*`` values above. Defaults to ``ubproject.toml``.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -24,7 +24,7 @@ bare package, whose single dependency is ``lxml``::
 
    pip install sphinx-test-reports
 
-.. versionchanged:: 1.5.0
+.. versionchanged:: 2.0.0
    ``pip install sphinx-test-reports`` -- without an extra -- no longer
    installs Sphinx and Sphinx-Needs. A documentation project has to add the
    ``sphinx`` extra to its install line; a test runner or a build action that

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -2,7 +2,7 @@
 
 pytest plugin
 =============
-.. versionadded:: 1.5.0
+.. versionadded:: 2.0.0
 
 A stock pytest run writes a JUnit XML that this extension can only partly use.
 Under pytest's default ``junit_family = xunit2`` no ``<testcase>`` carries the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sphinx-test-reports"
-version = "1.4.0"
+version = "2.0.0"
 description = "Sphinx extension for showing test results and test environment information inside sphinx documentations"
 readme = "README.rst"
 license = { text = "MIT" }

--- a/sphinxcontrib/test_reports/test_reports.py
+++ b/sphinxcontrib/test_reports/test_reports.py
@@ -54,7 +54,7 @@ from sphinxcontrib.test_reports.projectconfig import (
 
 # fmt: on
 
-VERSION = "1.4.0"
+VERSION = "2.0.0"
 
 try:
     # sphinx-needs >= 7.0: fields are registered through add_field.


### PR DESCRIPTION
## Release v2.0.0

Bumps the version, retitles the version directives that were written against
the planned 1.5.0, and turns the `Unreleased` changelog into the 2.0.0
section.

### Why 2.0.0 and not 1.5.0

Four changes in this cycle are breaking, so the major digit moves. The first
three break an existing install; the fourth breaks project content instead:

| Change | PR | What breaks |
| --- | --- | --- |
| Sphinx and Sphinx-Needs became the `sphinx` extra | #159 | A documentation project has to install `sphinx-test-reports[sphinx]`; the bare package no longer brings a toolchain |
| Python 3.10 dropped | #147 | 3.11 is the floor |
| Sphinx-Needs 6.0.1 / Sphinx 7.4 floors | #150 | The compatibility branches for older releases are gone |
| A failed test case's `result` is `failed`, not `failure` | #161 | A filter naming the value (`'failure' == result`), a custom `tr_report_template` — which carries two such filters from the shipped template it was copied from — and custom CSS on the generated `tr_failure` class, now `tr_failed` |

The docs were already written for 1.5.0, so every `versionadded` /
`versionchanged` directive naming it is retitled here.

### Changes

- **Version** → `2.0.0` in `pyproject.toml`, `docs/conf.py` (`version` =
  `2.0`, `release` = `2.0.0`) and `sphinxcontrib/test_reports/test_reports.py`
  (`VERSION`), matching the three places 1.4.0 touched.
- **Version directives** → `2.0.0` in `docs/cli.rst`, `docs/pytest.rst`,
  `docs/install.rst` and the five in `docs/configuration.rst`.
- **Changelog** → new `2.0.0` section, released 11.09.2026, with the
  `Unreleased` heading kept empty on top.

### Changelog notes

The entry prose is unchanged; it is regrouped by category the way the 1.4.0
section is, and each entry now carries its PR link. Two deliberate edits:

- The Python 3.10 drop and the Sphinx-Needs 6.0.1 / Sphinx 7.4 floors were
  labelled `Support:`. They are relabelled `Breaking:`, since they are what
  the major bump is for.
- #154 (`packaging` dropped as a runtime dependency, moved into the `docs` and
  `test` extras) had no changelog line. Added as a `Support:` entry — it
  changes the installed dependency set, which is this release's theme.

All 16 `Unreleased` entries survive; the new count is 17. Rebasing onto master
after #161 merged folded in its two entries — the `Breaking:` rename and the
`Improvement:` parser normalisation — bringing the section to 19. They are
placed by the same category grouping, and the section's opening prose gained
the rename as a fourth breaking change; its "Nothing else in an existing
project has to change" sentence had to be inverted, since the rename makes it
false.

### Verification

- `uv run pytest -n auto tests/` → **421 passed** (Python 3.14, from a fresh
  `uv sync --all-groups --all-extras`), re-run on the rebased branch; 407
  before #161, which added a test module.
- `uv run sphinx-build -b html docs docs/_build/html` → `build succeeded.`,
  no warnings, so the rewritten changelog is valid reStructuredText.
- `uv run pre-commit run --files <the 8 changed files>` → all hooks pass.
- `grep -rn "1\.5\.0" docs/ sphinxcontrib/ pyproject.toml` → no matches left.
- No test asserts the package version, so the bump needed no test changes.

### After merge

Push a `2.0.0` tag. `.github/workflows/release.yaml` triggers on tags matching
`[0-9].[0-9]+.[0-9]+`, which `2.0.0` does, and publishes to PyPI via trusted
publishing.

### One thing left for you to decide

`pyproject.toml` still classifies the project as
`Development Status :: 4 - Beta`. A 2.0.0 release is a natural moment to move
it to `5 - Production/Stable`, but that is a call about the project rather than
part of the version bump, so it is untouched here.
