### PR TITLE
feat(parsers)!: spell a failed result `failed`, not `failure` — one result vocabulary for both parsers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,28 @@ Unreleased
 ----------
 :Released: under development
 
+* Breaking: a failed test case now carries the ``result`` value ``failed``
+  instead of ``failure``, so that every state is spelled the same way -- as a
+  participle, like the ``passed``, ``skipped`` and ``disabled`` beside it, and
+  like the ``failed`` count on a test-file and test-suite need. ``failure`` was
+  never a chosen name: it was the name of the JUnit ``<failure>`` element,
+  passed through by the parser. The full vocabulary is now ``passed``,
+  ``failed``, ``error``, ``skipped``, ``disabled``; ``error`` is unchanged,
+  because it agrees with the ``errors`` count beside it. **Three things in a
+  project have to be updated:** a filter naming the value
+  (``'failure' == result`` becomes ``'failed' == result``), a custom
+  ``tr_report_template``, which contains two such filters in the shipped
+  template it was copied from, and custom CSS targeting the generated
+  ``tr_failure`` class, which is now ``tr_failed`` (the stylesheet still
+  carries rules for both, so the colours survive either way). The value is also
+  what ``test-reports build needs`` writes into ``needs.json``, so a consumer
+  of that file -- a schema, a metamodel validator -- has to be updated with it.
+* Improvement: both parsers now map their input onto that one vocabulary
+  instead of each passing its own through, so a JSON report written against
+  the JUnit dialect no longer produces a different ``result`` than the XML it
+  mirrors. A state this package does not know is still passed through
+  untouched, so a ``tr_json_mapping`` pointing at a report with a vocabulary
+  of its own keeps working.
 * Breaking: ``pip install sphinx-test-reports`` no longer installs Sphinx and
   Sphinx-Needs. They are the new ``sphinx`` extra, so the install line of a
   documentation project becomes ``pip install "sphinx-test-reports[sphinx]"``.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -41,7 +41,7 @@ lost evidence.
 Each test case becomes one need shaped exactly like the need the build's
 ``test-case`` directive creates for it: titled with the case name; ``suite``,
 ``case``, ``case_name``, ``case_parameter``, ``classname``, ``result`` (spelled
-as the build spells it -- ``passed``, ``failure``, ``error``, ``skipped``,
+as the build spells it -- ``passed``, ``failed``, ``error``, ``skipped``,
 ``disabled`` -- so one filter matches imported and local cases alike) and
 ``time``; the report path under ``file``; the test's source location under
 ``case_file`` and ``case_line``; a one-line ``result_text``; and the full

--- a/docs/custom_test_report_template.txt
+++ b/docs/custom_test_report_template.txt
@@ -24,7 +24,7 @@
 **Failed test cases**:
 
 .. needtable::
-   :filter: '{id}' in tags and 'failure' == result
+   :filter: '{id}' in tags and 'failed' == result
    :columns: id, title, result
    :style_row: tr_[[copy('result')]]
 
@@ -40,7 +40,7 @@
 
 | Test suites: :need_count:`'{id}' in tags and type=='{suite_need}'`
 | Test cases: :need_count:`'{id}' in tags and type=='{case_need}'`
-| Failed test cases: :need_count:`'{id}' in tags and 'failure' == result and type=='{case_need}'`
+| Failed test cases: :need_count:`'{id}' in tags and 'failed' == result and type=='{case_need}'`
 | Skipped test cases: :need_count:`'{id}' in tags and 'skipped' == result and type=='{case_need}'`
 
 

--- a/docs/directives/test_case.rst
+++ b/docs/directives/test_case.rst
@@ -38,7 +38,8 @@ or if it selects only the first found test case. The best case is to always try 
 
 ``test-case`` creates a need of type ``testcase`` and adds the following options automatically:
 
-* **result**: Result of the test case run. E.g passed or failed.
+* **result**: Result of the test case run: ``passed``, ``failed``, ``error``,
+  ``skipped`` or ``disabled``.
 * **time**: Needed time for running the test case
 
 These options can also be used to :ref:`filter for certain test-files <filter>`.

--- a/docs/examples/pytest.rst
+++ b/docs/examples/pytest.rst
@@ -7,13 +7,13 @@ The data is coming from a pytest-run on the tests of the sphinx project.
 
 | Test suites: :need_count:`'pytest_sphinx' in tags and type=='testsuite'`
 | Test cases: :need_count:`'pytest_sphinx' in tags and type=='testcase'`
-| Failed test cases: :need_count:`'pytest_sphinx' in tags and 'failure' == result and type=='testcase'`
+| Failed test cases: :need_count:`'pytest_sphinx' in tags and 'failed' == result and type=='testcase'`
 | Skipped test cases: :need_count:`'pytest_sphinx' in tags and 'skipped' == result and type=='testcase'`
 
 **Failed test cases**:
 
 .. needtable::
-   :filter: 'pytest_sphinx' in tags and 'failure' == result
+   :filter: 'pytest_sphinx' in tags and 'failed' == result
    :columns: id, title, result
    :style: table
    :style_row: tr_[[copy('result')]]

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -173,7 +173,7 @@ spelling. Empty values are not written, and a decorator that would write
 nothing is an error at import time. The values are written when the test is
 set up, against the declared model; a wrong shape -- a list where one value is
 expected -- makes that test error at setup with the ``TypeError`` above (its
-need then carries the result ``error``, not ``failure``). The properties keep
+need then carries the result ``error``, not ``failed``). The properties keep
 the order of the keywords.
 
 The decorator also goes on a class, and decorators stack: a classification on

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,6 +32,7 @@ TOOLCHAIN_FREE_TESTS = [
     "tests/test_needs_export.py",
     "tests/test_project_config.py",
     "tests/test_pytest_plugin.py",
+    "tests/test_result_vocabulary.py",
     "tests/test_toolchain.py",
 ]
 

--- a/sphinxcontrib/test_reports/css/common.css
+++ b/sphinxcontrib/test_reports/css/common.css
@@ -2,6 +2,11 @@ tr.tr_passed, div.tr_passed {
     background-color: rgba(0,250,0,0.2) !important;
 }
 
+/* `tr_failure` is the class needs carried before the result was spelled
+   `failed`. It is kept because a project may still produce it: a result a
+   `tr_json_mapping` supplies under a vocabulary of its own is passed through
+   unnormalised, and the class is built from the result value. */
+tr.tr_failed, div.tr_failed,
 tr.tr_failure, div.tr_failure {
     background-color: rgba(250,0,0,0.2) !important;
 }
@@ -25,6 +30,7 @@ td.status p.tr_passed{
     color: #008000;
 }
 
+td.status p.tr_failed,
 td.status p.tr_failure{
     border: 1px solid #800000;
     color: #800000;

--- a/sphinxcontrib/test_reports/directives/test_report_template.txt
+++ b/sphinxcontrib/test_reports/directives/test_report_template.txt
@@ -6,7 +6,7 @@
 
 | Test suites: :need_count:`'{id}' in tags and type=='{suite_need}'`
 | Test cases: :need_count:`'{id}' in tags and type=='{case_need}'`
-| Failed test cases: :need_count:`'{id}' in tags and 'failure' == result and type=='{case_need}'`
+| Failed test cases: :need_count:`'{id}' in tags and 'failed' == result and type=='{case_need}'`
 | Skipped test cases: :need_count:`'{id}' in tags and 'skipped' == result and type=='{case_need}'`
 
 **Test cases**:
@@ -19,7 +19,7 @@
 **Failed test cases**:
 
 .. needtable::
-   :filter: '{id}' in tags and 'failure' == result
+   :filter: '{id}' in tags and 'failed' == result
    :columns: id, title, result
    :style_row: tr_[[copy('result')]]
 

--- a/sphinxcontrib/test_reports/fields.py
+++ b/sphinxcontrib/test_reports/fields.py
@@ -18,6 +18,8 @@ sphinx-needs declares every registered field.
 
 from typing import Iterable, Mapping
 
+from sphinxcontrib.test_reports.results import CANONICAL_RESULTS
+
 #: ``name -> (JSON type, description)`` for every field declared under a fixed
 #: name. The build registers all of them, on test-file, test-suite and
 #: test-case needs alike; the converter writes test-case needs and therefore
@@ -38,7 +40,10 @@ FIELDS: dict[str, tuple[str, str]] = {
     # Turning it into a number is issue #156: it has to change here, in both
     # writers and in every consuming filter at once.
     "time": ("string", "Test execution time, in seconds"),
-    "result": ("string", "Test result status"),
+    # The states are named, not just the field: a consumer reading the
+    # declarations out of a produced `needs.json` learns the field's domain
+    # from them without having to load this package.
+    "result": ("string", f"Test result status: {', '.join(CANONICAL_RESULTS)}"),
     "result_text": ("string", "One-line rendering of the first failure message"),
     "remote_url": ("string", "URL of the test's source in the remote repository"),
     "suites": ("integer", "Number of test suites"),

--- a/sphinxcontrib/test_reports/jsonparser.py
+++ b/sphinxcontrib/test_reports/jsonparser.py
@@ -12,6 +12,8 @@ import os
 from functools import reduce
 from typing import Any, Dict, List
 
+from sphinxcontrib.test_reports.results import normalize_result
+
 
 def dict_get(root, items, default=None):
     """
@@ -60,6 +62,14 @@ class JsonParser:
             tc_dict = {
                 k: dict_get(json_dict, v[0], v[1]) for k, v in tc_mapping.items()
             }
+            # A JSON report written against the JUnit dialect spells a failure
+            # `failure`, after the element name. The API is documented as being
+            # in sync with the JUnit parser's, so the same outcome has to
+            # arrive under the same `result` here -- a value this package does
+            # not know is left as the report wrote it.
+            result = tc_dict.get("result")
+            if isinstance(result, str):
+                tc_dict["result"] = normalize_result(result)
             return tc_dict
 
         def parse_testsuite(json_dict) -> Dict[str, Any]:

--- a/sphinxcontrib/test_reports/junitparser.py
+++ b/sphinxcontrib/test_reports/junitparser.py
@@ -6,6 +6,8 @@ import os
 
 from lxml import etree, objectify
 
+from sphinxcontrib.test_reports.results import normalize_result
+
 #: Attributes the JUnit/googletest dialects define themselves. Every *other*
 #: attribute is a ``RecordProperty`` value in attribute form: googletest wrote
 #: test-case properties as attributes before 1.8.1 (the form its official docs
@@ -46,7 +48,9 @@ TESTSUITE_KNOWN_ATTRIBUTES = frozenset(
 )
 
 #: ``<testcase>`` children carrying a result, in the precedence order used to
-#: classify a case that has more than one kind of them.
+#: classify a case that has more than one kind of them. These are XML element
+#: names, not ``result`` values -- ``<failure>`` is read as the result
+#: ``failed`` (see :mod:`sphinxcontrib.test_reports.results`).
 RESULT_PART_KINDS = ("skipped", "failure", "error")
 
 
@@ -187,7 +191,11 @@ class JUnitParser:
                 None,
             )
             if first_part is not None:
-                tc_dict["result"] = first_part["kind"]
+                # The part's `kind` is the name of the XML element the evidence
+                # came from and stays that way -- the converter capitalises it
+                # into the evidence heading. `result` is this package's
+                # vocabulary, so it goes through the mapping.
+                tc_dict["result"] = normalize_result(first_part["kind"])
                 tc_dict["type"] = first_part["type"]
                 # part text can be None for pytest xfail test cases
                 tc_dict["text"] = first_part["text"]

--- a/sphinxcontrib/test_reports/needs_export.py
+++ b/sphinxcontrib/test_reports/needs_export.py
@@ -176,11 +176,11 @@ def build_need(
     ``case_name``/``case_parameter``/``classname``/``result``/``time`` plus the
     renameable report-path and source-location fields in *fields* (see
     :data:`DEFAULT_FIELD_NAMES`) -- and so are the values: the title is the
-    case name and ``result`` keeps the parser's spelling (``failure``, which is
-    also a documented field value and the ``tr_failure`` CSS class), so that a
-    need imported from the produced ``needs.json`` and one created locally from
-    the same report are indistinguishable to a schema, a filter or a
-    ``needtable``.
+    case name and ``result`` keeps the parser's spelling (``failed``, which is
+    also a documented field value and the ``tr_failed`` CSS class, see
+    :mod:`sphinxcontrib.test_reports.results`), so that a need imported from
+    the produced ``needs.json`` and one created locally from the same report
+    are indistinguishable to a schema, a filter or a ``needtable``.
 
     XML properties become fields under their own names only when listed in
     *extra_options* -- the same list that makes the build register them as need

--- a/sphinxcontrib/test_reports/results.py
+++ b/sphinxcontrib/test_reports/results.py
@@ -1,0 +1,63 @@
+"""The vocabulary of the ``result`` field, and the one place it is decided.
+
+Every state a test case can be in is spelled as a participle: ``passed``,
+``failed``, ``error``, ``skipped``, ``disabled``. That is one decision applied
+to two parsers, which is the point of this module -- before it, ``result`` was
+whatever the input happened to call it. The JUnit parser passed the name of the
+result-carrying ``<testcase>`` child through verbatim, so a failure was
+``failure`` after the ``<failure>`` element, while the two states with no
+element of their own were invented as participles (``passed``, and ``disabled``
+for googletest's ``status="notrun"``). The JSON parser passed its report's own
+value through untouched. So the same outcome could arrive under two spellings,
+and a single test case was ``failure`` while the count of them on its suite was
+``failed`` (:data:`~sphinxcontrib.test_reports.fields.FIELDS`).
+
+``error`` stays a noun-state deliberately: it agrees with the ``errors`` count
+beside it and with pytest, which spells that outcome ``error`` too. The pair
+that disagreed was ``failure``/``failed``, and ``failed`` is the half that
+already appeared in a field name.
+
+**Nothing in this module may import Sphinx.** Both parsers run under the
+``test-reports`` command, as a build action without the documentation
+toolchain installed.
+"""
+
+#: Every value the parsers of this package put into ``result``. A documented
+#: field value: a project filters on it (``'failed' == result``), the
+#: directives turn it into the CSS class that colours a need and a table row
+#: (``tr_failed``), and the converter writes it into ``needs.json`` for
+#: consumers that never load this extension.
+#:
+#: A tuple, in the order a reader wants them rather than alphabetically:
+#: :func:`~sphinxcontrib.test_reports.fields.declaration` renders it into the
+#: declared description of the field, and the converter's output has to be
+#: byte-stable, which a set's iteration order is not.
+CANONICAL_RESULTS: tuple[str, ...] = (
+    "passed",
+    "failed",
+    "error",
+    "skipped",
+    "disabled",
+)
+
+#: ``as read -> canonical``, for the input spellings that are not already the
+#: vocabulary above. Only spellings some input really produces are listed, so
+#: that a state this package does not know -- ``tr_json_mapping`` points at an
+#: arbitrary report, whose states are its own -- survives untouched instead of
+#: being rewritten into something a project's filters no longer match.
+RESULT_ALIASES: dict[str, str] = {
+    # The name of the JUnit ``<failure>`` element, which the JUnit parser reads
+    # a case's result from, and which a JSON report written against the same
+    # dialect uses as its value.
+    "failure": "failed",
+}
+
+
+def normalize_result(result: str) -> str:
+    """*result* in the vocabulary of :data:`CANONICAL_RESULTS`.
+
+    Idempotent, and total: a value already canonical and a value this package
+    does not know are both returned unchanged, so the function can be applied
+    wherever a result is read without having to know where it came from.
+    """
+    return RESULT_ALIASES.get(result, result)

--- a/tests/doc_test/custom_tr_koi8_template/custom_test_report_template.txt
+++ b/tests/doc_test/custom_tr_koi8_template/custom_test_report_template.txt
@@ -24,7 +24,7 @@
 **Fehlgeschlagene Tests**:
 
 .. needtable::
-   :filter: '{id}' in tags and 'failure' == result
+   :filter: '{id}' in tags and 'failed' == result
    :columns: id, title, result
    :style_row: tr_[[copy('result')]]
 
@@ -40,7 +40,7 @@
 
 | Test Gruppen: :need_count:`'{id}' in tags and type=='{suite_need}'`
 | Test F?lle: :need_count:`'{id}' in tags and type=='{case_need}'`
-| Fehlgeschlagene Tests: :need_count:`'{id}' in tags and 'failure' == result and type=='{case_need}'`
+| Fehlgeschlagene Tests: :need_count:`'{id}' in tags and 'failed' == result and type=='{case_need}'`
 | Ausgelassene Tests: :need_count:`'{id}' in tags and 'skipped' == result and type=='{case_need}'`
 
 

--- a/tests/doc_test/custom_tr_template/custom_test_report_template.txt
+++ b/tests/doc_test/custom_tr_template/custom_test_report_template.txt
@@ -24,7 +24,7 @@
 **Failed test cases**:
 
 .. needtable::
-   :filter: '{id}' in tags and 'failure' == result
+   :filter: '{id}' in tags and 'failed' == result
    :columns: id, title, result
    :style_row: tr_[[copy('result')]]
 
@@ -40,7 +40,7 @@
 
 | Test suites: :need_count:`'{id}' in tags and type=='{suite_need}'`
 | Test cases: :need_count:`'{id}' in tags and type=='{case_need}'`
-| Failed test cases: :need_count:`'{id}' in tags and 'failure' == result and type=='{case_need}'`
+| Failed test cases: :need_count:`'{id}' in tags and 'failed' == result and type=='{case_need}'`
 | Skipped test cases: :need_count:`'{id}' in tags and 'skipped' == result and type=='{case_need}'`
 
 

--- a/tests/doc_test/custom_tr_utf8_template/custom_test_report_template.txt
+++ b/tests/doc_test/custom_tr_utf8_template/custom_test_report_template.txt
@@ -24,7 +24,7 @@
 **Fehlgeschlagene Tests**:
 
 .. needtable::
-   :filter: '{id}' in tags and 'failure' == result
+   :filter: '{id}' in tags and 'failed' == result
    :columns: id, title, result
    :style_row: tr_[[copy('result')]]
 
@@ -40,7 +40,7 @@
 
 | Test Gruppen: :need_count:`'{id}' in tags and type=='{suite_need}'`
 | Test Fälle: :need_count:`'{id}' in tags and type=='{case_need}'`
-| Fehlgeschlagene Tests: :need_count:`'{id}' in tags and 'failure' == result and type=='{case_need}'`
+| Fehlgeschlagene Tests: :need_count:`'{id}' in tags and 'failed' == result and type=='{case_need}'`
 | Ausgelassene Tests: :need_count:`'{id}' in tags and 'skipped' == result and type=='{case_need}'`
 
 

--- a/tests/doc_test/default_tr_template/conf.py
+++ b/tests/doc_test/default_tr_template/conf.py
@@ -1,0 +1,8 @@
+# A `test-report` build that leaves `tr_report_template` at its default, so the
+# template this package ships is the one that renders. Every other
+# `test-report` fixture points the option at a template of its own, which left
+# the shipped template -- and the `result` value its filters name -- uncovered.
+extensions = ["sphinx_needs", "sphinxcontrib.test_reports"]
+
+master_doc = "index"
+html_theme = "basic"

--- a/tests/doc_test/default_tr_template/index.rst
+++ b/tests/doc_test/default_tr_template/index.rst
@@ -1,0 +1,10 @@
+Default Report Template
+=======================
+
+``xml_data.xml`` holds three test cases, exactly one of which carries a
+``<failure>`` child -- so the template's failed-case count is 1.
+
+.. test-report:: My Report
+   :id: REPORT
+   :file: ../utils/xml_data.xml
+   :tags: my_report

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -567,8 +567,8 @@ def test_url_synthesis_needs_both_parts(tmp_path, flag):
 class TestResultVocabulary:
     """The export uses the parser's vocabulary, which is the build's.
 
-    ``failure`` is a documented need field value and a CSS class
-    (``tr_failure``), and the shipped report template filters on it. A project
+    ``failed`` is a documented need field value and a CSS class
+    (``tr_failed``), and the shipped report template filters on it. A project
     that mixes imported and locally created test-case needs filters both with
     one expression only if the two writers spell the result alike.
     """
@@ -577,7 +577,7 @@ class TestResultVocabulary:
         _, data = _convert(tmp_path)
 
         assert (
-            _needs(data)["testcase__MathTest__Subtraction_srmht"]["result"] == "failure"
+            _needs(data)["testcase__MathTest__Subtraction_srmht"]["result"] == "failed"
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -148,7 +148,7 @@ def test_parse_ctest_xml():
     )  # fail in name, but nowhere in status, faked fail
     assert test_suite["testcases"][2]["result"] == "passed"
     assert test_suite["testcases"][3]["name"] == "fail_test_output"
-    assert test_suite["testcases"][3]["result"] == "failure"
+    assert test_suite["testcases"][3]["result"] == "failed"
     assert test_suite["testcases"][4]["name"] == "skipped_test"
     assert test_suite["testcases"][4]["result"] == "skipped"
 
@@ -171,7 +171,7 @@ def test_parse_error_xml():
     assert test_suite["testcases"][0]["result"] == "passed"
 
     assert test_suite["testcases"][1]["name"] == "AFailingTest"
-    assert test_suite["testcases"][1]["result"] == "failure"
+    assert test_suite["testcases"][1]["result"] == "failed"
 
     assert test_suite["testcases"][2]["name"] == "AnErrorTest"
     assert test_suite["testcases"][2]["result"] == "error"

--- a/tests/test_junit_parser_gtest.py
+++ b/tests/test_junit_parser_gtest.py
@@ -59,7 +59,7 @@ def test_first_failure_part_stays_in_the_legacy_flat_keys():
     """``text``/``message`` keep their meaning for existing consumers."""
     case = _case("MathTest", "Subtraction")
 
-    assert case["result"] == "failure"
+    assert case["result"] == "failed"
     assert case["message"] == case["parts"][0]["message"]
     assert case["text"] == case["parts"][0]["text"]
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -159,7 +159,7 @@ class TestParserBackwardCompatibility:
 
         tc = results[0]["testcases"][2]
         assert tc["name"] == "AFailingTest"
-        assert tc["result"] == "failure"
+        assert tc["result"] == "failed"
         assert tc["text"] == " details about failure "
 
 

--- a/tests/test_result_vocabulary.py
+++ b/tests/test_result_vocabulary.py
@@ -1,0 +1,172 @@
+"""The ``result`` field's vocabulary, and the one place it is decided.
+
+A test case's ``result`` used to be whatever the input spelled it: the JUnit
+parser passed the name of the ``<testcase>`` child element through verbatim
+(``failure``), the JSON parser passed the report's own value through, and the
+two states with no element of their own -- ``passed`` and ``disabled`` -- were
+spelled as participles because nothing forced a choice. So one product said
+``failure`` for a single case and ``failed`` for the count of them
+(``fields.FIELDS``), and the documented value and the documented example
+disagreed.
+
+These tests pin the vocabulary down: every parser maps its input onto the same
+participles, and the mapping is the only place that decides. The part-level
+``kind`` is deliberately *not* normalised -- it names the XML element the
+evidence came from, which is what the rendered evidence heading reports.
+"""
+
+import os
+
+import pytest
+
+UTILS = os.path.join(os.path.dirname(__file__), "doc_test", "utils")
+XML_PATH = os.path.join(UTILS, "xml_data.xml")
+JSON_PATH = os.path.join(UTILS, "json_data.json")
+
+#: The mapping the JSON parser needs, as ``tr_json_mapping`` declares it.
+JSON_MAPPING = {
+    "testsuite": {
+        "name": (["name"], "unknown"),
+        "tests": (["tests"], "unknown"),
+        "errors": (["errors"], "unknown"),
+        "failures": (["failures"], "unknown"),
+        "skips": (["skips"], "unknown"),
+        "passed": (["passed"], "unknown"),
+        "time": (["time"], "unknown"),
+        "testcases": (["testcase"], "unknown"),
+    },
+    "testcase": {
+        "name": (["name"], "unknown"),
+        "classname": (["classname"], "unknown"),
+        "file": (["file"], "unknown"),
+        "line": (["line"], "unknown"),
+        "time": (["time"], "unknown"),
+        "result": (["result"], "unknown"),
+        "type": (["type"], "unknown"),
+        "text": (["text"], "unknown"),
+        "message": (["message"], "unknown"),
+        "system-out": (["system-out"], "unknown"),
+    },
+}
+
+
+class TestNormalisation:
+    """One function decides the vocabulary, so both parsers cannot disagree."""
+
+    def test_the_junit_failure_element_name_becomes_failed(self):
+        from sphinxcontrib.test_reports.results import normalize_result
+
+        assert normalize_result("failure") == "failed"
+
+    def test_normalising_the_canonical_spelling_changes_nothing(self):
+        """Normalisation runs on already-canonical values too, so it must be
+        idempotent -- a JSON report may already spell the result ``failed``."""
+        from sphinxcontrib.test_reports.results import normalize_result
+
+        assert normalize_result("failed") == "failed"
+
+    @pytest.mark.parametrize("result", ["passed", "skipped", "error", "disabled"])
+    def test_the_other_states_are_already_canonical(self, result):
+        from sphinxcontrib.test_reports.results import normalize_result
+
+        assert normalize_result(result) == result
+
+    def test_a_vocabulary_this_extension_does_not_know_is_left_alone(self):
+        """``tr_json_mapping`` points at an arbitrary report, so a project may
+        feed in states of its own. Rewriting those would break its filters."""
+        from sphinxcontrib.test_reports.results import normalize_result
+
+        assert normalize_result("flaky") == "flaky"
+
+    def test_the_canonical_states_are_the_documented_ones(self):
+        """Ordered, because the declared field description is built from it and
+        the converter's output has to be byte-stable."""
+        from sphinxcontrib.test_reports.results import CANONICAL_RESULTS
+
+        assert CANONICAL_RESULTS == (
+            "passed",
+            "failed",
+            "error",
+            "skipped",
+            "disabled",
+        )
+
+
+class TestDeclaredSchema:
+    """The converter writes the field declarations into the ``needs.json`` it
+    produces, so that a consumer which never loads this extension -- a schema
+    check, a metamodel validator -- learns the fields from the file. Naming the
+    states in the ``result`` description tells it the field's domain too.
+    """
+
+    def test_the_result_declaration_names_every_state(self):
+        from sphinxcontrib.test_reports.fields import declaration
+        from sphinxcontrib.test_reports.results import CANONICAL_RESULTS
+
+        _, description = declaration("result")
+
+        assert all(state in description for state in CANONICAL_RESULTS), description
+
+
+class TestJUnitParser:
+    """The JUnit dialect is where the old spelling came from."""
+
+    def test_a_failure_child_yields_the_failed_result(self):
+        from sphinxcontrib.test_reports.junitparser import JUnitParser
+
+        suite = JUnitParser(XML_PATH).parse()[0]
+
+        assert suite["testcases"][2]["result"] == "failed"
+
+    def test_a_result_part_keeps_the_name_of_its_xml_element(self):
+        """``kind`` reports which element the evidence came from -- the
+        converter capitalises it into the evidence heading -- so it stays the
+        XML name even though ``result`` no longer is."""
+        from sphinxcontrib.test_reports.junitparser import JUnitParser
+
+        suite = JUnitParser(XML_PATH).parse()[0]
+
+        assert suite["testcases"][2]["parts"][0]["kind"] == "failure"
+
+
+class TestJsonParser:
+    """The JSON parser's API is documented as being in sync with the JUnit
+    parser's, so the same report content has to produce the same result."""
+
+    def test_the_failure_spelling_in_a_json_report_is_normalised(self):
+        from sphinxcontrib.test_reports.jsonparser import JsonParser
+
+        parser = JsonParser(JSON_PATH, json_mapping=JSON_MAPPING)
+        suite = parser.parse()[0]
+
+        assert suite["testcases"][0]["result"] == "failed"
+
+    def test_the_results_needing_no_normalisation_are_untouched(self):
+        from sphinxcontrib.test_reports.jsonparser import JsonParser
+
+        parser = JsonParser(JSON_PATH, json_mapping=JSON_MAPPING)
+        suite = parser.parse()[0]
+
+        assert suite["testcases"][1]["result"] == "passed"
+        assert suite["testcases"][2]["result"] == "skipped"
+
+
+@pytest.mark.toolchain
+@pytest.mark.parametrize(
+    "test_app",
+    [{"buildername": "html", "srcdir": "doc_test/default_tr_template"}],
+    indirect=True,
+)
+def test_the_shipped_report_template_counts_a_failed_case(test_app):
+    """The template that ``tr_report_template`` defaults to filters on the
+    ``result`` value, and every fixture that exercises ``test-report`` used to
+    override it -- so a rename could empty its "Failed test cases" table and
+    its count without a single test noticing.
+    """
+    from pathlib import Path
+
+    app = test_app
+    app.build()
+    html = Path(app.outdir, "index.html").read_text()
+
+    assert "Failed test cases: 1" in html


### PR DESCRIPTION
## Why

S-CORE cannot adopt the `result` field as it is spelled today.

A test case's `result` was never a chosen name — it was whatever the input called it. The JUnit parser passed the name of the result-carrying `<testcase>` child through verbatim, so a failure came out as `failure`, after the `<failure>` element:

```python
RESULT_PART_KINDS = ("skipped", "failure", "error")   # XML element names
...
tc_dict["result"] = first_part["kind"]                # the element name, verbatim
```

The two states with no element of their own were invented in the `else` branch, and whoever wrote it reached for participles — `passed`, and `disabled` for googletest's `status="notrun"`. The JSON parser passed its report's own value through untouched.

Three consequences:

* the same product said `failure` for one case's result and `failed` for the count of them on its suite (`fields.FIELDS`), and `errors` next to `error`;
* the same logical outcome could arrive under two spellings depending on the input format, although `jsonparser`'s API is documented as being in sync with `junitparser`'s;
* `docs/directives/test_case.rst` documented the value as **`failed`** — which it never was. The page that documents the directive was simply wrong.

S-CORE's own colouring hook keys on pytest's vocabulary (`passed`/`failed`/`skipped`/`disabled`), so STR-converted needs would render uncoloured against it.

## What changed

Every state is now a participle: **`passed`, `failed`, `error`, `skipped`, `disabled`**.

`error` is deliberately *not* renamed. It agrees with the `errors` count beside it and with pytest, which spells that outcome `error` too. The pair that disagreed was `failure`/`failed`, and `failed` is the half that already appeared in a field name.

The substance is not the rename but the **normalisation step that did not exist**: the vocabulary is declared once, in a new `results` module, and both parsers map their input onto it. A JSON report written against the JUnit dialect no longer produces a different `result` than the XML it mirrors. A state this package does not know is still passed through untouched, so a `tr_json_mapping` pointing at a report with a vocabulary of its own keeps working.

The part-level `kind` stays the XML element name — it reports which element the evidence came from, and the converter capitalises it into the evidence heading ("Failure: …"). A test pins that divergence, and it is red-green verified: normalising `kind` too makes it fail.

The declared `result` description now names the states, so a consumer reading the declarations out of a produced `needs.json` — a schema check, a metamodel validator, S-CORE's tooling — learns the field's domain from the file:

```json
"description": "Test result status: passed, failed, error, skipped, disabled"
```

## Breaking — what a project has to update

1. **A filter naming the value**: `'failure' == result` becomes `'failed' == result`.
2. **A custom `tr_report_template`**: it carries *two* such filters from the shipped template it was copied from. This is the dangerous one — see below.
3. **Custom CSS** targeting the generated `tr_failure` class, now `tr_failed`. The stylesheet keeps rules for both, so the colours survive either way.

The value is also what `test-reports build needs` writes into `needs.json`, so a consumer of that file has to be updated with it. All of this is in the changelog entry.

## The untested coupling this surfaced

The shipped `test_report_template.txt` filters on the result value twice, and it had **no test coverage at all**: every fixture exercising `test-report` pointed `tr_report_template` at a template of its own. A rename could have emptied its "Failed test cases" table and count in every project using the default, silently.

A fixture now builds with the default template, and its count caught exactly that during this change — the parser started saying `failed` while the template still filtered `failure`, and the count went to zero.

## Verification

* `pytest -n auto tests/` — **421 passed**, 0 failures (baseline before the change: 407)
* `mypy` (strict) — **Success: no issues found in 14 source files**. The new module is type-checked rather than parked on the `#114` exclude list that both parsers sit on.
* `nox -s toolchain_free` — 3.11 and 3.12 both successful; the new tests run with Sphinx, sphinx-needs and docutils all absent, so the normalisation stays toolchain-free.
* `pre-commit run --all-files` — all hooks pass. The KOI8-encoded fixture template survived the edit (its test asserts on the decoded text).
* `sphinx-build docs` — clean. The documentation's own pytest example, filtering `'failed' == result` against a real report, renders **"Failed test cases: 4"** and emits `tr_failed` 12 times, so the filter and the CSS class are verified end to end rather than by inspection.

## Follow-ups, deliberately not in this PR

* `common.css` has no `tr_disabled` rule although the parser emits `disabled`, and no dark-theme variants at all.
* Annotating a *reference* to a test-case need with its result (the S-CORE feature this came from) — that belongs in sphinx-needs' `need_ref`/`meta_links`, with STR supplying the `tr_<result>` palette.

---

Targets `master`, adding to the `Unreleased` section; #160 gets rebased on top, which folds the entry into the 2.0.0 section.
